### PR TITLE
fix(nanvix): handle both old and new sqlite artifact formats

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -161,8 +161,13 @@ jobs:
           echo "Downloading SQLite from: $SQLITE_URL"
           if curl -fsSL -o "sqlite-dep/${SQLITE_ARTIFACT}" "$SQLITE_URL"; then
             tar -xjf "sqlite-dep/${SQLITE_ARTIFACT}" -C sqlite-dep
-            SQLITE_DIR=$(find sqlite-dep -mindepth 1 -maxdepth 1 -type d -name "sqlite-*" | head -1)
-            if [[ -n "$SQLITE_DIR" ]]; then
+            # Try new tarball format first: sysroot/{lib,include}/...
+            SQLITE_DIR="sqlite-dep/sysroot"
+            if [[ ! -d "$SQLITE_DIR" ]]; then
+              # Fall back to old format: sqlite-<platform>-<mode>/{lib,include}/...
+              SQLITE_DIR=$(find sqlite-dep -mindepth 1 -maxdepth 1 -type d -name "sqlite-*" | head -1)
+            fi
+            if [[ -n "$SQLITE_DIR" ]] && [[ -d "$SQLITE_DIR" ]]; then
               echo "Installing SQLite from $SQLITE_DIR to $NANVIX_HOME..."
               cp -f "$SQLITE_DIR"/lib/*.a "$NANVIX_HOME/lib/" 2>/dev/null || true
               cp -f "$SQLITE_DIR"/include/*.h "$NANVIX_HOME/include/" 2>/dev/null || true


### PR DESCRIPTION
## Summary

The sqlite CI changed its artifact layout from `sqlite-<platform>-<mode>/` to `sysroot/` (via [sqlite PR #5](https://github.com/nanvix/sqlite/pull/5)).

This broke the cpython CI because it only looked for the old `sqlite-*` directory format.

## Changes

- Try new tarball format first (`sysroot/`) then fall back to old format (`sqlite-*`) for backward compatibility during transition.

## Related

- Caused by: https://github.com/nanvix/sqlite/pull/5
- Failed run: https://github.com/nanvix/cpython/actions/runs/22081348597