### PR TITLE
fix(ci): fix double-escaped semicolon in find -exec

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \\;
+          find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \;
           ls -la release-assets/
 
       - name: Get Release Metadata


### PR DESCRIPTION
## Problem

The **release** job in the Nanvix CI workflow was failing at the **Prepare Release Assets** step with:

```
find: missing argument to `-exec'
```

See failed run: https://github.com/nanvix/cpython/actions/runs/22293621694/job/64503473003

## Root Cause

The semicolon terminator in the `find -exec` command was double-escaped (`\\;`). In YAML, `\\;` produces the literal string `\;`, but `find -exec` expects a bare `;` as the terminator.

## Fix

Changed `\\;` to `\;` so that the shell receives the correct `;` terminator.