### PR TITLE
ci: remove non-build workflow dispatch/listener

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -11,7 +11,7 @@ on:
       - nanvix/**
   workflow_dispatch:
   repository_dispatch:
-    types: [sqlite-release, openssl-release, bzip2-release, expat-release, libffi-release]
+    types: [sqlite-release, openssl-release, bzip2-release, libffi-release]
 
 permissions:
   contents: write


### PR DESCRIPTION
This PR removes repository_dispatch links that do not correspond to actual build-time dependencies in this repository's CI workflow.