### PR TITLE
fix: restore repository_dispatch with DISPATCH_TOKEN for cross-repo triggers

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -215,21 +215,18 @@ jobs:
       - name: Trigger Dependent Workflows
         if: success()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
-          for repo in cymem murmurhash preshed srsly kiwi numpy; do
-            echo "Dispatching workflow run for nanvix/$repo..."
-            gh workflow run nanvix-ci.yml \
-              --repo "nanvix/$repo" \
-              -r main || echo "::warning::Failed to dispatch $repo"
+          for repo in cymem murmurhash preshed srsly kiwi numpy nanvix-python; do
+            echo "Dispatching nanvix/$repo..."
+            gh api repos/nanvix/$repo/dispatches \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -f event_type="cpython-release" \
+              -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
+              -f "client_payload[cpython_tag]=${RELEASE_TAG}" || echo "::warning::Failed to dispatch $repo"
           done
-          # nanvix-python uses ci.yml and accepts cpython_tag input
-          echo "Dispatching workflow run for nanvix/nanvix-python..."
-          gh workflow run ci.yml \
-            --repo nanvix/nanvix-python \
-            -r main \
-            -f "cpython_tag=${RELEASE_TAG}" || echo "::warning::Failed to dispatch nanvix-python"
 
   report-failure:
     needs: [build-and-test]


### PR DESCRIPTION
## Problem

Cross-repo workflow dispatching fails with HTTP 403 because `GITHUB_TOKEN` is scoped only to the current repository.

PR #213 changed the dispatch token from `DISPATCH_TOKEN` (a PAT with org-wide scope) to `GITHUB_TOKEN`, and PR #216 attempted `workflow_dispatch` API instead — both fail cross-repo.

## Fix

- Reverts to `repository_dispatch` API (`POST /repos/{owner}/{repo}/dispatches`)
- Uses `DISPATCH_TOKEN` secret (PAT with org-wide repo access)
- Restores `nanvix-python` in the unified dispatch loop with `cpython_tag` and `nanvix_sha` in `client_payload`

Reverts #216 and partially reverts #213 (only the dispatch step token).