### PR TITLE
Enable hardware-assisted __thread TLS for Nanvix

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -670,6 +670,7 @@ extern char * _getpty(int *, int, mode_t, int);
 #    ifdef HAVE_THREAD_LOCAL
 #      error "HAVE_THREAD_LOCAL is already defined"
 #    endif
+#    define HAVE_THREAD_LOCAL 1
 #    ifdef thread_local
 #      define _Py_thread_local thread_local
 #    elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)


### PR DESCRIPTION
## Summary

Re-enable `HAVE_THREAD_LOCAL` in `Include/pyport.h`, which was previously removed (commit d3f4dfd8ff2) because Nanvix lacked hardware TLS support. Since [nanvix/nanvix@0efd021](https://github.com/nanvix/nanvix/commit/0efd021e4a466e9ba568c08ff05c401f4a5e4712), Nanvix supports hardware-assisted Thread Data Areas via the GS segment register.

When `HAVE_THREAD_LOCAL` is enabled, CPython uses direct `%gs:`-based TLS access for `_Py_tss_tstate` instead of the slower `PyThread_tss_*()` API, eliminating function call overhead on every `_PyThreadState_GET()`.

## Changes

- **`Include/pyport.h`** (+1 line): Add `#define HAVE_THREAD_LOCAL 1` to enable fast `__thread` TLS.

## Requirements

- Nanvix >= 0.12.84, which ships a fixed `user.ld` linker script that correctly handles `.tls` NOBITS sections ([nanvix/nanvix#1486](https://github.com/nanvix/nanvix/issues/1486)).

## Performance

Median of 10 runs, Nanvix 0.12.84, hyperlight platform:

| Test | Baseline | TLS-enabled | Improvement |
|------|----------|-------------|-------------|
| hello | 2866ms | 2656ms | +7.3% |
| smoke | 3454ms | 3355ms | +2.9% |
| functional | 8256ms | 6280ms | +23.9% |
| **heavy_bench** | **5307ms** | **3156ms** | **+40.5%** |

The heavy benchmark (dict ops, sorting, string formatting, exception handling, function calls, generators) is the most CPU-bound and thus most representative of the TLS improvement — each of these operations triggers `_PyThreadState_GET()` internally.

## Testing

- ✅ Hello-world test: PASS
- ✅ Smoke test (9 checks): PASS
- ✅ Functional test (8 checks): PASS
