### PR TITLE
nanvix: enable dynamic loading of extension modules

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -129,7 +129,7 @@ CONFIGURE_ENV = \
 	AR="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-ar" \
 	RANLIB="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-ranlib" \
 	CFLAGS="-L$(SYSROOT_PATH)/lib -I$(SYSROOT_PATH)/include" \
-	LDFLAGS="-static -T$(SYSROOT_PATH)/lib/user.ld -Wl,--allow-multiple-definition" \
+	LDFLAGS="-T$(SYSROOT_PATH)/lib/user.ld -Wl,--allow-multiple-definition -Wl,-pie -Wl,--export-dynamic -Wl,--no-dynamic-linker" \
 	LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) -lsqlite3 -lssl -lcrypto -lz -lbz2 -lffi -Wl,--end-group" \
 	LIBSQLITE3_LIBS="-L$(SYSROOT_PATH)/lib -lsqlite3" \
 	LIBSQLITE3_CFLAGS="-I$(SYSROOT_PATH)/include" \
@@ -159,7 +159,9 @@ CONFIGURE_OPTS = \
 	ac_cv_file__dev_ptc=no \
 	ac_cv_pthread_is_default=yes \
 	ac_cv_pthread=yes \
-	ac_cv_kthread=no
+	ac_cv_kthread=no \
+	ac_cv_func_dlopen=yes \
+	ac_cv_header_dlfcn_h=yes
 
 # Marker file to track if configure has been run
 CONFIGURED_MARKER = .nanvix-configured


### PR DESCRIPTION
## Summary

Enable CPython to dynamically load `.so` extension modules on Nanvix by leveraging Nanvix's `dlopen()`/`dlsym()`/`dlclose()` support.

## Changes

- **Makefile.nanvix**: Add `ac_cv_func_dlopen=yes` and `ac_cv_header_dlfcn_h=yes` to configure options, enabling `HAVE_DYNAMIC_LOADING` and compiling `dynload_shlib.o` instead of `dynload_stub.o`
- **Python/dynload_shlib.c**: Call `_Py_Nanvix_RegisterDynloadSymbols()` before `dlopen()` on Nanvix (guarded by `#ifdef __nanvix__`)
- **Python/dynload_nanvix_register.c** *(new)*: Registers ~180 Python C API symbols (functions, type objects, exception types, singletons) in Nanvix's global symbol table via `dlregister()`
- **.nanvix/tests/**: Test extension module (`hellomodule.c`) and test scripts

## How It Works

Since Nanvix's `dlopen()` cannot resolve symbols from the statically-linked main executable, CPython registers its C API symbols in a global symbol table (via `dlregister()`) before loading any extension module. When an extension's `dlopen()` encounters undefined symbols, the Nanvix dynamic linker falls back to this global table.

## Testing

```
DYNLOAD_TEST: Module loaded successfully: <module 'hello' from '.../hello.cpython-312.so'>
DYNLOAD_TEST: greet = Hello, Nanvix! (from dynamically loaded module)
DYNLOAD_TEST: add(3, 4) = 7
DYNLOAD_TEST: PASS - Dynamic module loading works!
```

## Dependencies

Requires nanvix/nanvix#1525 (global symbol table in dlfcn)