### PR TITLE
fix: copy all Nanvix binaries to test staging directory

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -207,10 +207,12 @@ else
 endif
 	@# Copy test script into the staging sysroot
 	@echo "import sys; print('CPYTHON_TEST_HELLO: Hello from Python', sys.version_info[:2])" > $(TEST_STAGING)/sysroot/test_hello.py
-	@# Copy nanvixd.elf into the staging sysroot
+	@# Copy Nanvix binaries into the staging sysroot
 	@mkdir -p $(TEST_STAGING)/sysroot/bin
 	@cp "$(abspath $(NANVIX_HOME))/bin/nanvixd.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
 	@cp "$(abspath $(NANVIX_HOME))/bin/kernel.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
+	@cp "$(abspath $(NANVIX_HOME))/bin/linuxd.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
+	@cp "$(abspath $(NANVIX_HOME))/bin/uservm.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
 ifeq ($(PROCESS_MODE),standalone)
 	@cp "$(abspath $(NANVIX_HOME))/bin/mkramfs.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
 	@echo "Test: Hello world (standalone)..."


### PR DESCRIPTION
Copy linuxd.elf and uservm.elf to the test staging directory alongside nanvixd.elf and kernel.elf. This ensures nanvixd finds all multi-process binaries locally and avoids the registry fallback download, which was selecting the wrong memory-size archive (1024mb instead of 128mb) and causing VM crashes on hyperlight-multi-process-128mb.

Fixes: https://github.com/nanvix/nanvix/issues/1618
Upstream fix: https://github.com/nanvix/nanvix/pull/1620
Failed run: https://github.com/nanvix/cpython/actions/runs/23013037262