### PR TITLE
ci: drop hyperlight and enable test for standalone

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [hyperlight, microvm]
+        platform: [microvm]
         process-mode: [multi-process, single-process, standalone]
         memory: [128mb]
     name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
@@ -92,7 +92,6 @@ jobs:
         run: ./z build
 
       - name: Test
-        if: matrix.process-mode != 'standalone'
         run: ./z test
 
       - name: Package

--- a/z
+++ b/z
@@ -332,6 +332,7 @@ nanvix_make() {
     -f Makefile.nanvix
     CONFIG_NANVIX=y
     NANVIX_HOME="$NANVIX_HOME"
+    PROCESS_MODE="$NANVIX_PROCESS_MODE"
   )
 
   if [[ -n "$NANVIX_TOOLCHAIN" ]]; then


### PR DESCRIPTION
## Changes

- Remove `hyperlight` from the CI platform matrix (microvm only)
- Enable the test step for `standalone` process mode (previously skipped)
