### PR TITLE
Fix: strip python binary inside Docker during standalone test

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -261,8 +261,16 @@ ifeq ($(PROCESS_MODE),standalone)
 	@rm -f $(TEST_STAGING)/sysroot/bin/python3.12-config $(TEST_STAGING)/sysroot/bin/python3
 	@find $(TEST_STAGING)/sysroot -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
 	@# Strip debug symbols from the python binary
+ifdef CONFIG_NANVIX_DOCKER
+	$(DOCKER_RUN) sh -c '\
+		if [ -x "$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" ] && [ -f "$(DOCKER_WORKSPACE_PATH)/.nanvix/_test_staging/sysroot/bin/python3.12" ]; then \
+			"$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" --strip-debug \
+				"$(DOCKER_WORKSPACE_PATH)/.nanvix/_test_staging/sysroot/bin/python3.12" || true; \
+		fi'
+else
 	$(if $(wildcard $(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip),\
 		$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip --strip-debug $(TEST_STAGING)/sysroot/bin/python3.12 2>/dev/null || true)
+endif
 	@echo "Test: Hello world (standalone)..."
 	cd $(TEST_STAGING)/sysroot && \
 		./bin/mkramfs.elf -o /tmp/rootfs.img . && \


### PR DESCRIPTION
## Problem

When `CONFIG_NANVIX_DOCKER` is set, `TOOLCHAIN_PREFIX` resolves to `/opt/nanvix` — a path that only exists inside the Docker container. The `$(wildcard ...)` check on the host always returned empty, silently skipping the strip step in the standalone test path of `Makefile.nanvix`.

This left the installed `python3.12` unstripped (~51 MB instead of ~18 MB), causing the ramfs image (~142 MB) to exceed the 128 MB guest memory limit and fail the standalone test.

## Fix

Run the strip command inside Docker using `$(DOCKER_RUN)` when in Docker mode, matching the same pattern already used by the `build` target.

## Testing

Verified locally with a full clean rebuild:

```
./z setup   # NANVIX_PLATFORM=microvm NANVIX_PROCESS_MODE=standalone NANVIX_MEMORY_SIZE=128mb
./z build
./z test    # PASS — ramfs image: 73 MB, execution time: ~2.2s
```

Before the fix, the ramfs image was ~142 MB and `nanvixd` failed with exit code 255 (image exceeds guest memory).