### PR TITLE
fix(test): anchor hello-world grep to detect interleaved errors

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -289,8 +289,8 @@ endif
 			if [ $$test_status -ne 0 ]; then \
 				echo "  FAIL: Hello test timed out or exited with status $$test_status"; cat /tmp/cpython_test.log; exit 1; \
 			fi; \
-			if grep -q 'CPYTHON_TEST_HELLO:' /tmp/cpython_test.log; then \
-				echo "  PASS: $$(grep 'CPYTHON_TEST_HELLO:' /tmp/cpython_test.log)"; \
+			if grep -q '^CPYTHON_TEST_HELLO:' /tmp/cpython_test.log; then \
+				echo "  PASS: $$(grep -m 1 '^CPYTHON_TEST_HELLO:' /tmp/cpython_test.log)"; \
 			else \
 				echo "  FAIL: Hello test did not produce expected output"; cat /tmp/cpython_test.log; exit 1; \
 			fi; \
@@ -310,8 +310,8 @@ else
 			if [ $$test_status -ne 0 ]; then \
 				echo "  FAIL: Hello test timed out or exited with status $$test_status"; cat /tmp/cpython_test.log; exit 1; \
 			fi; \
-			if grep -q 'CPYTHON_TEST_HELLO:' /tmp/cpython_test.log; then \
-				echo "  PASS: $$(grep 'CPYTHON_TEST_HELLO:' /tmp/cpython_test.log)"; \
+			if grep -q '^CPYTHON_TEST_HELLO:' /tmp/cpython_test.log; then \
+				echo "  PASS: $$(grep -m 1 '^CPYTHON_TEST_HELLO:' /tmp/cpython_test.log)"; \
 			else \
 				echo "  FAIL: Hello test did not produce expected output"; cat /tmp/cpython_test.log; exit 1; \
 			fi; \


### PR DESCRIPTION
## Problem

The smoke test in `Makefile.nanvix` grepped for `CPYTHON_TEST_HELLO:` anywhere in the log line. When the Nanvix runtime emitted an `[ERROR]` on the same line — e.g.:

```
[ERROR][syscalCPYTHON_TEST_HELLO: Hello from Python (3, 12)
```

— the unanchored grep still matched, so the test reported **PASS** despite the runtime error.

**Ref:** workflow run [23665129631](https://github.com/nanvix/cpython/actions/runs/23665129631), job [68945078516](https://github.com/nanvix/cpython/actions/runs/23665129631/job/68945078516)

## Fix

Anchor the grep to `^CPYTHON_TEST_HELLO:` so the marker must appear at the **start of the line**. When runtime errors are interleaved on the same line, the anchored grep will not match and the test will correctly fail.

Applies to both standalone and non-standalone test blocks.