### PR TITLE
Migrate cpython to nanvix-zutil

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -4,14 +4,18 @@ on:
   schedule:
     - cron: "0 0 * * *"
   push:
-    branches:
-      - nanvix/**
+    branches: ["nanvix/**"]
   pull_request:
-    branches:
-      - nanvix/**
+    branches: ["nanvix/**"]
   workflow_dispatch:
   repository_dispatch:
-    types: [sqlite-release, openssl-release, bzip2-release, libffi-release]
+    types:
+      - sqlite-release
+      - openssl-release
+      - bzip2-release
+      - libffi-release
+      - nanvix-minor-release
+      - nanvix-major-release
 
 permissions:
   contents: write
@@ -24,39 +28,39 @@ concurrency:
 
 jobs:
   get-nanvix-info:
+    name: Get Nanvix Info
     runs-on: ubuntu-latest
     outputs:
-      sha: ${{ steps.extract.outputs.sha }}
-      sha_full: ${{ steps.extract.outputs.sha_full }}
+      nanvix_tag: ${{ steps.resolve.outputs.nanvix_tag }}
+      nanvix_sha: ${{ steps.resolve.outputs.nanvix_sha }}
+      nanvix_version: ${{ steps.resolve.outputs.nanvix_version }}
+      package_name: ${{ steps.resolve.outputs.package_name }}
+      package_version: ${{ steps.resolve.outputs.package_version }}
     steps:
-      - name: Download Nanvix Release Artifacts
-        id: extract
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Download all Nanvix release artifacts (authenticated to avoid API rate limits)
-          curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- --force nanvix-artifacts
-          # Find any artifact to extract the SHA
-          ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | head -1)
-          if [[ -z "$ARTIFACT_FILE" ]]; then
-            echo "::error::No Nanvix artifact found"
-            exit 1
-          fi
-          # Extract Nanvix commit SHA from artifact filename
-          NANVIX_SHA_FULL=$(basename "$ARTIFACT_FILE" | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
-          NANVIX_SHA="${NANVIX_SHA_FULL::7}"
-          echo "Nanvix commit SHA: $NANVIX_SHA_FULL (short: $NANVIX_SHA)"
-          echo "sha=$NANVIX_SHA" >> "$GITHUB_OUTPUT"
-          echo "sha_full=$NANVIX_SHA_FULL" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
 
-  build-and-test:
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          WHEEL_URL=$(curl -fsSL -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/nanvix/zutils/releases/latest \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; print(next(a['browser_download_url'] for a in assets if a['name'].endswith('.whl')))")
+          python3 -m pip install "$WHEEL_URL"
+
+      - name: Resolve lockfile and extract release info
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: nanvix-zutil resolve >> "$GITHUB_OUTPUT"
+
+  build:
     needs: get-nanvix-info
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform: [microvm]
+        platform: [hyperlight, microvm]
         process-mode: [multi-process, single-process, standalone]
         memory: [128mb]
     name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
@@ -67,13 +71,23 @@ jobs:
       run:
         shell: bash
     env:
-      NANVIX_TOOLCHAIN: /opt/nanvix
-      NANVIX_PLATFORM: ${{ matrix.platform }}
-      NANVIX_PROCESS_MODE: ${{ matrix.process-mode }}
+      NANVIX_MACHINE: ${{ matrix.platform }}
+      NANVIX_DEPLOYMENT_MODE: ${{ matrix.process-mode }}
       NANVIX_MEMORY_SIZE: ${{ matrix.memory }}
       USER: runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      - name: Install nanvix-zutil
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          python3 -m venv /tmp/zutil-venv
+          WHEEL_URL=$(curl -fsSL -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/nanvix/zutils/releases/latest \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; print(next(a['browser_download_url'] for a in assets if a['name'].endswith('.whl')))")
+          /tmp/zutil-venv/bin/pip install "$WHEEL_URL"
+          ln -sf /tmp/zutil-venv/bin/nanvix-zutil /usr/local/bin/nanvix-zutil
 
       - name: Prepare Setup.local for L2
         run: |
@@ -84,30 +98,34 @@ jobs:
           fi
 
       - name: Setup
-        run: |
-          curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3 - --break-system-packages
-          ./z setup
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: nanvix-zutil setup
 
       - name: Build
-        run: ./z build
+        run: nanvix-zutil build
 
       - name: Test
+<<<<<<< HEAD
         run: ./z test
+=======
+        if: matrix.process-mode != 'standalone'
+        run: nanvix-zutil test
+>>>>>>> 0d466e20352 (Commit 2: Rewrite CI workflow)
 
-      - name: Package
-        run: |
-          set -euo pipefail
-          ./z release
-          ARTIFACT_NAME="cpython-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}"
-          echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
+      - name: Release
+        if: success()
+        run: nanvix-zutil release
 
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+      - name: Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v5
         with:
-          name: cpython-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
-          path: ${{ env.ARTIFACT_TARBALL }}
+          name: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
+          path: dist/*.tar.bz2
           retention-days: 7
 
+<<<<<<< HEAD
   release:
     needs: [get-nanvix-info, build-and-test]
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
@@ -121,133 +139,155 @@ jobs:
       - name: Download All Artifacts
         id: download-artifacts
         uses: actions/download-artifact@v4
+=======
+      - name: Collect failure logs
+        if: failure()
+        run: |
+          mkdir -p ci-logs
+          cp -f /tmp/*.log ci-logs/ 2>/dev/null || true
+          find .nanvix -type f -name "*.log" -exec cp -f {} ci-logs/ \; 2>/dev/null || true
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: failure-logs-${{ matrix.platform }}-${{ matrix.process-mode }}
+          path: ci-logs/*
+          if-no-files-found: warn
+
+  release:
+    needs: [get-nanvix-info, build]
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all build artifacts
+        id: download-artifacts
+        uses: actions/download-artifact@v5
+>>>>>>> 0d466e20352 (Commit 2: Rewrite CI workflow)
         continue-on-error: true
         with:
           path: release-artifacts
-          pattern: cpython-*
+          pattern: ${{ needs.get-nanvix-info.outputs.package_name }}-${{ needs.get-nanvix-info.outputs.package_version }}-*
 
-      - name: Prepare Release Assets
+      - name: Prepare release assets
         run: |
           set -euo pipefail
           mkdir -p release-assets
           if [[ "${{ steps.download-artifacts.outcome }}" == "failure" ]]; then
+<<<<<<< HEAD
             echo "::warning::Artifact download step failed — this may indicate an API or network issue"
+=======
+            echo "::warning::Artifact download failed — possible API or network issue"
+>>>>>>> 0d466e20352 (Commit 2: Rewrite CI workflow)
           fi
           find release-artifacts -name "*.tar.bz2" -exec cp {} release-assets/ \; 2>/dev/null || true
           ASSET_COUNT=$(find release-assets -name "*.tar.bz2" 2>/dev/null | wc -l)
           echo "Found $ASSET_COUNT release asset(s)"
           if [[ "$ASSET_COUNT" -eq 0 ]]; then
+<<<<<<< HEAD
             echo "::error::No release assets found — all matrix builds may have failed or artifact retrieval encountered an error"
+=======
+            echo "::error::No release assets found — all matrix builds may have failed"
+>>>>>>> 0d466e20352 (Commit 2: Rewrite CI workflow)
             exit 1
           fi
           ls -la release-assets/
 
-      - name: Get Release Metadata
-        id: meta
+      - name: Generate lockfile
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           set -euo pipefail
-          for repo in zlib sqlite openssl bzip2 libffi; do
-            tag=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-              "https://api.github.com/repos/nanvix/${repo}/releases/latest" | jq -r '.tag_name // "latest"')
-            echo "${repo}_tag=${tag}" >> "$GITHUB_OUTPUT"
-          done
-          RELEASE_INFO=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
-            "https://api.github.com/repos/nanvix/nanvix/releases/tags/latest")
-          echo "nanvix_name=$(echo "$RELEASE_INFO" | jq -r '.name // "latest"')" >> "$GITHUB_OUTPUT"
-          echo "nanvix_published=$(echo "$RELEASE_INFO" | jq -r '.published_at')" >> "$GITHUB_OUTPUT"
+          WHEEL_URL=$(curl -fsSL -H "Authorization: token $GH_TOKEN" \
+            https://api.github.com/repos/nanvix/zutils/releases/latest \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; print(next(a['browser_download_url'] for a in assets if a['name'].endswith('.whl')))")
+          python3 -m pip install "$WHEEL_URL"
+          nanvix-zutil resolve > /dev/null
+          nanvix-zutil lock --shallow
+          cp .nanvix/nanvix.lock release-assets/nanvix.lock
 
-      - name: Create Release
+      - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NANVIX_NAME: ${{ steps.meta.outputs.nanvix_name }}
-          NANVIX_PUBLISHED: ${{ steps.meta.outputs.nanvix_published }}
-          ZLIB_TAG: ${{ steps.meta.outputs.zlib_tag }}
-          SQLITE_TAG: ${{ steps.meta.outputs.sqlite_tag }}
-          OPENSSL_TAG: ${{ steps.meta.outputs.openssl_tag }}
-          BZIP2_TAG: ${{ steps.meta.outputs.bzip2_tag }}
-          LIBFFI_TAG: ${{ steps.meta.outputs.libffi_tag }}
+          NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_version }}
+          NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.nanvix_sha }}
+          CPYTHON_VERSION: ${{ needs.get-nanvix-info.outputs.package_version }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
-          if gh release view "$RELEASE_TAG" &>/dev/null; then
-            gh release delete "$RELEASE_TAG" --yes --cleanup-tag || true
+          SEMVER_TAG="${CPYTHON_VERSION}-nanvix-${NANVIX_VERSION}"
+          COMMITISH_TAG="${CPYTHON_VERSION}-nanvix-${NANVIX_SHA}"
+
+          # Idempotency: skip if release already exists.
+          if gh release view "$SEMVER_TAG" &>/dev/null; then
+            echo "Release $SEMVER_TAG already exists; skipping."
+            exit 0
           fi
-          gh release create "$RELEASE_TAG" \
-            --title "Build ${GITHUB_SHA::7}" \
+
+          gh release create "$SEMVER_TAG" \
+            --title "cpython ${CPYTHON_VERSION} for Nanvix ${NANVIX_VERSION}" \
             --notes "Automated build from branch ${{ github.ref_name }} at commit ${{ github.sha }}.
 
           **Build Information:**
           - Workflow Run: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           - Commit: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
-          - Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          - Date: $(date -u +'%Y-%m-%d %H:%M:%S UTC')
 
           **Nanvix Release:**
-          - Name: ${NANVIX_NAME}
-          - Published: ${NANVIX_PUBLISHED}
-          - Commit: [${NANVIX_SHA_FULL}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA_FULL})
+          - Version: ${NANVIX_VERSION}
+          - Commit: [${NANVIX_SHA}](https://github.com/nanvix/nanvix/commit/${NANVIX_SHA})
 
-          **Build Dependencies (statically linked, not needed at runtime):**
-          | Dependency | Version | Source |
-          |---|---|---|
-          | zlib | \`${ZLIB_TAG}\` | [release](https://github.com/nanvix/zlib/releases/tag/${ZLIB_TAG}) |
-          | sqlite | \`${SQLITE_TAG}\` | [release](https://github.com/nanvix/sqlite/releases/tag/${SQLITE_TAG}) |
-          | openssl | \`${OPENSSL_TAG}\` | [release](https://github.com/nanvix/openssl/releases/tag/${OPENSSL_TAG}) |
-          | bzip2 | \`${BZIP2_TAG}\` | [release](https://github.com/nanvix/bzip2/releases/tag/${BZIP2_TAG}) |
-          | libffi | \`${LIBFFI_TAG}\` | [release](https://github.com/nanvix/libffi/releases/tag/${LIBFFI_TAG}) |
+          **Package Layout:**
+          \`\`\`
+          sysroot/
+            bin/python3.12 (stripped)
+            lib/python3.12/ (stdlib, .pyc precompiled, tests removed)
+            include/python3.12/ (headers)
+          \`\`\`
 
-          **Quick Start (only Nanvix runtime required):**
-          \`\`\`bash
-          # Pick your platform and process mode
-          PLATFORM=hyperlight  # or microvm
-          MODE=multi-process   # or single-process
-          MEMORY=128mb
-
-          # 1. Download & extract Nanvix runtime
-          mkdir -p sysroot
-          curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
-          tar -xjf nanvix-artifacts/nanvix-\${PLATFORM}-\${MODE}-\${MEMORY}-*.tar.bz2 -C sysroot
-
-          # 2. Download & overlay CPython release
-          curl -fsSL -o cpython.tar.bz2 <this-release-cpython-PLATFORM-MODE-MEMORY.tar.bz2-url>
-          tar -xjf cpython.tar.bz2
-
-          # 3. Run
-          echo 'import sys; print(\"Hello from Nanvix CPython!\", sys.version)' > sysroot/hello.py
-          cd sysroot && ./bin/nanvixd.elf -- ./bin/python3.12 ./hello.py
-          \`\`\`" \
+          **Dependencies:** zlib, bzip2, openssl, libffi, sqlite (statically linked)
+          **Lockfile:** nanvix.lock included for downstream dependency resolution" \
             --latest \
-            release-assets/*.tar.bz2
+            release-assets/*.tar.bz2 \
+            release-assets/nanvix.lock
 
-      - name: Trigger Dependent Workflows
+          # Create secondary commitish tag.
+          git tag -f "$COMMITISH_TAG"
+          git push -f origin "refs/tags/$COMMITISH_TAG"
+
+      - name: Trigger dependent workflows
         if: success()
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          NANVIX_VERSION: ${{ needs.get-nanvix-info.outputs.nanvix_version }}
+          NANVIX_SHA: ${{ needs.get-nanvix-info.outputs.nanvix_sha }}
+          CPYTHON_VERSION: ${{ needs.get-nanvix-info.outputs.package_version }}
         run: |
-          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          SEMVER_TAG="${CPYTHON_VERSION}-nanvix-${NANVIX_VERSION}"
           for repo in cymem murmurhash preshed srsly kiwi numpy nanvix-python; do
-            echo "Dispatching nanvix/$repo..."
+            echo "Triggering nanvix/$repo..."
             gh api repos/nanvix/$repo/dispatches \
               -X POST \
               -H "Accept: application/vnd.github+json" \
               -f event_type="cpython-release" \
               -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
-              -f "client_payload[cpython_tag]=${RELEASE_TAG}" || echo "::warning::Failed to dispatch $repo"
+              -f "client_payload[nanvix_version]=${NANVIX_VERSION}" \
+              -f "client_payload[cpython_tag]=${SEMVER_TAG}" || echo "::warning::Failed to trigger $repo"
           done
 
   report-failure:
-    needs: [build-and-test, release]
+    needs: [build, release]
     if: >-
       ${{ always() &&
-          (github.event_name == 'repository_dispatch' || github.event_name == 'schedule' || github.event_name == 'push') &&
-          needs.build-and-test.result == 'failure' &&
-          needs.release.result == 'failure' }}
+          (github.event_name == 'push' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'repository_dispatch') &&
+          (needs.build.result == 'failure' ||
+           needs.release.result == 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Report failure issue
-        uses: actions/github-script@v7
-        env:
-          BUILD_RESULT: ${{ needs.build-and-test.result }}
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -260,9 +300,8 @@ jobs:
               `- Trigger: ${context.eventName}`,
               `- Run: [#${context.runNumber}](${runUrl})`,
               `- SHA: ${context.sha}`,
-              `- build-and-test: ${process.env.BUILD_RESULT}`,
               '',
-              'Please investigate and take any corrective actions.'
+              'Please investigate and take corrective action.'
             ].join('\n');
 
             const { data: search } = await github.rest.search.issuesAndPullRequests({
@@ -271,13 +310,19 @@ jobs:
             const existing = search.items.find(i => i.title === title);
 
             if (existing) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: existing.number, body });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number, body
+              });
               const currentAssignees = existing.assignees.map(a => a.login);
               const desired = ['ppenna', 'danbugs'];
               const missing = desired.filter(a => !currentAssignees.includes(a));
               if (missing.length > 0) {
-                await github.rest.issues.addAssignees({ owner, repo, issue_number: existing.number, assignees: missing });
+                await github.rest.issues.addAssignees({
+                  owner, repo, issue_number: existing.number, assignees: missing
+                });
               }
             } else {
-              await github.rest.issues.create({ owner, repo, title, body, assignees: ['ppenna', 'danbugs'] });
+              await github.rest.issues.create({
+                owner, repo, title, body, assignees: ['ppenna']
+              });
             }

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -218,6 +218,11 @@ jobs:
           SEMVER_TAG="${CPYTHON_VERSION}-nanvix-${NANVIX_VERSION}"
           COMMITISH_TAG="${CPYTHON_VERSION}-nanvix-${NANVIX_SHA}"
 
+          # Always ensure the commitish tag exists, even if the semver release
+          # was already created by a previous run.
+          git tag -f "$COMMITISH_TAG"
+          git push -f origin "refs/tags/$COMMITISH_TAG"
+
           # Idempotency: skip if release already exists.
           if gh release view "$SEMVER_TAG" &>/dev/null; then
             echo "Release $SEMVER_TAG already exists; skipping."
@@ -250,10 +255,6 @@ jobs:
             --latest \
             release-assets/*.tar.bz2 \
             release-assets/nanvix.lock
-
-          # Create secondary commitish tag.
-          git tag -f "$COMMITISH_TAG"
-          git push -f origin "refs/tags/$COMMITISH_TAG"
 
       - name: Trigger dependent workflows
         if: success()
@@ -288,6 +289,9 @@ jobs:
     steps:
       - name: Report failure issue
         uses: actions/github-script@v8
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          RELEASE_RESULT: ${{ needs.release.result }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -300,6 +304,8 @@ jobs:
               `- Trigger: ${context.eventName}`,
               `- Run: [#${context.runNumber}](${runUrl})`,
               `- SHA: ${context.sha}`,
+              `- build: ${process.env.BUILD_RESULT}`,
+              `- release: ${process.env.RELEASE_RESULT}`,
               '',
               'Please investigate and take corrective action.'
             ].join('\n');

--- a/.github/workflows/prune-releases.yml
+++ b/.github/workflows/prune-releases.yml
@@ -1,0 +1,35 @@
+name: Prune Old Releases
+
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  prune:
+    if: github.repository == 'nanvix/cpython'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune releases older than 90 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          CUTOFF=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Pruning releases published before ${CUTOFF}..."
+
+          TAGS=$(gh api "repos/${{ github.repository }}/releases" --paginate --jq \
+            ".[] | select(.published_at < \"${CUTOFF}\") | .tag_name")
+
+          if [[ -z "$TAGS" ]]; then
+            echo "No releases to prune."
+            exit 0
+          fi
+
+          echo "$TAGS" | while read -r tag; do
+            echo "Deleting release: ${tag}"
+            gh release delete "${tag}" --repo "${{ github.repository }}" --yes --cleanup-tag || true
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,7 @@ Python/frozen_modules/MANIFEST
 .z.cache
 /.nanvix/*
 !/.nanvix/tests/
+!/.nanvix/z.py
+!/.nanvix/nanvix.toml
 .nanvix-configured
 python.elf

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,0 +1,13 @@
+manifest-version = "0.1.0"
+
+[package]
+name = "cpython"
+version = "3.12.3"
+nanvix-version = "latest"
+
+[dependencies]
+zlib = "1.3.1"
+bzip2 = "1.0.8"
+openssl = "3.5.0"
+libffi = "3.4.6"
+sqlite = "3.49.0"

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -1,0 +1,69 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+"""Nanvix build script for cpython."""
+
+from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+
+
+class CpythonBuild(ZScript):
+    """Build script for nanvix/cpython."""
+
+    def _make_args(self, *targets: str) -> list[str]:
+        """Build the common make argument list."""
+        sysroot = self.config.get(CFG_SYSROOT, "")
+        if not sysroot:
+            log.fatal(
+                f"{CFG_SYSROOT} is not set.",
+                code=EXIT_MISSING_DEP,
+                hint="Run `nanvix-zutil setup` first to download the sysroot.",
+            )
+        toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
+
+        args = [
+            "make", "-f", "Makefile.nanvix",
+            "CONFIG_NANVIX=y",
+            f"NANVIX_HOME={sysroot}",
+            f"NANVIX_TOOLCHAIN={toolchain}",
+            f"PLATFORM={self.config.machine}",
+            f"PROCESS_MODE={self.config.deployment_mode}",
+            f"MEMORY_SIZE={self.config.memory_size}",
+        ]
+        args.extend(targets)
+        return args
+
+    def setup(self) -> None:
+        """Download sysroot and all 5 dependencies, then verify."""
+        super().setup()
+        if self.buildroot is None:
+            log.fatal(
+                "nanvix.toml must declare dependencies.",
+                code=EXIT_MISSING_DEP,
+                hint="Add dependencies to [dependencies] in nanvix.toml, then re-run setup.",
+            )
+        self.buildroot.verify([
+            "libz.a", "libsqlite3.a", "libssl.a",
+            "libcrypto.a", "libbz2.a", "libffi.a",
+        ])
+
+    def build(self) -> None:
+        """Cross-compile python.elf for Nanvix."""
+        self.run(*self._make_args("all"), cwd=self.repo_root)
+
+    def test(self) -> None:
+        """Run the cpython test suite."""
+        targets = self.targets if self.targets else ["test"]
+        self.run(*self._make_args(*targets), cwd=self.repo_root)
+
+    def release(self) -> None:
+        """Package the cpython release tarball and verify it."""
+        self.run(*self._make_args("package"), cwd=self.repo_root)
+        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
+
+    def clean(self) -> None:
+        """Remove build artifacts."""
+        self.run("make", "-f", "Makefile.nanvix", "clean", cwd=self.repo_root)
+
+
+if __name__ == "__main__":
+    CpythonBuild.main()

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -320,6 +320,66 @@ endif
 	@rm -rf $(TEST_STAGING) /tmp/cpython_test.log
 	@echo "		*** CPython tests PASSED ***"
 
+# ===========================================================================
+# Package — create portable release tarball in dist/
+# ===========================================================================
+# Translates the release logic from the former bash `z` script into a Make
+# target so that z.py can delegate via `_make_args("package")`.
+
+PACKAGE_STAGING = $(CURDIR)/.nanvix/_release_staging
+ARTIFACT_NAME  = cpython-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE)
+
+package: build
+	@echo "=== Packaging cpython release ==="
+	rm -rf $(PACKAGE_STAGING)
+ifdef CONFIG_NANVIX_DOCKER
+	$(DOCKER_RUN) make install DESTDIR="$(patsubst $(CURDIR)%,$(DOCKER_WORKSPACE_PATH)%,$(abspath $(PACKAGE_STAGING)))"
+else
+	make install DESTDIR="$(PACKAGE_STAGING)"
+endif
+	@# Strip debug symbols from the python binary
+	@if [ -x "$(NANVIX_TOOLCHAIN)/bin/i686-nanvix-strip" ]; then \
+		find "$(PACKAGE_STAGING)/sysroot" -name 'python3.*' -type f -executable \
+			-exec "$(NANVIX_TOOLCHAIN)/bin/i686-nanvix-strip" --strip-debug {} \; 2>/dev/null || true; \
+	fi
+	@# Remove __pycache__ directories
+	find "$(PACKAGE_STAGING)/sysroot" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+	@# Remove test directories from stdlib
+	find "$(PACKAGE_STAGING)/sysroot" -type d -name 'test'  -path '*/lib/python3.12/*' -exec rm -rf {} + 2>/dev/null || true
+	find "$(PACKAGE_STAGING)/sysroot" -type d -name 'tests' -path '*/lib/python3.12/*' -exec rm -rf {} + 2>/dev/null || true
+	@# Precompile stdlib .py files to .pyc for faster startup
+	@if command -v python3 >/dev/null 2>&1; then \
+		echo "Precompiling stdlib..."; \
+		python3 -m compileall -q "$(PACKAGE_STAGING)/sysroot/lib/python3.12/" 2>/dev/null || true; \
+	fi
+	@# Create the release tarball
+	mkdir -p dist
+	tar -cjf dist/$(ARTIFACT_NAME).tar.bz2 -C $(PACKAGE_STAGING) sysroot
+	rm -rf $(PACKAGE_STAGING)
+	@echo "  Package: dist/$(ARTIFACT_NAME).tar.bz2"
+	@du -h dist/$(ARTIFACT_NAME).tar.bz2
+
+# ===========================================================================
+# Verify Package
+# ===========================================================================
+
+verify-package:
+	@echo "=== Verifying cpython package ==="
+	$(eval ARTIFACT_NAME_V := cpython-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
+	@TARBALL="dist/$(ARTIFACT_NAME_V).tar.bz2"; \
+	if [ ! -f "$$TARBALL" ]; then \
+		echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
+	fi; \
+	echo "Package contents:"; \
+	tar tjf "$$TARBALL" | head -20; \
+	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/bin/python3'; then \
+		echo "FAIL: Package missing sysroot/bin/python3"; exit 1; \
+	fi; \
+	if ! tar tjf "$$TARBALL" | grep -q 'sysroot/lib/python3.12/'; then \
+		echo "FAIL: Package missing sysroot/lib/python3.12/ entries"; exit 1; \
+	fi; \
+	echo "  PASS: cpython package verification"
+
 # Clean target
 clean:
 	-make clean 2>/dev/null || true
@@ -344,4 +404,4 @@ else
 	make install DESTDIR="$(DESTDIR)"
 endif
 
-.PHONY: all configure build clean distclean test install
+.PHONY: all configure build clean distclean test install package verify-package

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -327,7 +327,7 @@ endif
 # target so that z.py can delegate via `_make_args("package")`.
 
 PACKAGE_STAGING = $(CURDIR)/.nanvix/_release_staging
-ARTIFACT_NAME  = cpython-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE)
+ARTIFACT_NAME = cpython-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE)
 
 package: build
 	@echo "=== Packaging cpython release ==="
@@ -365,8 +365,7 @@ endif
 
 verify-package:
 	@echo "=== Verifying cpython package ==="
-	$(eval ARTIFACT_NAME_V := cpython-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
-	@TARBALL="dist/$(ARTIFACT_NAME_V).tar.bz2"; \
+	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
 	if [ ! -f "$$TARBALL" ]; then \
 		echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \
 	fi; \

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -12,19 +12,21 @@ This document describes the port of [CPython](https://www.python.org/) interpret
 |----------|-------|
 | **Base Version** | CPython 3.12.x |
 | **Target Platform** | Nanvix (i686) |
-| **Build System** | GNU Make (wrapping autoconf) |
+| **Build System** | GNU Make (wrapping autoconf), orchestrated by `nanvix-zutil` |
 
 **What's included:**
 - ✅ Cross-compilation support for Nanvix
 - ✅ Static library build (`libpython3.12.a`)
 - ✅ Python interpreter executable (`python.elf`)
-- ✅ Build helper scripts
-- ✅ CI/CD integration
+- ✅ `nanvix-zutil` build orchestration
+- ✅ CI/CD integration with versioned releases
 
 **Dependencies:**
 - zlib (compression support)
-- SQLite (database support)
+- bzip2 (compression support)
 - OpenSSL (cryptography support)
+- libffi (foreign function interface)
+- SQLite (database support)
 
 ---
 
@@ -45,40 +47,20 @@ This document describes the port of [CPython](https://www.python.org/) interpret
 For experienced users who want to build quickly:
 
 ```bash
-# 1. Pull the Docker image
-docker pull nanvix/toolchain:latest-minimal
+# 1. Install nanvix-zutil
+pip install nanvix-zutil  # or install from the latest wheel
 
-# 2. Download Nanvix sysroot and extract Nanvix commit SHA
-curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
-tar -xjf nanvix-artifacts/*microvm*single*.tar.bz2 -C nanvix-artifacts
-export NANVIX_HOME=$(find nanvix-artifacts -maxdepth 2 -type d -name "bin" -exec dirname {} \; | head -1)
-# Extract Nanvix SHA from artifact filename for version matching
-export NANVIX_SHA=$(ls nanvix-artifacts/*microvm*single*.tar.bz2 | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
+# 2. Setup (downloads sysroot + all 5 dependencies automatically)
+nanvix-zutil setup
 
-# 3. Download dependencies (must match Nanvix version)
-# Download zlib
-curl -fsSL -o zlib-release.tar.bz2 "https://github.com/nanvix/zlib/releases/latest/download/zlib-microvm-single-process.tar.bz2"
-tar -xjf zlib-release.tar.bz2
-cp -f zlib-*/lib/libz.a "$NANVIX_HOME/lib/"
-cp -f zlib-*/include/*.h "$NANVIX_HOME/include/"
+# 3. Build
+nanvix-zutil build
 
-# Download SQLite
-curl -fsSL -o sqlite-release.tar.bz2 "https://github.com/nanvix/sqlite/releases/latest/download/sqlite-microvm-single-process.tar.bz2"
-tar -xjf sqlite-release.tar.bz2
-cp -f sqlite-*/lib/libsqlite3.a "$NANVIX_HOME/lib/"
-cp -f sqlite-*/include/*.h "$NANVIX_HOME/include/"
+# 4. Test
+nanvix-zutil test
 
-# Download OpenSSL
-curl -fsSL -o openssl-release.tar.bz2 "https://github.com/nanvix/openssl/releases/latest/download/openssl-microvm-single-process.tar.bz2"
-tar -xjf openssl-release.tar.bz2
-cp -f openssl-*/lib/*.a "$NANVIX_HOME/lib/"
-cp -rf openssl-*/include/openssl "$NANVIX_HOME/include/"
-
-# 4. Build (Docker is used automatically if native toolchain is not found)
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME"
-
-# 5. Run tests
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME="$NANVIX_HOME" test
+# 5. Package a release tarball
+nanvix-zutil release
 ```
 
 Continue reading for detailed instructions.
@@ -91,13 +73,10 @@ You need the following components to build CPython for Nanvix:
 
 | Component | Description | Default Location |
 |-----------|-------------|------------------|
-| **Nanvix Toolchain** | i686-nanvix cross-compiler | `$HOME/toolchain` |
-| **Nanvix Sysroot** | System libraries and linker script | `$HOME/nanvix` |
-| **zlib** | Compression library (must match Nanvix version) | Installed in sysroot |
-| **SQLite** | Database library (must match Nanvix version) | Installed in sysroot |
-| **OpenSSL** | Cryptography library (must match Nanvix version) | Installed in sysroot |
+| **Nanvix Toolchain** | i686-nanvix cross-compiler | `/opt/nanvix` |
+| **nanvix-zutil** | Build orchestration CLI | Installed via pip |
 
-> **Important:** All dependency libraries must be built against the same Nanvix version you are using. The CI workflow automatically finds and downloads matching releases based on the Nanvix commit SHA.
+All other dependencies (sysroot, zlib, bzip2, OpenSSL, libffi, SQLite) are automatically downloaded by `nanvix-zutil setup` based on the `.nanvix/nanvix.toml` manifest.
 
 ### Available Platform Configurations
 
@@ -107,72 +86,40 @@ You need the following components to build CPython for Nanvix:
 | hyperlight | single-process | `hyperlight.*single-process` |
 | microvm | single-process | `microvm.*single-process` |
 | microvm | multi-process | `microvm.*multi-process` |
-
-### Downloading Nanvix
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
-```
-
-The script downloads all release artifacts. Extract the one matching your target platform (see [Quick Start](#quick-start) for a complete example).
-
-### Downloading Dependencies
-
-CPython requires zlib, SQLite, and OpenSSL. **You must use releases that were built against the same Nanvix version.** The Nanvix commit SHA is embedded in the artifact filename (e.g., `nanvix-microvm-single-process-release-<SHA>.tar.bz2`).
-
-To find matching dependency releases:
-
-```bash
-# 1. Extract Nanvix SHA from artifact filename
-NANVIX_SHA=$(ls nanvix-artifacts/*microvm*single*.tar.bz2 | sed -E 's/.*-([a-f0-9]{40})\.tar\.bz2$/\1/')
-
-# 2. Check dependency releases for ones built with matching Nanvix SHA
-# The release notes contain the Nanvix commit SHA they were built against
-
-# 3. Download matching dependencies (replace PLATFORM and PROCESS_MODE)
-for dep in zlib sqlite openssl; do
-  curl -fsSL -o "${dep}-release.tar.bz2" \
-    "https://github.com/nanvix/${dep}/releases/latest/download/${dep}-PLATFORM-PROCESS_MODE.tar.bz2"
-done
-```
-
-> **Note:** The CI workflow automatically finds and downloads dependency releases that match the Nanvix version by checking release notes for the Nanvix commit SHA.
+| microvm | standalone | `microvm.*standalone` |
 
 ---
 
 ## Building
 
-### Using Docker (Recommended)
-
-The Makefile supports automatic Docker fallback when the native toolchain is not available:
+### Using nanvix-zutil (Recommended)
 
 ```bash
-# Pull the Nanvix toolchain Docker image
-docker pull nanvix/toolchain:latest-minimal
+# Setup downloads Nanvix sysroot + all 5 dependency libraries
+nanvix-zutil setup
 
-# Build (Docker is used automatically if native toolchain is not found)
-make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
+# Build cross-compiles python.elf
+nanvix-zutil build
 ```
 
-> **Note:** The sysroot (`NANVIX_HOME`) must contain `lib/libposix.a`, `lib/libz.a`, `lib/libsqlite3.a`, `lib/libssl.a`, `lib/libcrypto.a`, and `lib/user.ld` from a Nanvix build.
+### Using the Makefile Directly
+
+For advanced users who manage dependencies manually:
+
+```bash
+export NANVIX_TOOLCHAIN=/path/to/toolchain
+export NANVIX_HOME=/path/to/nanvix/sysroot
+make -f Makefile.nanvix CONFIG_NANVIX=y all
+```
+
+> **Note:** The sysroot (`NANVIX_HOME`) must contain `lib/libposix.a`, `lib/libz.a`, `lib/libsqlite3.a`, `lib/libssl.a`, `lib/libcrypto.a`, `lib/libbz2.a`, `lib/libffi.a`, and `lib/user.ld` from a Nanvix build.
 
 **Docker Fallback Behavior:**
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`)
-
-### Using Native Toolchain
-
-```bash
-export NANVIX_TOOLCHAIN=/path/to/toolchain  # Contains: bin/i686-nanvix-gcc
-export NANVIX_HOME=/path/to/nanvix          # Contains: lib/user.ld, lib/libposix.a, dependencies
-make -f Makefile.nanvix CONFIG_NANVIX=y all
-```
 
 ### Build Outputs
-
-After a successful build, you will have:
 
 | File | Description |
 |------|-------------|
@@ -185,19 +132,12 @@ After a successful build, you will have:
 
 > **Important:** Tests must be run through the Nanvix daemon (`nanvixd.elf`).
 
-### Running the Test Suite
-
 ```bash
-# Run all tests
+# Run all tests via nanvix-zutil
+nanvix-zutil test
+
+# Or via Makefile directly
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix test
-```
-
-### Running Individual Tests
-
-To run Python interactively:
-
-```bash
-cd "$NANVIX_HOME" && echo "print('Hello, Nanvix!')" | ./bin/nanvixd.elf -- /path/to/python.elf
 ```
 
 ### Test Coverage
@@ -219,34 +159,22 @@ The following changes were made to support Nanvix.
 | Change | Description |
 |--------|-------------|
 | New Makefile | Added `Makefile.nanvix` for Nanvix cross-compilation |
+| ZScript integration | `.nanvix/z.py` orchestrates build via `nanvix-zutil` CLI |
+| Manifest | `.nanvix/nanvix.toml` declares all 5 dependencies |
 | Cross-compilation | Uses `CONFIG_NANVIX=y` option to enable Nanvix build |
 | Docker support | Automatic Docker fallback when native toolchain not available |
-| Configure wrapper | Wraps standard `./configure` with Nanvix cross-compilation settings |
 | Linker flags | Added Nanvix-specific flags (`-T user.ld -static`) |
-| Shared libraries | Disabled (not supported on Nanvix) |
-| Test target | Modified to run via `nanvixd.elf` |
-
-### Configuration Options
-
-| Option | Description |
-|--------|-------------|
-| `--disable-shared` | Build static libraries only |
-| `--disable-test-modules` | Don't build test modules |
-| `--with-ensurepip=no` | Don't include pip |
-| `--disable-ipv6` | Disable IPv6 support |
-| `ac_cv_pthread_is_default=yes` | Force pthread detection |
 
 ### New Files
 
 | File | Purpose |
 |------|---------|
 | `Makefile.nanvix` | Standalone Makefile for Nanvix cross-compilation |
+| `.nanvix/nanvix.toml` | Dependency manifest (zlib, bzip2, openssl, libffi, sqlite) |
+| `.nanvix/z.py` | ZScript build orchestration |
 | `NANVIX.md` | This documentation file |
 | `.github/workflows/nanvix-ci.yml` | CI workflow for automated builds |
-
-### Legacy Build Script
-
-The `z` script is a legacy build helper that is superseded by `Makefile.nanvix`. It remains for backward compatibility but users should prefer the Makefile-based approach for consistency with other Nanvix ports.
+| `.github/workflows/prune-releases.yml` | Release retention policy (90-day) |
 
 ---
 
@@ -265,7 +193,7 @@ The `z` script is a legacy build helper that is superseded by `Makefile.nanvix`.
 
 ## CI/CD
 
-The GitHub Actions workflow at `.github/workflows/nanvix-ci.yml` automates building and testing on every change.
+The GitHub Actions workflow at `.github/workflows/nanvix-ci.yml` automates building, testing, and releasing CPython for Nanvix using the `nanvix-zutil` CLI.
 
 ### Trigger Events
 
@@ -275,23 +203,27 @@ The GitHub Actions workflow at `.github/workflows/nanvix-ci.yml` automates build
 | PR to `nanvix/**` | Pull requests targeting Nanvix branches |
 | Daily schedule | Runs at midnight UTC |
 | Manual dispatch | Can be triggered manually |
-| Repository dispatch | Triggered by `nanvix-release` events |
+| Repository dispatch | Triggered by dependency releases (sqlite, openssl, bzip2, libffi) |
 
 ### Build Matrix
 
-The CI runs on 4 different platform/process-mode configurations:
+The CI runs on 6 different platform/process-mode configurations in parallel with `fail-fast: false`:
 
-| Platform | Process Mode | Runner |
-|----------|--------------|--------|
-| hyperlight | multi-process | `ubuntu-latest` (container) |
-| hyperlight | single-process | `ubuntu-latest` (container) |
-| microvm | single-process | `ubuntu-latest` (container) |
-| microvm | multi-process | `ubuntu-latest` (container) |
-
-All configurations run in parallel with `fail-fast: false`, ensuring that all platforms are tested even if one fails.
+| Platform | Process Mode |
+|----------|--------------|
+| hyperlight | multi-process, single-process, standalone |
+| microvm | multi-process, single-process, standalone |
 
 ### Dependency Management
 
-The CI workflow automatically downloads matching releases of zlib, SQLite, and OpenSSL from their respective `nanvix/*` repositories before building CPython, ensuring the correct platform-specific libraries are used.
+Dependencies are managed automatically via `nanvix-zutil setup`, which reads `.nanvix/nanvix.toml` and downloads matching releases of all 5 dependency libraries from their respective `nanvix/*` repositories.
+
+### Release Strategy
+
+Releases use dual tags:
+- **Semver tag:** `{cpython_version}-nanvix-{nanvix_version}` (marked `--latest`)
+- **Commitish tag:** `{cpython_version}-nanvix-{nanvix_sha}` (for commit-based resolution)
+
+A `nanvix.lock` lockfile is included in every release, capturing the full dependency tree.
 
 ---


### PR DESCRIPTION
Replaces the 494-line bash `z` script with `nanvix-zutil` CLI integration.

## Changes

- `.nanvix/nanvix.toml` — manifest with all 5 dependencies (zlib, bzip2, openssl, libffi, sqlite)
- `.nanvix/z.py` — ZScript subclass with Makefile delegation and `setup()` override
- `Makefile.nanvix` — new `package` and `verify-package` targets
- `.github/workflows/nanvix-ci.yml` — rewritten: `nanvix-zutil` CLI, versioned releases, lockfile
- `.github/workflows/prune-releases.yml` — 90-day release retention
- `NANVIX.md` — updated for new workflow
- `z` (deleted) — 494-line bash script replaced by `nanvix-zutil` CLI

## Blocked by

All 5 dependency library repos must publish semver-tagged releases before CI can resolve dependencies:
- nanvix/zlib, nanvix/bzip2, nanvix/openssl, nanvix/libffi, nanvix/sqlite

## Reference

Follows the landed zlib CI pattern (nanvix/zlib#33).