### PR TITLE
feat: optimize cold-boot time with frozen encodings and snapshot support

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -5,7 +5,4 @@ nanvix-version = "latest"
 
 [dependencies]
 zlib = "1.3.1"
-sqlite = "3.49.0"
-openssl = "3.5.0"
-bzip2 = "1.0.8"
 libffi = "3.4.6"

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -136,13 +136,9 @@ CONFIGURE_ENV = \
 	CFLAGS="-L$(SYSROOT_PATH)/lib -I$(SYSROOT_PATH)/include" \
 	CFLAGS_NODIST="-fno-semantic-interposition" \
 	LDFLAGS="-T$(SYSROOT_PATH)/lib/user.ld -Wl,--allow-multiple-definition -Wl,-pie -Wl,--export-dynamic -Wl,--no-dynamic-linker" \
-	LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) -lsqlite3 -lssl -lcrypto -lz -lbz2 -lffi -Wl,--end-group" \
-	LIBSQLITE3_LIBS="-L$(SYSROOT_PATH)/lib -lsqlite3" \
-	LIBSQLITE3_CFLAGS="-I$(SYSROOT_PATH)/include" \
+	LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) -lz -lffi -Wl,--end-group" \
 	ZLIB_LIBS="-L$(SYSROOT_PATH)/lib -lz" \
 	ZLIB_CFLAGS="-I$(SYSROOT_PATH)/include" \
-	BZIP2_LIBS="-L$(SYSROOT_PATH)/lib -lbz2" \
-	BZIP2_CFLAGS="-I$(SYSROOT_PATH)/include" \
 	LIBFFI_LIBS="-L$(SYSROOT_PATH)/lib -lffi" \
 	LIBFFI_CFLAGS="-I$(SYSROOT_PATH)/include"
 
@@ -160,7 +156,6 @@ CONFIGURE_OPTS = \
 	--exec-prefix="$(INSTALL_PREFIX)" \
 	--with-ensurepip=no \
 	--with-pkg-config=no \
-	--with-openssl="$(SYSROOT_PATH)" \
 	--disable-ipv6 \
 	ac_cv_file__dev_ptmx=no \
 	ac_cv_file__dev_ptc=no \
@@ -168,7 +163,25 @@ CONFIGURE_OPTS = \
 	ac_cv_pthread=yes \
 	ac_cv_kthread=no \
 	ac_cv_func_dlopen=yes \
-	ac_cv_header_dlfcn_h=yes
+	ac_cv_header_dlfcn_h=yes \
+	ac_cv_sizeof_double=8 \
+	ac_cv_sizeof_float=4 \
+	ac_cv_sizeof_fpos_t=4 \
+	ac_cv_sizeof_int=4 \
+	ac_cv_sizeof_long=4 \
+	ac_cv_sizeof_long_double=12 \
+	ac_cv_sizeof_long_long=8 \
+	ac_cv_sizeof_off_t=8 \
+	ac_cv_sizeof_pid_t=4 \
+	ac_cv_sizeof_pthread_key_t=4 \
+	ac_cv_sizeof_pthread_t=4 \
+	ac_cv_sizeof_short=2 \
+	ac_cv_sizeof_size_t=4 \
+	ac_cv_sizeof_time_t=8 \
+	ac_cv_sizeof_uintptr_t=4 \
+	ac_cv_sizeof_void_p=4 \
+	ac_cv_sizeof_wchar_t=4 \
+	ac_cv_sizeof__bool=1
 
 # Marker file to track if configure has been run
 CONFIGURED_MARKER = .nanvix-configured
@@ -192,6 +205,10 @@ endif
 build: $(CONFIGURED_MARKER)
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "Building inside Docker..."
+	@# Compile nanvix snapshot helper (outside LTO, so it survives optimization)
+	$(DOCKER_RUN) $(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-gcc -c Modules/nanvix_snapshot.S -o Modules/nanvix_snapshot.o
+	@# Inject the snapshot object into the generated Makefile's link objects
+	$(DOCKER_RUN) sh -c 'grep -q "nanvix_snapshot.o" Makefile || sed -i "/Modules\/main\.o/s|$$| Modules/nanvix_snapshot.o|" Makefile'
 	$(DOCKER_RUN) make -j$$(nproc) all
 	@# Rename python to python.elf for consistency (always use the latest build)
 	@if [ -f python ]; then mv -f python python$(EXE); fi

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1108,6 +1108,128 @@ FROZEN_FILES_IN = \
 		Lib/zipimport.py \
 		Lib/abc.py \
 		Lib/codecs.py \
+		Lib/encodings/__init__.py \
+		Lib/encodings/aliases.py \
+		Lib/encodings/ascii.py \
+		Lib/encodings/base64_codec.py \
+		Lib/encodings/big5.py \
+		Lib/encodings/big5hkscs.py \
+		Lib/encodings/bz2_codec.py \
+		Lib/encodings/charmap.py \
+		Lib/encodings/cp037.py \
+		Lib/encodings/cp1006.py \
+		Lib/encodings/cp1026.py \
+		Lib/encodings/cp1125.py \
+		Lib/encodings/cp1140.py \
+		Lib/encodings/cp1250.py \
+		Lib/encodings/cp1251.py \
+		Lib/encodings/cp1252.py \
+		Lib/encodings/cp1253.py \
+		Lib/encodings/cp1254.py \
+		Lib/encodings/cp1255.py \
+		Lib/encodings/cp1256.py \
+		Lib/encodings/cp1257.py \
+		Lib/encodings/cp1258.py \
+		Lib/encodings/cp273.py \
+		Lib/encodings/cp424.py \
+		Lib/encodings/cp437.py \
+		Lib/encodings/cp500.py \
+		Lib/encodings/cp720.py \
+		Lib/encodings/cp737.py \
+		Lib/encodings/cp775.py \
+		Lib/encodings/cp850.py \
+		Lib/encodings/cp852.py \
+		Lib/encodings/cp855.py \
+		Lib/encodings/cp856.py \
+		Lib/encodings/cp857.py \
+		Lib/encodings/cp858.py \
+		Lib/encodings/cp860.py \
+		Lib/encodings/cp861.py \
+		Lib/encodings/cp862.py \
+		Lib/encodings/cp863.py \
+		Lib/encodings/cp864.py \
+		Lib/encodings/cp865.py \
+		Lib/encodings/cp866.py \
+		Lib/encodings/cp869.py \
+		Lib/encodings/cp874.py \
+		Lib/encodings/cp875.py \
+		Lib/encodings/cp932.py \
+		Lib/encodings/cp949.py \
+		Lib/encodings/cp950.py \
+		Lib/encodings/euc_jis_2004.py \
+		Lib/encodings/euc_jisx0213.py \
+		Lib/encodings/euc_jp.py \
+		Lib/encodings/euc_kr.py \
+		Lib/encodings/gb18030.py \
+		Lib/encodings/gb2312.py \
+		Lib/encodings/gbk.py \
+		Lib/encodings/hex_codec.py \
+		Lib/encodings/hp_roman8.py \
+		Lib/encodings/hz.py \
+		Lib/encodings/idna.py \
+		Lib/encodings/iso2022_jp.py \
+		Lib/encodings/iso2022_jp_1.py \
+		Lib/encodings/iso2022_jp_2.py \
+		Lib/encodings/iso2022_jp_2004.py \
+		Lib/encodings/iso2022_jp_3.py \
+		Lib/encodings/iso2022_jp_ext.py \
+		Lib/encodings/iso2022_kr.py \
+		Lib/encodings/iso8859_1.py \
+		Lib/encodings/iso8859_10.py \
+		Lib/encodings/iso8859_11.py \
+		Lib/encodings/iso8859_13.py \
+		Lib/encodings/iso8859_14.py \
+		Lib/encodings/iso8859_15.py \
+		Lib/encodings/iso8859_16.py \
+		Lib/encodings/iso8859_2.py \
+		Lib/encodings/iso8859_3.py \
+		Lib/encodings/iso8859_4.py \
+		Lib/encodings/iso8859_5.py \
+		Lib/encodings/iso8859_6.py \
+		Lib/encodings/iso8859_7.py \
+		Lib/encodings/iso8859_8.py \
+		Lib/encodings/iso8859_9.py \
+		Lib/encodings/johab.py \
+		Lib/encodings/koi8_r.py \
+		Lib/encodings/koi8_t.py \
+		Lib/encodings/koi8_u.py \
+		Lib/encodings/kz1048.py \
+		Lib/encodings/latin_1.py \
+		Lib/encodings/mac_arabic.py \
+		Lib/encodings/mac_croatian.py \
+		Lib/encodings/mac_cyrillic.py \
+		Lib/encodings/mac_farsi.py \
+		Lib/encodings/mac_greek.py \
+		Lib/encodings/mac_iceland.py \
+		Lib/encodings/mac_latin2.py \
+		Lib/encodings/mac_roman.py \
+		Lib/encodings/mac_romanian.py \
+		Lib/encodings/mac_turkish.py \
+		Lib/encodings/mbcs.py \
+		Lib/encodings/oem.py \
+		Lib/encodings/palmos.py \
+		Lib/encodings/ptcp154.py \
+		Lib/encodings/punycode.py \
+		Lib/encodings/quopri_codec.py \
+		Lib/encodings/raw_unicode_escape.py \
+		Lib/encodings/rot_13.py \
+		Lib/encodings/shift_jis.py \
+		Lib/encodings/shift_jis_2004.py \
+		Lib/encodings/shift_jisx0213.py \
+		Lib/encodings/tis_620.py \
+		Lib/encodings/undefined.py \
+		Lib/encodings/unicode_escape.py \
+		Lib/encodings/utf_16.py \
+		Lib/encodings/utf_16_be.py \
+		Lib/encodings/utf_16_le.py \
+		Lib/encodings/utf_32.py \
+		Lib/encodings/utf_32_be.py \
+		Lib/encodings/utf_32_le.py \
+		Lib/encodings/utf_7.py \
+		Lib/encodings/utf_8.py \
+		Lib/encodings/utf_8_sig.py \
+		Lib/encodings/uu_codec.py \
+		Lib/encodings/zlib_codec.py \
 		Lib/io.py \
 		Lib/_collections_abc.py \
 		Lib/_sitebuiltins.py \
@@ -1133,6 +1255,128 @@ FROZEN_FILES_OUT = \
 		Python/frozen_modules/zipimport.h \
 		Python/frozen_modules/abc.h \
 		Python/frozen_modules/codecs.h \
+		Python/frozen_modules/encodings.h \
+		Python/frozen_modules/encodings.aliases.h \
+		Python/frozen_modules/encodings.ascii.h \
+		Python/frozen_modules/encodings.base64_codec.h \
+		Python/frozen_modules/encodings.big5.h \
+		Python/frozen_modules/encodings.big5hkscs.h \
+		Python/frozen_modules/encodings.bz2_codec.h \
+		Python/frozen_modules/encodings.charmap.h \
+		Python/frozen_modules/encodings.cp037.h \
+		Python/frozen_modules/encodings.cp1006.h \
+		Python/frozen_modules/encodings.cp1026.h \
+		Python/frozen_modules/encodings.cp1125.h \
+		Python/frozen_modules/encodings.cp1140.h \
+		Python/frozen_modules/encodings.cp1250.h \
+		Python/frozen_modules/encodings.cp1251.h \
+		Python/frozen_modules/encodings.cp1252.h \
+		Python/frozen_modules/encodings.cp1253.h \
+		Python/frozen_modules/encodings.cp1254.h \
+		Python/frozen_modules/encodings.cp1255.h \
+		Python/frozen_modules/encodings.cp1256.h \
+		Python/frozen_modules/encodings.cp1257.h \
+		Python/frozen_modules/encodings.cp1258.h \
+		Python/frozen_modules/encodings.cp273.h \
+		Python/frozen_modules/encodings.cp424.h \
+		Python/frozen_modules/encodings.cp437.h \
+		Python/frozen_modules/encodings.cp500.h \
+		Python/frozen_modules/encodings.cp720.h \
+		Python/frozen_modules/encodings.cp737.h \
+		Python/frozen_modules/encodings.cp775.h \
+		Python/frozen_modules/encodings.cp850.h \
+		Python/frozen_modules/encodings.cp852.h \
+		Python/frozen_modules/encodings.cp855.h \
+		Python/frozen_modules/encodings.cp856.h \
+		Python/frozen_modules/encodings.cp857.h \
+		Python/frozen_modules/encodings.cp858.h \
+		Python/frozen_modules/encodings.cp860.h \
+		Python/frozen_modules/encodings.cp861.h \
+		Python/frozen_modules/encodings.cp862.h \
+		Python/frozen_modules/encodings.cp863.h \
+		Python/frozen_modules/encodings.cp864.h \
+		Python/frozen_modules/encodings.cp865.h \
+		Python/frozen_modules/encodings.cp866.h \
+		Python/frozen_modules/encodings.cp869.h \
+		Python/frozen_modules/encodings.cp874.h \
+		Python/frozen_modules/encodings.cp875.h \
+		Python/frozen_modules/encodings.cp932.h \
+		Python/frozen_modules/encodings.cp949.h \
+		Python/frozen_modules/encodings.cp950.h \
+		Python/frozen_modules/encodings.euc_jis_2004.h \
+		Python/frozen_modules/encodings.euc_jisx0213.h \
+		Python/frozen_modules/encodings.euc_jp.h \
+		Python/frozen_modules/encodings.euc_kr.h \
+		Python/frozen_modules/encodings.gb18030.h \
+		Python/frozen_modules/encodings.gb2312.h \
+		Python/frozen_modules/encodings.gbk.h \
+		Python/frozen_modules/encodings.hex_codec.h \
+		Python/frozen_modules/encodings.hp_roman8.h \
+		Python/frozen_modules/encodings.hz.h \
+		Python/frozen_modules/encodings.idna.h \
+		Python/frozen_modules/encodings.iso2022_jp.h \
+		Python/frozen_modules/encodings.iso2022_jp_1.h \
+		Python/frozen_modules/encodings.iso2022_jp_2.h \
+		Python/frozen_modules/encodings.iso2022_jp_2004.h \
+		Python/frozen_modules/encodings.iso2022_jp_3.h \
+		Python/frozen_modules/encodings.iso2022_jp_ext.h \
+		Python/frozen_modules/encodings.iso2022_kr.h \
+		Python/frozen_modules/encodings.iso8859_1.h \
+		Python/frozen_modules/encodings.iso8859_10.h \
+		Python/frozen_modules/encodings.iso8859_11.h \
+		Python/frozen_modules/encodings.iso8859_13.h \
+		Python/frozen_modules/encodings.iso8859_14.h \
+		Python/frozen_modules/encodings.iso8859_15.h \
+		Python/frozen_modules/encodings.iso8859_16.h \
+		Python/frozen_modules/encodings.iso8859_2.h \
+		Python/frozen_modules/encodings.iso8859_3.h \
+		Python/frozen_modules/encodings.iso8859_4.h \
+		Python/frozen_modules/encodings.iso8859_5.h \
+		Python/frozen_modules/encodings.iso8859_6.h \
+		Python/frozen_modules/encodings.iso8859_7.h \
+		Python/frozen_modules/encodings.iso8859_8.h \
+		Python/frozen_modules/encodings.iso8859_9.h \
+		Python/frozen_modules/encodings.johab.h \
+		Python/frozen_modules/encodings.koi8_r.h \
+		Python/frozen_modules/encodings.koi8_t.h \
+		Python/frozen_modules/encodings.koi8_u.h \
+		Python/frozen_modules/encodings.kz1048.h \
+		Python/frozen_modules/encodings.latin_1.h \
+		Python/frozen_modules/encodings.mac_arabic.h \
+		Python/frozen_modules/encodings.mac_croatian.h \
+		Python/frozen_modules/encodings.mac_cyrillic.h \
+		Python/frozen_modules/encodings.mac_farsi.h \
+		Python/frozen_modules/encodings.mac_greek.h \
+		Python/frozen_modules/encodings.mac_iceland.h \
+		Python/frozen_modules/encodings.mac_latin2.h \
+		Python/frozen_modules/encodings.mac_roman.h \
+		Python/frozen_modules/encodings.mac_romanian.h \
+		Python/frozen_modules/encodings.mac_turkish.h \
+		Python/frozen_modules/encodings.mbcs.h \
+		Python/frozen_modules/encodings.oem.h \
+		Python/frozen_modules/encodings.palmos.h \
+		Python/frozen_modules/encodings.ptcp154.h \
+		Python/frozen_modules/encodings.punycode.h \
+		Python/frozen_modules/encodings.quopri_codec.h \
+		Python/frozen_modules/encodings.raw_unicode_escape.h \
+		Python/frozen_modules/encodings.rot_13.h \
+		Python/frozen_modules/encodings.shift_jis.h \
+		Python/frozen_modules/encodings.shift_jis_2004.h \
+		Python/frozen_modules/encodings.shift_jisx0213.h \
+		Python/frozen_modules/encodings.tis_620.h \
+		Python/frozen_modules/encodings.undefined.h \
+		Python/frozen_modules/encodings.unicode_escape.h \
+		Python/frozen_modules/encodings.utf_16.h \
+		Python/frozen_modules/encodings.utf_16_be.h \
+		Python/frozen_modules/encodings.utf_16_le.h \
+		Python/frozen_modules/encodings.utf_32.h \
+		Python/frozen_modules/encodings.utf_32_be.h \
+		Python/frozen_modules/encodings.utf_32_le.h \
+		Python/frozen_modules/encodings.utf_7.h \
+		Python/frozen_modules/encodings.utf_8.h \
+		Python/frozen_modules/encodings.utf_8_sig.h \
+		Python/frozen_modules/encodings.uu_codec.h \
+		Python/frozen_modules/encodings.zlib_codec.h \
 		Python/frozen_modules/io.h \
 		Python/frozen_modules/_collections_abc.h \
 		Python/frozen_modules/_sitebuiltins.h \
@@ -1180,6 +1424,372 @@ Python/frozen_modules/abc.h: Lib/abc.py $(FREEZE_MODULE_DEPS)
 
 Python/frozen_modules/codecs.h: Lib/codecs.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) codecs $(srcdir)/Lib/codecs.py Python/frozen_modules/codecs.h
+
+Python/frozen_modules/encodings.h: Lib/encodings/__init__.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings $(srcdir)/Lib/encodings/__init__.py Python/frozen_modules/encodings.h
+
+Python/frozen_modules/encodings.aliases.h: Lib/encodings/aliases.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.aliases $(srcdir)/Lib/encodings/aliases.py Python/frozen_modules/encodings.aliases.h
+
+Python/frozen_modules/encodings.ascii.h: Lib/encodings/ascii.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.ascii $(srcdir)/Lib/encodings/ascii.py Python/frozen_modules/encodings.ascii.h
+
+Python/frozen_modules/encodings.base64_codec.h: Lib/encodings/base64_codec.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.base64_codec $(srcdir)/Lib/encodings/base64_codec.py Python/frozen_modules/encodings.base64_codec.h
+
+Python/frozen_modules/encodings.big5.h: Lib/encodings/big5.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.big5 $(srcdir)/Lib/encodings/big5.py Python/frozen_modules/encodings.big5.h
+
+Python/frozen_modules/encodings.big5hkscs.h: Lib/encodings/big5hkscs.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.big5hkscs $(srcdir)/Lib/encodings/big5hkscs.py Python/frozen_modules/encodings.big5hkscs.h
+
+Python/frozen_modules/encodings.bz2_codec.h: Lib/encodings/bz2_codec.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.bz2_codec $(srcdir)/Lib/encodings/bz2_codec.py Python/frozen_modules/encodings.bz2_codec.h
+
+Python/frozen_modules/encodings.charmap.h: Lib/encodings/charmap.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.charmap $(srcdir)/Lib/encodings/charmap.py Python/frozen_modules/encodings.charmap.h
+
+Python/frozen_modules/encodings.cp037.h: Lib/encodings/cp037.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp037 $(srcdir)/Lib/encodings/cp037.py Python/frozen_modules/encodings.cp037.h
+
+Python/frozen_modules/encodings.cp1006.h: Lib/encodings/cp1006.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1006 $(srcdir)/Lib/encodings/cp1006.py Python/frozen_modules/encodings.cp1006.h
+
+Python/frozen_modules/encodings.cp1026.h: Lib/encodings/cp1026.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1026 $(srcdir)/Lib/encodings/cp1026.py Python/frozen_modules/encodings.cp1026.h
+
+Python/frozen_modules/encodings.cp1125.h: Lib/encodings/cp1125.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1125 $(srcdir)/Lib/encodings/cp1125.py Python/frozen_modules/encodings.cp1125.h
+
+Python/frozen_modules/encodings.cp1140.h: Lib/encodings/cp1140.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1140 $(srcdir)/Lib/encodings/cp1140.py Python/frozen_modules/encodings.cp1140.h
+
+Python/frozen_modules/encodings.cp1250.h: Lib/encodings/cp1250.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1250 $(srcdir)/Lib/encodings/cp1250.py Python/frozen_modules/encodings.cp1250.h
+
+Python/frozen_modules/encodings.cp1251.h: Lib/encodings/cp1251.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1251 $(srcdir)/Lib/encodings/cp1251.py Python/frozen_modules/encodings.cp1251.h
+
+Python/frozen_modules/encodings.cp1252.h: Lib/encodings/cp1252.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1252 $(srcdir)/Lib/encodings/cp1252.py Python/frozen_modules/encodings.cp1252.h
+
+Python/frozen_modules/encodings.cp1253.h: Lib/encodings/cp1253.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1253 $(srcdir)/Lib/encodings/cp1253.py Python/frozen_modules/encodings.cp1253.h
+
+Python/frozen_modules/encodings.cp1254.h: Lib/encodings/cp1254.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1254 $(srcdir)/Lib/encodings/cp1254.py Python/frozen_modules/encodings.cp1254.h
+
+Python/frozen_modules/encodings.cp1255.h: Lib/encodings/cp1255.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1255 $(srcdir)/Lib/encodings/cp1255.py Python/frozen_modules/encodings.cp1255.h
+
+Python/frozen_modules/encodings.cp1256.h: Lib/encodings/cp1256.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1256 $(srcdir)/Lib/encodings/cp1256.py Python/frozen_modules/encodings.cp1256.h
+
+Python/frozen_modules/encodings.cp1257.h: Lib/encodings/cp1257.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1257 $(srcdir)/Lib/encodings/cp1257.py Python/frozen_modules/encodings.cp1257.h
+
+Python/frozen_modules/encodings.cp1258.h: Lib/encodings/cp1258.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp1258 $(srcdir)/Lib/encodings/cp1258.py Python/frozen_modules/encodings.cp1258.h
+
+Python/frozen_modules/encodings.cp273.h: Lib/encodings/cp273.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp273 $(srcdir)/Lib/encodings/cp273.py Python/frozen_modules/encodings.cp273.h
+
+Python/frozen_modules/encodings.cp424.h: Lib/encodings/cp424.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp424 $(srcdir)/Lib/encodings/cp424.py Python/frozen_modules/encodings.cp424.h
+
+Python/frozen_modules/encodings.cp437.h: Lib/encodings/cp437.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp437 $(srcdir)/Lib/encodings/cp437.py Python/frozen_modules/encodings.cp437.h
+
+Python/frozen_modules/encodings.cp500.h: Lib/encodings/cp500.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp500 $(srcdir)/Lib/encodings/cp500.py Python/frozen_modules/encodings.cp500.h
+
+Python/frozen_modules/encodings.cp720.h: Lib/encodings/cp720.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp720 $(srcdir)/Lib/encodings/cp720.py Python/frozen_modules/encodings.cp720.h
+
+Python/frozen_modules/encodings.cp737.h: Lib/encodings/cp737.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp737 $(srcdir)/Lib/encodings/cp737.py Python/frozen_modules/encodings.cp737.h
+
+Python/frozen_modules/encodings.cp775.h: Lib/encodings/cp775.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp775 $(srcdir)/Lib/encodings/cp775.py Python/frozen_modules/encodings.cp775.h
+
+Python/frozen_modules/encodings.cp850.h: Lib/encodings/cp850.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp850 $(srcdir)/Lib/encodings/cp850.py Python/frozen_modules/encodings.cp850.h
+
+Python/frozen_modules/encodings.cp852.h: Lib/encodings/cp852.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp852 $(srcdir)/Lib/encodings/cp852.py Python/frozen_modules/encodings.cp852.h
+
+Python/frozen_modules/encodings.cp855.h: Lib/encodings/cp855.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp855 $(srcdir)/Lib/encodings/cp855.py Python/frozen_modules/encodings.cp855.h
+
+Python/frozen_modules/encodings.cp856.h: Lib/encodings/cp856.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp856 $(srcdir)/Lib/encodings/cp856.py Python/frozen_modules/encodings.cp856.h
+
+Python/frozen_modules/encodings.cp857.h: Lib/encodings/cp857.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp857 $(srcdir)/Lib/encodings/cp857.py Python/frozen_modules/encodings.cp857.h
+
+Python/frozen_modules/encodings.cp858.h: Lib/encodings/cp858.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp858 $(srcdir)/Lib/encodings/cp858.py Python/frozen_modules/encodings.cp858.h
+
+Python/frozen_modules/encodings.cp860.h: Lib/encodings/cp860.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp860 $(srcdir)/Lib/encodings/cp860.py Python/frozen_modules/encodings.cp860.h
+
+Python/frozen_modules/encodings.cp861.h: Lib/encodings/cp861.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp861 $(srcdir)/Lib/encodings/cp861.py Python/frozen_modules/encodings.cp861.h
+
+Python/frozen_modules/encodings.cp862.h: Lib/encodings/cp862.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp862 $(srcdir)/Lib/encodings/cp862.py Python/frozen_modules/encodings.cp862.h
+
+Python/frozen_modules/encodings.cp863.h: Lib/encodings/cp863.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp863 $(srcdir)/Lib/encodings/cp863.py Python/frozen_modules/encodings.cp863.h
+
+Python/frozen_modules/encodings.cp864.h: Lib/encodings/cp864.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp864 $(srcdir)/Lib/encodings/cp864.py Python/frozen_modules/encodings.cp864.h
+
+Python/frozen_modules/encodings.cp865.h: Lib/encodings/cp865.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp865 $(srcdir)/Lib/encodings/cp865.py Python/frozen_modules/encodings.cp865.h
+
+Python/frozen_modules/encodings.cp866.h: Lib/encodings/cp866.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp866 $(srcdir)/Lib/encodings/cp866.py Python/frozen_modules/encodings.cp866.h
+
+Python/frozen_modules/encodings.cp869.h: Lib/encodings/cp869.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp869 $(srcdir)/Lib/encodings/cp869.py Python/frozen_modules/encodings.cp869.h
+
+Python/frozen_modules/encodings.cp874.h: Lib/encodings/cp874.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp874 $(srcdir)/Lib/encodings/cp874.py Python/frozen_modules/encodings.cp874.h
+
+Python/frozen_modules/encodings.cp875.h: Lib/encodings/cp875.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp875 $(srcdir)/Lib/encodings/cp875.py Python/frozen_modules/encodings.cp875.h
+
+Python/frozen_modules/encodings.cp932.h: Lib/encodings/cp932.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp932 $(srcdir)/Lib/encodings/cp932.py Python/frozen_modules/encodings.cp932.h
+
+Python/frozen_modules/encodings.cp949.h: Lib/encodings/cp949.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp949 $(srcdir)/Lib/encodings/cp949.py Python/frozen_modules/encodings.cp949.h
+
+Python/frozen_modules/encodings.cp950.h: Lib/encodings/cp950.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.cp950 $(srcdir)/Lib/encodings/cp950.py Python/frozen_modules/encodings.cp950.h
+
+Python/frozen_modules/encodings.euc_jis_2004.h: Lib/encodings/euc_jis_2004.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.euc_jis_2004 $(srcdir)/Lib/encodings/euc_jis_2004.py Python/frozen_modules/encodings.euc_jis_2004.h
+
+Python/frozen_modules/encodings.euc_jisx0213.h: Lib/encodings/euc_jisx0213.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.euc_jisx0213 $(srcdir)/Lib/encodings/euc_jisx0213.py Python/frozen_modules/encodings.euc_jisx0213.h
+
+Python/frozen_modules/encodings.euc_jp.h: Lib/encodings/euc_jp.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.euc_jp $(srcdir)/Lib/encodings/euc_jp.py Python/frozen_modules/encodings.euc_jp.h
+
+Python/frozen_modules/encodings.euc_kr.h: Lib/encodings/euc_kr.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.euc_kr $(srcdir)/Lib/encodings/euc_kr.py Python/frozen_modules/encodings.euc_kr.h
+
+Python/frozen_modules/encodings.gb18030.h: Lib/encodings/gb18030.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.gb18030 $(srcdir)/Lib/encodings/gb18030.py Python/frozen_modules/encodings.gb18030.h
+
+Python/frozen_modules/encodings.gb2312.h: Lib/encodings/gb2312.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.gb2312 $(srcdir)/Lib/encodings/gb2312.py Python/frozen_modules/encodings.gb2312.h
+
+Python/frozen_modules/encodings.gbk.h: Lib/encodings/gbk.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.gbk $(srcdir)/Lib/encodings/gbk.py Python/frozen_modules/encodings.gbk.h
+
+Python/frozen_modules/encodings.hex_codec.h: Lib/encodings/hex_codec.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.hex_codec $(srcdir)/Lib/encodings/hex_codec.py Python/frozen_modules/encodings.hex_codec.h
+
+Python/frozen_modules/encodings.hp_roman8.h: Lib/encodings/hp_roman8.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.hp_roman8 $(srcdir)/Lib/encodings/hp_roman8.py Python/frozen_modules/encodings.hp_roman8.h
+
+Python/frozen_modules/encodings.hz.h: Lib/encodings/hz.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.hz $(srcdir)/Lib/encodings/hz.py Python/frozen_modules/encodings.hz.h
+
+Python/frozen_modules/encodings.idna.h: Lib/encodings/idna.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.idna $(srcdir)/Lib/encodings/idna.py Python/frozen_modules/encodings.idna.h
+
+Python/frozen_modules/encodings.iso2022_jp.h: Lib/encodings/iso2022_jp.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_jp $(srcdir)/Lib/encodings/iso2022_jp.py Python/frozen_modules/encodings.iso2022_jp.h
+
+Python/frozen_modules/encodings.iso2022_jp_1.h: Lib/encodings/iso2022_jp_1.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_jp_1 $(srcdir)/Lib/encodings/iso2022_jp_1.py Python/frozen_modules/encodings.iso2022_jp_1.h
+
+Python/frozen_modules/encodings.iso2022_jp_2.h: Lib/encodings/iso2022_jp_2.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_jp_2 $(srcdir)/Lib/encodings/iso2022_jp_2.py Python/frozen_modules/encodings.iso2022_jp_2.h
+
+Python/frozen_modules/encodings.iso2022_jp_2004.h: Lib/encodings/iso2022_jp_2004.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_jp_2004 $(srcdir)/Lib/encodings/iso2022_jp_2004.py Python/frozen_modules/encodings.iso2022_jp_2004.h
+
+Python/frozen_modules/encodings.iso2022_jp_3.h: Lib/encodings/iso2022_jp_3.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_jp_3 $(srcdir)/Lib/encodings/iso2022_jp_3.py Python/frozen_modules/encodings.iso2022_jp_3.h
+
+Python/frozen_modules/encodings.iso2022_jp_ext.h: Lib/encodings/iso2022_jp_ext.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_jp_ext $(srcdir)/Lib/encodings/iso2022_jp_ext.py Python/frozen_modules/encodings.iso2022_jp_ext.h
+
+Python/frozen_modules/encodings.iso2022_kr.h: Lib/encodings/iso2022_kr.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso2022_kr $(srcdir)/Lib/encodings/iso2022_kr.py Python/frozen_modules/encodings.iso2022_kr.h
+
+Python/frozen_modules/encodings.iso8859_1.h: Lib/encodings/iso8859_1.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_1 $(srcdir)/Lib/encodings/iso8859_1.py Python/frozen_modules/encodings.iso8859_1.h
+
+Python/frozen_modules/encodings.iso8859_10.h: Lib/encodings/iso8859_10.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_10 $(srcdir)/Lib/encodings/iso8859_10.py Python/frozen_modules/encodings.iso8859_10.h
+
+Python/frozen_modules/encodings.iso8859_11.h: Lib/encodings/iso8859_11.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_11 $(srcdir)/Lib/encodings/iso8859_11.py Python/frozen_modules/encodings.iso8859_11.h
+
+Python/frozen_modules/encodings.iso8859_13.h: Lib/encodings/iso8859_13.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_13 $(srcdir)/Lib/encodings/iso8859_13.py Python/frozen_modules/encodings.iso8859_13.h
+
+Python/frozen_modules/encodings.iso8859_14.h: Lib/encodings/iso8859_14.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_14 $(srcdir)/Lib/encodings/iso8859_14.py Python/frozen_modules/encodings.iso8859_14.h
+
+Python/frozen_modules/encodings.iso8859_15.h: Lib/encodings/iso8859_15.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_15 $(srcdir)/Lib/encodings/iso8859_15.py Python/frozen_modules/encodings.iso8859_15.h
+
+Python/frozen_modules/encodings.iso8859_16.h: Lib/encodings/iso8859_16.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_16 $(srcdir)/Lib/encodings/iso8859_16.py Python/frozen_modules/encodings.iso8859_16.h
+
+Python/frozen_modules/encodings.iso8859_2.h: Lib/encodings/iso8859_2.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_2 $(srcdir)/Lib/encodings/iso8859_2.py Python/frozen_modules/encodings.iso8859_2.h
+
+Python/frozen_modules/encodings.iso8859_3.h: Lib/encodings/iso8859_3.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_3 $(srcdir)/Lib/encodings/iso8859_3.py Python/frozen_modules/encodings.iso8859_3.h
+
+Python/frozen_modules/encodings.iso8859_4.h: Lib/encodings/iso8859_4.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_4 $(srcdir)/Lib/encodings/iso8859_4.py Python/frozen_modules/encodings.iso8859_4.h
+
+Python/frozen_modules/encodings.iso8859_5.h: Lib/encodings/iso8859_5.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_5 $(srcdir)/Lib/encodings/iso8859_5.py Python/frozen_modules/encodings.iso8859_5.h
+
+Python/frozen_modules/encodings.iso8859_6.h: Lib/encodings/iso8859_6.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_6 $(srcdir)/Lib/encodings/iso8859_6.py Python/frozen_modules/encodings.iso8859_6.h
+
+Python/frozen_modules/encodings.iso8859_7.h: Lib/encodings/iso8859_7.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_7 $(srcdir)/Lib/encodings/iso8859_7.py Python/frozen_modules/encodings.iso8859_7.h
+
+Python/frozen_modules/encodings.iso8859_8.h: Lib/encodings/iso8859_8.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_8 $(srcdir)/Lib/encodings/iso8859_8.py Python/frozen_modules/encodings.iso8859_8.h
+
+Python/frozen_modules/encodings.iso8859_9.h: Lib/encodings/iso8859_9.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.iso8859_9 $(srcdir)/Lib/encodings/iso8859_9.py Python/frozen_modules/encodings.iso8859_9.h
+
+Python/frozen_modules/encodings.johab.h: Lib/encodings/johab.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.johab $(srcdir)/Lib/encodings/johab.py Python/frozen_modules/encodings.johab.h
+
+Python/frozen_modules/encodings.koi8_r.h: Lib/encodings/koi8_r.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.koi8_r $(srcdir)/Lib/encodings/koi8_r.py Python/frozen_modules/encodings.koi8_r.h
+
+Python/frozen_modules/encodings.koi8_t.h: Lib/encodings/koi8_t.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.koi8_t $(srcdir)/Lib/encodings/koi8_t.py Python/frozen_modules/encodings.koi8_t.h
+
+Python/frozen_modules/encodings.koi8_u.h: Lib/encodings/koi8_u.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.koi8_u $(srcdir)/Lib/encodings/koi8_u.py Python/frozen_modules/encodings.koi8_u.h
+
+Python/frozen_modules/encodings.kz1048.h: Lib/encodings/kz1048.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.kz1048 $(srcdir)/Lib/encodings/kz1048.py Python/frozen_modules/encodings.kz1048.h
+
+Python/frozen_modules/encodings.latin_1.h: Lib/encodings/latin_1.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.latin_1 $(srcdir)/Lib/encodings/latin_1.py Python/frozen_modules/encodings.latin_1.h
+
+Python/frozen_modules/encodings.mac_arabic.h: Lib/encodings/mac_arabic.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_arabic $(srcdir)/Lib/encodings/mac_arabic.py Python/frozen_modules/encodings.mac_arabic.h
+
+Python/frozen_modules/encodings.mac_croatian.h: Lib/encodings/mac_croatian.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_croatian $(srcdir)/Lib/encodings/mac_croatian.py Python/frozen_modules/encodings.mac_croatian.h
+
+Python/frozen_modules/encodings.mac_cyrillic.h: Lib/encodings/mac_cyrillic.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_cyrillic $(srcdir)/Lib/encodings/mac_cyrillic.py Python/frozen_modules/encodings.mac_cyrillic.h
+
+Python/frozen_modules/encodings.mac_farsi.h: Lib/encodings/mac_farsi.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_farsi $(srcdir)/Lib/encodings/mac_farsi.py Python/frozen_modules/encodings.mac_farsi.h
+
+Python/frozen_modules/encodings.mac_greek.h: Lib/encodings/mac_greek.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_greek $(srcdir)/Lib/encodings/mac_greek.py Python/frozen_modules/encodings.mac_greek.h
+
+Python/frozen_modules/encodings.mac_iceland.h: Lib/encodings/mac_iceland.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_iceland $(srcdir)/Lib/encodings/mac_iceland.py Python/frozen_modules/encodings.mac_iceland.h
+
+Python/frozen_modules/encodings.mac_latin2.h: Lib/encodings/mac_latin2.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_latin2 $(srcdir)/Lib/encodings/mac_latin2.py Python/frozen_modules/encodings.mac_latin2.h
+
+Python/frozen_modules/encodings.mac_roman.h: Lib/encodings/mac_roman.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_roman $(srcdir)/Lib/encodings/mac_roman.py Python/frozen_modules/encodings.mac_roman.h
+
+Python/frozen_modules/encodings.mac_romanian.h: Lib/encodings/mac_romanian.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_romanian $(srcdir)/Lib/encodings/mac_romanian.py Python/frozen_modules/encodings.mac_romanian.h
+
+Python/frozen_modules/encodings.mac_turkish.h: Lib/encodings/mac_turkish.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mac_turkish $(srcdir)/Lib/encodings/mac_turkish.py Python/frozen_modules/encodings.mac_turkish.h
+
+Python/frozen_modules/encodings.mbcs.h: Lib/encodings/mbcs.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.mbcs $(srcdir)/Lib/encodings/mbcs.py Python/frozen_modules/encodings.mbcs.h
+
+Python/frozen_modules/encodings.oem.h: Lib/encodings/oem.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.oem $(srcdir)/Lib/encodings/oem.py Python/frozen_modules/encodings.oem.h
+
+Python/frozen_modules/encodings.palmos.h: Lib/encodings/palmos.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.palmos $(srcdir)/Lib/encodings/palmos.py Python/frozen_modules/encodings.palmos.h
+
+Python/frozen_modules/encodings.ptcp154.h: Lib/encodings/ptcp154.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.ptcp154 $(srcdir)/Lib/encodings/ptcp154.py Python/frozen_modules/encodings.ptcp154.h
+
+Python/frozen_modules/encodings.punycode.h: Lib/encodings/punycode.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.punycode $(srcdir)/Lib/encodings/punycode.py Python/frozen_modules/encodings.punycode.h
+
+Python/frozen_modules/encodings.quopri_codec.h: Lib/encodings/quopri_codec.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.quopri_codec $(srcdir)/Lib/encodings/quopri_codec.py Python/frozen_modules/encodings.quopri_codec.h
+
+Python/frozen_modules/encodings.raw_unicode_escape.h: Lib/encodings/raw_unicode_escape.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.raw_unicode_escape $(srcdir)/Lib/encodings/raw_unicode_escape.py Python/frozen_modules/encodings.raw_unicode_escape.h
+
+Python/frozen_modules/encodings.rot_13.h: Lib/encodings/rot_13.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.rot_13 $(srcdir)/Lib/encodings/rot_13.py Python/frozen_modules/encodings.rot_13.h
+
+Python/frozen_modules/encodings.shift_jis.h: Lib/encodings/shift_jis.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.shift_jis $(srcdir)/Lib/encodings/shift_jis.py Python/frozen_modules/encodings.shift_jis.h
+
+Python/frozen_modules/encodings.shift_jis_2004.h: Lib/encodings/shift_jis_2004.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.shift_jis_2004 $(srcdir)/Lib/encodings/shift_jis_2004.py Python/frozen_modules/encodings.shift_jis_2004.h
+
+Python/frozen_modules/encodings.shift_jisx0213.h: Lib/encodings/shift_jisx0213.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.shift_jisx0213 $(srcdir)/Lib/encodings/shift_jisx0213.py Python/frozen_modules/encodings.shift_jisx0213.h
+
+Python/frozen_modules/encodings.tis_620.h: Lib/encodings/tis_620.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.tis_620 $(srcdir)/Lib/encodings/tis_620.py Python/frozen_modules/encodings.tis_620.h
+
+Python/frozen_modules/encodings.undefined.h: Lib/encodings/undefined.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.undefined $(srcdir)/Lib/encodings/undefined.py Python/frozen_modules/encodings.undefined.h
+
+Python/frozen_modules/encodings.unicode_escape.h: Lib/encodings/unicode_escape.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.unicode_escape $(srcdir)/Lib/encodings/unicode_escape.py Python/frozen_modules/encodings.unicode_escape.h
+
+Python/frozen_modules/encodings.utf_16.h: Lib/encodings/utf_16.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_16 $(srcdir)/Lib/encodings/utf_16.py Python/frozen_modules/encodings.utf_16.h
+
+Python/frozen_modules/encodings.utf_16_be.h: Lib/encodings/utf_16_be.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_16_be $(srcdir)/Lib/encodings/utf_16_be.py Python/frozen_modules/encodings.utf_16_be.h
+
+Python/frozen_modules/encodings.utf_16_le.h: Lib/encodings/utf_16_le.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_16_le $(srcdir)/Lib/encodings/utf_16_le.py Python/frozen_modules/encodings.utf_16_le.h
+
+Python/frozen_modules/encodings.utf_32.h: Lib/encodings/utf_32.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_32 $(srcdir)/Lib/encodings/utf_32.py Python/frozen_modules/encodings.utf_32.h
+
+Python/frozen_modules/encodings.utf_32_be.h: Lib/encodings/utf_32_be.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_32_be $(srcdir)/Lib/encodings/utf_32_be.py Python/frozen_modules/encodings.utf_32_be.h
+
+Python/frozen_modules/encodings.utf_32_le.h: Lib/encodings/utf_32_le.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_32_le $(srcdir)/Lib/encodings/utf_32_le.py Python/frozen_modules/encodings.utf_32_le.h
+
+Python/frozen_modules/encodings.utf_7.h: Lib/encodings/utf_7.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_7 $(srcdir)/Lib/encodings/utf_7.py Python/frozen_modules/encodings.utf_7.h
+
+Python/frozen_modules/encodings.utf_8.h: Lib/encodings/utf_8.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_8 $(srcdir)/Lib/encodings/utf_8.py Python/frozen_modules/encodings.utf_8.h
+
+Python/frozen_modules/encodings.utf_8_sig.h: Lib/encodings/utf_8_sig.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_8_sig $(srcdir)/Lib/encodings/utf_8_sig.py Python/frozen_modules/encodings.utf_8_sig.h
+
+Python/frozen_modules/encodings.uu_codec.h: Lib/encodings/uu_codec.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.uu_codec $(srcdir)/Lib/encodings/uu_codec.py Python/frozen_modules/encodings.uu_codec.h
+
+Python/frozen_modules/encodings.zlib_codec.h: Lib/encodings/zlib_codec.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.zlib_codec $(srcdir)/Lib/encodings/zlib_codec.py Python/frozen_modules/encodings.zlib_codec.h
 
 Python/frozen_modules/io.h: Lib/io.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) io $(srcdir)/Lib/io.py Python/frozen_modules/io.h
@@ -1260,6 +1870,128 @@ $(DEEPFREEZE_C): $(DEEPFREEZE_DEPS)
 	Python/frozen_modules/zipimport.h:zipimport \
 	Python/frozen_modules/abc.h:abc \
 	Python/frozen_modules/codecs.h:codecs \
+	Python/frozen_modules/encodings.h:encodings \
+	Python/frozen_modules/encodings.aliases.h:encodings.aliases \
+	Python/frozen_modules/encodings.ascii.h:encodings.ascii \
+	Python/frozen_modules/encodings.base64_codec.h:encodings.base64_codec \
+	Python/frozen_modules/encodings.big5.h:encodings.big5 \
+	Python/frozen_modules/encodings.big5hkscs.h:encodings.big5hkscs \
+	Python/frozen_modules/encodings.bz2_codec.h:encodings.bz2_codec \
+	Python/frozen_modules/encodings.charmap.h:encodings.charmap \
+	Python/frozen_modules/encodings.cp037.h:encodings.cp037 \
+	Python/frozen_modules/encodings.cp1006.h:encodings.cp1006 \
+	Python/frozen_modules/encodings.cp1026.h:encodings.cp1026 \
+	Python/frozen_modules/encodings.cp1125.h:encodings.cp1125 \
+	Python/frozen_modules/encodings.cp1140.h:encodings.cp1140 \
+	Python/frozen_modules/encodings.cp1250.h:encodings.cp1250 \
+	Python/frozen_modules/encodings.cp1251.h:encodings.cp1251 \
+	Python/frozen_modules/encodings.cp1252.h:encodings.cp1252 \
+	Python/frozen_modules/encodings.cp1253.h:encodings.cp1253 \
+	Python/frozen_modules/encodings.cp1254.h:encodings.cp1254 \
+	Python/frozen_modules/encodings.cp1255.h:encodings.cp1255 \
+	Python/frozen_modules/encodings.cp1256.h:encodings.cp1256 \
+	Python/frozen_modules/encodings.cp1257.h:encodings.cp1257 \
+	Python/frozen_modules/encodings.cp1258.h:encodings.cp1258 \
+	Python/frozen_modules/encodings.cp273.h:encodings.cp273 \
+	Python/frozen_modules/encodings.cp424.h:encodings.cp424 \
+	Python/frozen_modules/encodings.cp437.h:encodings.cp437 \
+	Python/frozen_modules/encodings.cp500.h:encodings.cp500 \
+	Python/frozen_modules/encodings.cp720.h:encodings.cp720 \
+	Python/frozen_modules/encodings.cp737.h:encodings.cp737 \
+	Python/frozen_modules/encodings.cp775.h:encodings.cp775 \
+	Python/frozen_modules/encodings.cp850.h:encodings.cp850 \
+	Python/frozen_modules/encodings.cp852.h:encodings.cp852 \
+	Python/frozen_modules/encodings.cp855.h:encodings.cp855 \
+	Python/frozen_modules/encodings.cp856.h:encodings.cp856 \
+	Python/frozen_modules/encodings.cp857.h:encodings.cp857 \
+	Python/frozen_modules/encodings.cp858.h:encodings.cp858 \
+	Python/frozen_modules/encodings.cp860.h:encodings.cp860 \
+	Python/frozen_modules/encodings.cp861.h:encodings.cp861 \
+	Python/frozen_modules/encodings.cp862.h:encodings.cp862 \
+	Python/frozen_modules/encodings.cp863.h:encodings.cp863 \
+	Python/frozen_modules/encodings.cp864.h:encodings.cp864 \
+	Python/frozen_modules/encodings.cp865.h:encodings.cp865 \
+	Python/frozen_modules/encodings.cp866.h:encodings.cp866 \
+	Python/frozen_modules/encodings.cp869.h:encodings.cp869 \
+	Python/frozen_modules/encodings.cp874.h:encodings.cp874 \
+	Python/frozen_modules/encodings.cp875.h:encodings.cp875 \
+	Python/frozen_modules/encodings.cp932.h:encodings.cp932 \
+	Python/frozen_modules/encodings.cp949.h:encodings.cp949 \
+	Python/frozen_modules/encodings.cp950.h:encodings.cp950 \
+	Python/frozen_modules/encodings.euc_jis_2004.h:encodings.euc_jis_2004 \
+	Python/frozen_modules/encodings.euc_jisx0213.h:encodings.euc_jisx0213 \
+	Python/frozen_modules/encodings.euc_jp.h:encodings.euc_jp \
+	Python/frozen_modules/encodings.euc_kr.h:encodings.euc_kr \
+	Python/frozen_modules/encodings.gb18030.h:encodings.gb18030 \
+	Python/frozen_modules/encodings.gb2312.h:encodings.gb2312 \
+	Python/frozen_modules/encodings.gbk.h:encodings.gbk \
+	Python/frozen_modules/encodings.hex_codec.h:encodings.hex_codec \
+	Python/frozen_modules/encodings.hp_roman8.h:encodings.hp_roman8 \
+	Python/frozen_modules/encodings.hz.h:encodings.hz \
+	Python/frozen_modules/encodings.idna.h:encodings.idna \
+	Python/frozen_modules/encodings.iso2022_jp.h:encodings.iso2022_jp \
+	Python/frozen_modules/encodings.iso2022_jp_1.h:encodings.iso2022_jp_1 \
+	Python/frozen_modules/encodings.iso2022_jp_2.h:encodings.iso2022_jp_2 \
+	Python/frozen_modules/encodings.iso2022_jp_2004.h:encodings.iso2022_jp_2004 \
+	Python/frozen_modules/encodings.iso2022_jp_3.h:encodings.iso2022_jp_3 \
+	Python/frozen_modules/encodings.iso2022_jp_ext.h:encodings.iso2022_jp_ext \
+	Python/frozen_modules/encodings.iso2022_kr.h:encodings.iso2022_kr \
+	Python/frozen_modules/encodings.iso8859_1.h:encodings.iso8859_1 \
+	Python/frozen_modules/encodings.iso8859_10.h:encodings.iso8859_10 \
+	Python/frozen_modules/encodings.iso8859_11.h:encodings.iso8859_11 \
+	Python/frozen_modules/encodings.iso8859_13.h:encodings.iso8859_13 \
+	Python/frozen_modules/encodings.iso8859_14.h:encodings.iso8859_14 \
+	Python/frozen_modules/encodings.iso8859_15.h:encodings.iso8859_15 \
+	Python/frozen_modules/encodings.iso8859_16.h:encodings.iso8859_16 \
+	Python/frozen_modules/encodings.iso8859_2.h:encodings.iso8859_2 \
+	Python/frozen_modules/encodings.iso8859_3.h:encodings.iso8859_3 \
+	Python/frozen_modules/encodings.iso8859_4.h:encodings.iso8859_4 \
+	Python/frozen_modules/encodings.iso8859_5.h:encodings.iso8859_5 \
+	Python/frozen_modules/encodings.iso8859_6.h:encodings.iso8859_6 \
+	Python/frozen_modules/encodings.iso8859_7.h:encodings.iso8859_7 \
+	Python/frozen_modules/encodings.iso8859_8.h:encodings.iso8859_8 \
+	Python/frozen_modules/encodings.iso8859_9.h:encodings.iso8859_9 \
+	Python/frozen_modules/encodings.johab.h:encodings.johab \
+	Python/frozen_modules/encodings.koi8_r.h:encodings.koi8_r \
+	Python/frozen_modules/encodings.koi8_t.h:encodings.koi8_t \
+	Python/frozen_modules/encodings.koi8_u.h:encodings.koi8_u \
+	Python/frozen_modules/encodings.kz1048.h:encodings.kz1048 \
+	Python/frozen_modules/encodings.latin_1.h:encodings.latin_1 \
+	Python/frozen_modules/encodings.mac_arabic.h:encodings.mac_arabic \
+	Python/frozen_modules/encodings.mac_croatian.h:encodings.mac_croatian \
+	Python/frozen_modules/encodings.mac_cyrillic.h:encodings.mac_cyrillic \
+	Python/frozen_modules/encodings.mac_farsi.h:encodings.mac_farsi \
+	Python/frozen_modules/encodings.mac_greek.h:encodings.mac_greek \
+	Python/frozen_modules/encodings.mac_iceland.h:encodings.mac_iceland \
+	Python/frozen_modules/encodings.mac_latin2.h:encodings.mac_latin2 \
+	Python/frozen_modules/encodings.mac_roman.h:encodings.mac_roman \
+	Python/frozen_modules/encodings.mac_romanian.h:encodings.mac_romanian \
+	Python/frozen_modules/encodings.mac_turkish.h:encodings.mac_turkish \
+	Python/frozen_modules/encodings.mbcs.h:encodings.mbcs \
+	Python/frozen_modules/encodings.oem.h:encodings.oem \
+	Python/frozen_modules/encodings.palmos.h:encodings.palmos \
+	Python/frozen_modules/encodings.ptcp154.h:encodings.ptcp154 \
+	Python/frozen_modules/encodings.punycode.h:encodings.punycode \
+	Python/frozen_modules/encodings.quopri_codec.h:encodings.quopri_codec \
+	Python/frozen_modules/encodings.raw_unicode_escape.h:encodings.raw_unicode_escape \
+	Python/frozen_modules/encodings.rot_13.h:encodings.rot_13 \
+	Python/frozen_modules/encodings.shift_jis.h:encodings.shift_jis \
+	Python/frozen_modules/encodings.shift_jis_2004.h:encodings.shift_jis_2004 \
+	Python/frozen_modules/encodings.shift_jisx0213.h:encodings.shift_jisx0213 \
+	Python/frozen_modules/encodings.tis_620.h:encodings.tis_620 \
+	Python/frozen_modules/encodings.undefined.h:encodings.undefined \
+	Python/frozen_modules/encodings.unicode_escape.h:encodings.unicode_escape \
+	Python/frozen_modules/encodings.utf_16.h:encodings.utf_16 \
+	Python/frozen_modules/encodings.utf_16_be.h:encodings.utf_16_be \
+	Python/frozen_modules/encodings.utf_16_le.h:encodings.utf_16_le \
+	Python/frozen_modules/encodings.utf_32.h:encodings.utf_32 \
+	Python/frozen_modules/encodings.utf_32_be.h:encodings.utf_32_be \
+	Python/frozen_modules/encodings.utf_32_le.h:encodings.utf_32_le \
+	Python/frozen_modules/encodings.utf_7.h:encodings.utf_7 \
+	Python/frozen_modules/encodings.utf_8.h:encodings.utf_8 \
+	Python/frozen_modules/encodings.utf_8_sig.h:encodings.utf_8_sig \
+	Python/frozen_modules/encodings.uu_codec.h:encodings.uu_codec \
+	Python/frozen_modules/encodings.zlib_codec.h:encodings.zlib_codec \
 	Python/frozen_modules/io.h:io \
 	Python/frozen_modules/_collections_abc.h:_collections_abc \
 	Python/frozen_modules/_sitebuiltins.h:_sitebuiltins \

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -10,6 +10,13 @@
 
 /* Includes for exit_sigint() */
 #include <stdio.h>                // perror()
+
+#ifdef __nanvix__
+#include <stdlib.h>               // getenv()
+#include <string.h>               // strcmp()
+/* Defined in Modules/nanvix_snapshot.S — separate .S file survives LTO. */
+extern void nanvix_snapshot(void);
+#endif
 #ifdef HAVE_SIGNAL_H
 #  include <signal.h>             // SIGINT
 #endif
@@ -735,6 +742,15 @@ pymain_main(_PyArgv *args)
     if (_PyStatus_EXCEPTION(status)) {
         pymain_exit_error(status);
     }
+
+#ifdef __nanvix__
+    /* Always trigger a VM snapshot after initialization.
+     * On restore, execution resumes here and proceeds to Py_RunMain(). */
+    {
+        register int _eax __asm__("eax") = 35;
+        __asm__ volatile("int $0x80" : "+r"(_eax) : : "edx", "memory");
+    }
+#endif
 
     return Py_RunMain();
 }

--- a/Modules/nanvix_snapshot.S
+++ b/Modules/nanvix_snapshot.S
@@ -1,0 +1,10 @@
+# Nanvix VM snapshot trigger via int 0x80 (syscall 35)
+# This is in a separate .S file to survive LTO optimization.
+    .text
+    .globl nanvix_snapshot
+    .type nanvix_snapshot, @function
+nanvix_snapshot:
+    movl $35, %eax
+    int $0x80
+    ret
+    .size nanvix_snapshot, .-nanvix_snapshot

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -271,6 +271,616 @@
       <IntFile>$(IntDir)codecs.g.h</IntFile>
       <OutFile>$(PySourcePath)Python\frozen_modules\codecs.h</OutFile>
     </None>
+    <None Include="..\Lib\encodings\__init__.py">
+      <ModName>encodings</ModName>
+      <IntFile>$(IntDir)encodings.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\aliases.py">
+      <ModName>encodings.aliases</ModName>
+      <IntFile>$(IntDir)encodings.aliases.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.aliases.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\ascii.py">
+      <ModName>encodings.ascii</ModName>
+      <IntFile>$(IntDir)encodings.ascii.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.ascii.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\base64_codec.py">
+      <ModName>encodings.base64_codec</ModName>
+      <IntFile>$(IntDir)encodings.base64_codec.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.base64_codec.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\big5.py">
+      <ModName>encodings.big5</ModName>
+      <IntFile>$(IntDir)encodings.big5.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.big5.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\big5hkscs.py">
+      <ModName>encodings.big5hkscs</ModName>
+      <IntFile>$(IntDir)encodings.big5hkscs.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.big5hkscs.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\bz2_codec.py">
+      <ModName>encodings.bz2_codec</ModName>
+      <IntFile>$(IntDir)encodings.bz2_codec.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.bz2_codec.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\charmap.py">
+      <ModName>encodings.charmap</ModName>
+      <IntFile>$(IntDir)encodings.charmap.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.charmap.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp037.py">
+      <ModName>encodings.cp037</ModName>
+      <IntFile>$(IntDir)encodings.cp037.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp037.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1006.py">
+      <ModName>encodings.cp1006</ModName>
+      <IntFile>$(IntDir)encodings.cp1006.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1006.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1026.py">
+      <ModName>encodings.cp1026</ModName>
+      <IntFile>$(IntDir)encodings.cp1026.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1026.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1125.py">
+      <ModName>encodings.cp1125</ModName>
+      <IntFile>$(IntDir)encodings.cp1125.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1125.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1140.py">
+      <ModName>encodings.cp1140</ModName>
+      <IntFile>$(IntDir)encodings.cp1140.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1140.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1250.py">
+      <ModName>encodings.cp1250</ModName>
+      <IntFile>$(IntDir)encodings.cp1250.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1250.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1251.py">
+      <ModName>encodings.cp1251</ModName>
+      <IntFile>$(IntDir)encodings.cp1251.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1251.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1252.py">
+      <ModName>encodings.cp1252</ModName>
+      <IntFile>$(IntDir)encodings.cp1252.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1252.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1253.py">
+      <ModName>encodings.cp1253</ModName>
+      <IntFile>$(IntDir)encodings.cp1253.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1253.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1254.py">
+      <ModName>encodings.cp1254</ModName>
+      <IntFile>$(IntDir)encodings.cp1254.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1254.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1255.py">
+      <ModName>encodings.cp1255</ModName>
+      <IntFile>$(IntDir)encodings.cp1255.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1255.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1256.py">
+      <ModName>encodings.cp1256</ModName>
+      <IntFile>$(IntDir)encodings.cp1256.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1256.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1257.py">
+      <ModName>encodings.cp1257</ModName>
+      <IntFile>$(IntDir)encodings.cp1257.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1257.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp1258.py">
+      <ModName>encodings.cp1258</ModName>
+      <IntFile>$(IntDir)encodings.cp1258.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp1258.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp273.py">
+      <ModName>encodings.cp273</ModName>
+      <IntFile>$(IntDir)encodings.cp273.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp273.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp424.py">
+      <ModName>encodings.cp424</ModName>
+      <IntFile>$(IntDir)encodings.cp424.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp424.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp437.py">
+      <ModName>encodings.cp437</ModName>
+      <IntFile>$(IntDir)encodings.cp437.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp437.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp500.py">
+      <ModName>encodings.cp500</ModName>
+      <IntFile>$(IntDir)encodings.cp500.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp500.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp720.py">
+      <ModName>encodings.cp720</ModName>
+      <IntFile>$(IntDir)encodings.cp720.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp720.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp737.py">
+      <ModName>encodings.cp737</ModName>
+      <IntFile>$(IntDir)encodings.cp737.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp737.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp775.py">
+      <ModName>encodings.cp775</ModName>
+      <IntFile>$(IntDir)encodings.cp775.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp775.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp850.py">
+      <ModName>encodings.cp850</ModName>
+      <IntFile>$(IntDir)encodings.cp850.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp850.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp852.py">
+      <ModName>encodings.cp852</ModName>
+      <IntFile>$(IntDir)encodings.cp852.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp852.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp855.py">
+      <ModName>encodings.cp855</ModName>
+      <IntFile>$(IntDir)encodings.cp855.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp855.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp856.py">
+      <ModName>encodings.cp856</ModName>
+      <IntFile>$(IntDir)encodings.cp856.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp856.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp857.py">
+      <ModName>encodings.cp857</ModName>
+      <IntFile>$(IntDir)encodings.cp857.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp857.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp858.py">
+      <ModName>encodings.cp858</ModName>
+      <IntFile>$(IntDir)encodings.cp858.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp858.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp860.py">
+      <ModName>encodings.cp860</ModName>
+      <IntFile>$(IntDir)encodings.cp860.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp860.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp861.py">
+      <ModName>encodings.cp861</ModName>
+      <IntFile>$(IntDir)encodings.cp861.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp861.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp862.py">
+      <ModName>encodings.cp862</ModName>
+      <IntFile>$(IntDir)encodings.cp862.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp862.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp863.py">
+      <ModName>encodings.cp863</ModName>
+      <IntFile>$(IntDir)encodings.cp863.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp863.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp864.py">
+      <ModName>encodings.cp864</ModName>
+      <IntFile>$(IntDir)encodings.cp864.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp864.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp865.py">
+      <ModName>encodings.cp865</ModName>
+      <IntFile>$(IntDir)encodings.cp865.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp865.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp866.py">
+      <ModName>encodings.cp866</ModName>
+      <IntFile>$(IntDir)encodings.cp866.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp866.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp869.py">
+      <ModName>encodings.cp869</ModName>
+      <IntFile>$(IntDir)encodings.cp869.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp869.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp874.py">
+      <ModName>encodings.cp874</ModName>
+      <IntFile>$(IntDir)encodings.cp874.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp874.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp875.py">
+      <ModName>encodings.cp875</ModName>
+      <IntFile>$(IntDir)encodings.cp875.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp875.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp932.py">
+      <ModName>encodings.cp932</ModName>
+      <IntFile>$(IntDir)encodings.cp932.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp932.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp949.py">
+      <ModName>encodings.cp949</ModName>
+      <IntFile>$(IntDir)encodings.cp949.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp949.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\cp950.py">
+      <ModName>encodings.cp950</ModName>
+      <IntFile>$(IntDir)encodings.cp950.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.cp950.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\euc_jis_2004.py">
+      <ModName>encodings.euc_jis_2004</ModName>
+      <IntFile>$(IntDir)encodings.euc_jis_2004.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.euc_jis_2004.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\euc_jisx0213.py">
+      <ModName>encodings.euc_jisx0213</ModName>
+      <IntFile>$(IntDir)encodings.euc_jisx0213.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.euc_jisx0213.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\euc_jp.py">
+      <ModName>encodings.euc_jp</ModName>
+      <IntFile>$(IntDir)encodings.euc_jp.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.euc_jp.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\euc_kr.py">
+      <ModName>encodings.euc_kr</ModName>
+      <IntFile>$(IntDir)encodings.euc_kr.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.euc_kr.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\gb18030.py">
+      <ModName>encodings.gb18030</ModName>
+      <IntFile>$(IntDir)encodings.gb18030.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.gb18030.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\gb2312.py">
+      <ModName>encodings.gb2312</ModName>
+      <IntFile>$(IntDir)encodings.gb2312.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.gb2312.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\gbk.py">
+      <ModName>encodings.gbk</ModName>
+      <IntFile>$(IntDir)encodings.gbk.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.gbk.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\hex_codec.py">
+      <ModName>encodings.hex_codec</ModName>
+      <IntFile>$(IntDir)encodings.hex_codec.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.hex_codec.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\hp_roman8.py">
+      <ModName>encodings.hp_roman8</ModName>
+      <IntFile>$(IntDir)encodings.hp_roman8.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.hp_roman8.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\hz.py">
+      <ModName>encodings.hz</ModName>
+      <IntFile>$(IntDir)encodings.hz.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.hz.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\idna.py">
+      <ModName>encodings.idna</ModName>
+      <IntFile>$(IntDir)encodings.idna.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.idna.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp.py">
+      <ModName>encodings.iso2022_jp</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_jp.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_1.py">
+      <ModName>encodings.iso2022_jp_1</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_jp_1.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_1.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_2.py">
+      <ModName>encodings.iso2022_jp_2</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_jp_2.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_2.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_2004.py">
+      <ModName>encodings.iso2022_jp_2004</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_jp_2004.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_2004.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_3.py">
+      <ModName>encodings.iso2022_jp_3</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_jp_3.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_3.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_ext.py">
+      <ModName>encodings.iso2022_jp_ext</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_jp_ext.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_ext.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_kr.py">
+      <ModName>encodings.iso2022_kr</ModName>
+      <IntFile>$(IntDir)encodings.iso2022_kr.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso2022_kr.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_1.py">
+      <ModName>encodings.iso8859_1</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_1.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_1.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_10.py">
+      <ModName>encodings.iso8859_10</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_10.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_10.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_11.py">
+      <ModName>encodings.iso8859_11</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_11.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_11.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_13.py">
+      <ModName>encodings.iso8859_13</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_13.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_13.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_14.py">
+      <ModName>encodings.iso8859_14</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_14.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_14.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_15.py">
+      <ModName>encodings.iso8859_15</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_15.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_15.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_16.py">
+      <ModName>encodings.iso8859_16</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_16.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_16.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_2.py">
+      <ModName>encodings.iso8859_2</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_2.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_2.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_3.py">
+      <ModName>encodings.iso8859_3</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_3.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_3.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_4.py">
+      <ModName>encodings.iso8859_4</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_4.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_4.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_5.py">
+      <ModName>encodings.iso8859_5</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_5.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_5.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_6.py">
+      <ModName>encodings.iso8859_6</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_6.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_6.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_7.py">
+      <ModName>encodings.iso8859_7</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_7.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_7.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_8.py">
+      <ModName>encodings.iso8859_8</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_8.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_8.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_9.py">
+      <ModName>encodings.iso8859_9</ModName>
+      <IntFile>$(IntDir)encodings.iso8859_9.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.iso8859_9.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\johab.py">
+      <ModName>encodings.johab</ModName>
+      <IntFile>$(IntDir)encodings.johab.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.johab.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\koi8_r.py">
+      <ModName>encodings.koi8_r</ModName>
+      <IntFile>$(IntDir)encodings.koi8_r.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.koi8_r.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\koi8_t.py">
+      <ModName>encodings.koi8_t</ModName>
+      <IntFile>$(IntDir)encodings.koi8_t.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.koi8_t.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\koi8_u.py">
+      <ModName>encodings.koi8_u</ModName>
+      <IntFile>$(IntDir)encodings.koi8_u.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.koi8_u.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\kz1048.py">
+      <ModName>encodings.kz1048</ModName>
+      <IntFile>$(IntDir)encodings.kz1048.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.kz1048.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\latin_1.py">
+      <ModName>encodings.latin_1</ModName>
+      <IntFile>$(IntDir)encodings.latin_1.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.latin_1.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_arabic.py">
+      <ModName>encodings.mac_arabic</ModName>
+      <IntFile>$(IntDir)encodings.mac_arabic.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_arabic.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_croatian.py">
+      <ModName>encodings.mac_croatian</ModName>
+      <IntFile>$(IntDir)encodings.mac_croatian.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_croatian.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_cyrillic.py">
+      <ModName>encodings.mac_cyrillic</ModName>
+      <IntFile>$(IntDir)encodings.mac_cyrillic.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_cyrillic.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_farsi.py">
+      <ModName>encodings.mac_farsi</ModName>
+      <IntFile>$(IntDir)encodings.mac_farsi.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_farsi.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_greek.py">
+      <ModName>encodings.mac_greek</ModName>
+      <IntFile>$(IntDir)encodings.mac_greek.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_greek.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_iceland.py">
+      <ModName>encodings.mac_iceland</ModName>
+      <IntFile>$(IntDir)encodings.mac_iceland.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_iceland.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_latin2.py">
+      <ModName>encodings.mac_latin2</ModName>
+      <IntFile>$(IntDir)encodings.mac_latin2.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_latin2.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_roman.py">
+      <ModName>encodings.mac_roman</ModName>
+      <IntFile>$(IntDir)encodings.mac_roman.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_roman.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_romanian.py">
+      <ModName>encodings.mac_romanian</ModName>
+      <IntFile>$(IntDir)encodings.mac_romanian.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_romanian.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mac_turkish.py">
+      <ModName>encodings.mac_turkish</ModName>
+      <IntFile>$(IntDir)encodings.mac_turkish.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mac_turkish.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\mbcs.py">
+      <ModName>encodings.mbcs</ModName>
+      <IntFile>$(IntDir)encodings.mbcs.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.mbcs.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\oem.py">
+      <ModName>encodings.oem</ModName>
+      <IntFile>$(IntDir)encodings.oem.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.oem.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\palmos.py">
+      <ModName>encodings.palmos</ModName>
+      <IntFile>$(IntDir)encodings.palmos.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.palmos.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\ptcp154.py">
+      <ModName>encodings.ptcp154</ModName>
+      <IntFile>$(IntDir)encodings.ptcp154.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.ptcp154.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\punycode.py">
+      <ModName>encodings.punycode</ModName>
+      <IntFile>$(IntDir)encodings.punycode.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.punycode.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\quopri_codec.py">
+      <ModName>encodings.quopri_codec</ModName>
+      <IntFile>$(IntDir)encodings.quopri_codec.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.quopri_codec.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\raw_unicode_escape.py">
+      <ModName>encodings.raw_unicode_escape</ModName>
+      <IntFile>$(IntDir)encodings.raw_unicode_escape.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.raw_unicode_escape.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\rot_13.py">
+      <ModName>encodings.rot_13</ModName>
+      <IntFile>$(IntDir)encodings.rot_13.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.rot_13.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\shift_jis.py">
+      <ModName>encodings.shift_jis</ModName>
+      <IntFile>$(IntDir)encodings.shift_jis.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.shift_jis.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\shift_jis_2004.py">
+      <ModName>encodings.shift_jis_2004</ModName>
+      <IntFile>$(IntDir)encodings.shift_jis_2004.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.shift_jis_2004.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\shift_jisx0213.py">
+      <ModName>encodings.shift_jisx0213</ModName>
+      <IntFile>$(IntDir)encodings.shift_jisx0213.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.shift_jisx0213.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\tis_620.py">
+      <ModName>encodings.tis_620</ModName>
+      <IntFile>$(IntDir)encodings.tis_620.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.tis_620.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\undefined.py">
+      <ModName>encodings.undefined</ModName>
+      <IntFile>$(IntDir)encodings.undefined.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.undefined.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\unicode_escape.py">
+      <ModName>encodings.unicode_escape</ModName>
+      <IntFile>$(IntDir)encodings.unicode_escape.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.unicode_escape.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_16.py">
+      <ModName>encodings.utf_16</ModName>
+      <IntFile>$(IntDir)encodings.utf_16.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_16.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_16_be.py">
+      <ModName>encodings.utf_16_be</ModName>
+      <IntFile>$(IntDir)encodings.utf_16_be.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_16_be.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_16_le.py">
+      <ModName>encodings.utf_16_le</ModName>
+      <IntFile>$(IntDir)encodings.utf_16_le.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_16_le.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_32.py">
+      <ModName>encodings.utf_32</ModName>
+      <IntFile>$(IntDir)encodings.utf_32.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_32.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_32_be.py">
+      <ModName>encodings.utf_32_be</ModName>
+      <IntFile>$(IntDir)encodings.utf_32_be.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_32_be.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_32_le.py">
+      <ModName>encodings.utf_32_le</ModName>
+      <IntFile>$(IntDir)encodings.utf_32_le.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_32_le.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_7.py">
+      <ModName>encodings.utf_7</ModName>
+      <IntFile>$(IntDir)encodings.utf_7.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_7.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_8.py">
+      <ModName>encodings.utf_8</ModName>
+      <IntFile>$(IntDir)encodings.utf_8.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_8.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_8_sig.py">
+      <ModName>encodings.utf_8_sig</ModName>
+      <IntFile>$(IntDir)encodings.utf_8_sig.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_8_sig.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\uu_codec.py">
+      <ModName>encodings.uu_codec</ModName>
+      <IntFile>$(IntDir)encodings.uu_codec.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.uu_codec.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\zlib_codec.py">
+      <ModName>encodings.zlib_codec</ModName>
+      <IntFile>$(IntDir)encodings.zlib_codec.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.zlib_codec.h</OutFile>
+    </None>
     <None Include="..\Lib\io.py">
       <ModName>io</ModName>
       <IntFile>$(IntDir)io.g.h</IntFile>
@@ -409,6 +1019,128 @@
 		 "$(PySourcePath)Python\frozen_modules\zipimport.h:zipimport" ^
 		 "$(PySourcePath)Python\frozen_modules\abc.h:abc" ^
 		 "$(PySourcePath)Python\frozen_modules\codecs.h:codecs" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.h:encodings" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.aliases.h:encodings.aliases" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.ascii.h:encodings.ascii" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.base64_codec.h:encodings.base64_codec" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.big5.h:encodings.big5" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.big5hkscs.h:encodings.big5hkscs" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.bz2_codec.h:encodings.bz2_codec" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.charmap.h:encodings.charmap" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp037.h:encodings.cp037" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1006.h:encodings.cp1006" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1026.h:encodings.cp1026" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1125.h:encodings.cp1125" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1140.h:encodings.cp1140" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1250.h:encodings.cp1250" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1251.h:encodings.cp1251" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1252.h:encodings.cp1252" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1253.h:encodings.cp1253" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1254.h:encodings.cp1254" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1255.h:encodings.cp1255" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1256.h:encodings.cp1256" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1257.h:encodings.cp1257" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp1258.h:encodings.cp1258" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp273.h:encodings.cp273" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp424.h:encodings.cp424" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp437.h:encodings.cp437" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp500.h:encodings.cp500" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp720.h:encodings.cp720" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp737.h:encodings.cp737" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp775.h:encodings.cp775" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp850.h:encodings.cp850" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp852.h:encodings.cp852" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp855.h:encodings.cp855" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp856.h:encodings.cp856" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp857.h:encodings.cp857" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp858.h:encodings.cp858" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp860.h:encodings.cp860" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp861.h:encodings.cp861" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp862.h:encodings.cp862" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp863.h:encodings.cp863" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp864.h:encodings.cp864" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp865.h:encodings.cp865" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp866.h:encodings.cp866" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp869.h:encodings.cp869" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp874.h:encodings.cp874" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp875.h:encodings.cp875" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp932.h:encodings.cp932" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp949.h:encodings.cp949" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.cp950.h:encodings.cp950" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.euc_jis_2004.h:encodings.euc_jis_2004" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.euc_jisx0213.h:encodings.euc_jisx0213" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.euc_jp.h:encodings.euc_jp" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.euc_kr.h:encodings.euc_kr" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.gb18030.h:encodings.gb18030" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.gb2312.h:encodings.gb2312" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.gbk.h:encodings.gbk" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.hex_codec.h:encodings.hex_codec" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.hp_roman8.h:encodings.hp_roman8" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.hz.h:encodings.hz" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.idna.h:encodings.idna" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp.h:encodings.iso2022_jp" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_1.h:encodings.iso2022_jp_1" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_2.h:encodings.iso2022_jp_2" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_2004.h:encodings.iso2022_jp_2004" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_3.h:encodings.iso2022_jp_3" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_jp_ext.h:encodings.iso2022_jp_ext" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso2022_kr.h:encodings.iso2022_kr" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_1.h:encodings.iso8859_1" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_10.h:encodings.iso8859_10" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_11.h:encodings.iso8859_11" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_13.h:encodings.iso8859_13" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_14.h:encodings.iso8859_14" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_15.h:encodings.iso8859_15" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_16.h:encodings.iso8859_16" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_2.h:encodings.iso8859_2" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_3.h:encodings.iso8859_3" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_4.h:encodings.iso8859_4" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_5.h:encodings.iso8859_5" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_6.h:encodings.iso8859_6" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_7.h:encodings.iso8859_7" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_8.h:encodings.iso8859_8" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.iso8859_9.h:encodings.iso8859_9" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.johab.h:encodings.johab" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.koi8_r.h:encodings.koi8_r" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.koi8_t.h:encodings.koi8_t" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.koi8_u.h:encodings.koi8_u" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.kz1048.h:encodings.kz1048" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.latin_1.h:encodings.latin_1" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_arabic.h:encodings.mac_arabic" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_croatian.h:encodings.mac_croatian" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_cyrillic.h:encodings.mac_cyrillic" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_farsi.h:encodings.mac_farsi" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_greek.h:encodings.mac_greek" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_iceland.h:encodings.mac_iceland" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_latin2.h:encodings.mac_latin2" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_roman.h:encodings.mac_roman" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_romanian.h:encodings.mac_romanian" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mac_turkish.h:encodings.mac_turkish" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.mbcs.h:encodings.mbcs" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.oem.h:encodings.oem" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.palmos.h:encodings.palmos" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.ptcp154.h:encodings.ptcp154" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.punycode.h:encodings.punycode" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.quopri_codec.h:encodings.quopri_codec" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.raw_unicode_escape.h:encodings.raw_unicode_escape" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.rot_13.h:encodings.rot_13" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.shift_jis.h:encodings.shift_jis" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.shift_jis_2004.h:encodings.shift_jis_2004" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.shift_jisx0213.h:encodings.shift_jisx0213" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.tis_620.h:encodings.tis_620" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.undefined.h:encodings.undefined" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.unicode_escape.h:encodings.unicode_escape" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_16.h:encodings.utf_16" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_16_be.h:encodings.utf_16_be" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_16_le.h:encodings.utf_16_le" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_32.h:encodings.utf_32" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_32_be.h:encodings.utf_32_be" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_32_le.h:encodings.utf_32_le" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_7.h:encodings.utf_7" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_8.h:encodings.utf_8" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_8_sig.h:encodings.utf_8_sig" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.uu_codec.h:encodings.uu_codec" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.zlib_codec.h:encodings.zlib_codec" ^
 		 "$(PySourcePath)Python\frozen_modules\io.h:io" ^
 		 "$(PySourcePath)Python\frozen_modules\_collections_abc.h:_collections_abc" ^
 		 "$(PySourcePath)Python\frozen_modules\_sitebuiltins.h:_sitebuiltins" ^

--- a/PCbuild/_freeze_module.vcxproj.filters
+++ b/PCbuild/_freeze_module.vcxproj.filters
@@ -444,6 +444,372 @@
     <None Include="..\Lib\codecs.py">
       <Filter>Python Files</Filter>
     </None>
+    <None Include="..\Lib\encodings\__init__.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\aliases.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\ascii.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\base64_codec.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\big5.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\big5hkscs.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\bz2_codec.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\charmap.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp037.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1006.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1026.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1125.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1140.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1250.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1251.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1252.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1253.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1254.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1255.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1256.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1257.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp1258.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp273.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp424.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp437.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp500.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp720.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp737.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp775.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp850.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp852.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp855.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp856.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp857.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp858.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp860.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp861.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp862.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp863.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp864.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp865.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp866.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp869.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp874.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp875.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp932.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp949.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\cp950.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\euc_jis_2004.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\euc_jisx0213.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\euc_jp.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\euc_kr.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\gb18030.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\gb2312.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\gbk.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\hex_codec.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\hp_roman8.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\hz.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\idna.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_1.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_2.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_2004.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_3.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_jp_ext.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso2022_kr.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_1.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_10.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_11.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_13.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_14.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_15.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_16.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_2.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_3.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_4.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_5.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_6.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_7.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_8.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\iso8859_9.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\johab.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\koi8_r.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\koi8_t.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\koi8_u.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\kz1048.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\latin_1.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_arabic.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_croatian.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_cyrillic.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_farsi.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_greek.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_iceland.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_latin2.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_roman.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_romanian.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mac_turkish.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\mbcs.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\oem.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\palmos.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\ptcp154.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\punycode.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\quopri_codec.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\raw_unicode_escape.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\rot_13.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\shift_jis.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\shift_jis_2004.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\shift_jisx0213.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\tis_620.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\undefined.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\unicode_escape.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_16.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_16_be.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_16_le.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_32.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_32_be.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_32_le.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_7.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_8.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_8_sig.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\uu_codec.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\zlib_codec.py">
+      <Filter>Python Files</Filter>
+    </None>
     <None Include="..\Lib\io.py">
       <Filter>Python Files</Filter>
     </None>

--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -41,29 +41,6 @@
 #include <stdbool.h>
 
 /* Includes for frozen modules: */
-#include "frozen_modules/importlib._bootstrap.h"
-#include "frozen_modules/importlib._bootstrap_external.h"
-#include "frozen_modules/zipimport.h"
-#include "frozen_modules/abc.h"
-#include "frozen_modules/codecs.h"
-#include "frozen_modules/io.h"
-#include "frozen_modules/_collections_abc.h"
-#include "frozen_modules/_sitebuiltins.h"
-#include "frozen_modules/genericpath.h"
-#include "frozen_modules/ntpath.h"
-#include "frozen_modules/posixpath.h"
-#include "frozen_modules/os.h"
-#include "frozen_modules/site.h"
-#include "frozen_modules/stat.h"
-#include "frozen_modules/importlib.util.h"
-#include "frozen_modules/importlib.machinery.h"
-#include "frozen_modules/runpy.h"
-#include "frozen_modules/__hello__.h"
-#include "frozen_modules/__phello__.h"
-#include "frozen_modules/__phello__.ham.h"
-#include "frozen_modules/__phello__.ham.eggs.h"
-#include "frozen_modules/__phello__.spam.h"
-#include "frozen_modules/frozen_only.h"
 /* End includes */
 
 #define GET_CODE(name) _Py_get_##name##_toplevel
@@ -74,6 +51,128 @@ extern PyObject *_Py_get_importlib__bootstrap_external_toplevel(void);
 extern PyObject *_Py_get_zipimport_toplevel(void);
 extern PyObject *_Py_get_abc_toplevel(void);
 extern PyObject *_Py_get_codecs_toplevel(void);
+extern PyObject *_Py_get_encodings_toplevel(void);
+extern PyObject *_Py_get_encodings_aliases_toplevel(void);
+extern PyObject *_Py_get_encodings_ascii_toplevel(void);
+extern PyObject *_Py_get_encodings_base64_codec_toplevel(void);
+extern PyObject *_Py_get_encodings_big5_toplevel(void);
+extern PyObject *_Py_get_encodings_big5hkscs_toplevel(void);
+extern PyObject *_Py_get_encodings_bz2_codec_toplevel(void);
+extern PyObject *_Py_get_encodings_charmap_toplevel(void);
+extern PyObject *_Py_get_encodings_cp037_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1006_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1026_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1125_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1140_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1250_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1251_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1252_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1253_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1254_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1255_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1256_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1257_toplevel(void);
+extern PyObject *_Py_get_encodings_cp1258_toplevel(void);
+extern PyObject *_Py_get_encodings_cp273_toplevel(void);
+extern PyObject *_Py_get_encodings_cp424_toplevel(void);
+extern PyObject *_Py_get_encodings_cp437_toplevel(void);
+extern PyObject *_Py_get_encodings_cp500_toplevel(void);
+extern PyObject *_Py_get_encodings_cp720_toplevel(void);
+extern PyObject *_Py_get_encodings_cp737_toplevel(void);
+extern PyObject *_Py_get_encodings_cp775_toplevel(void);
+extern PyObject *_Py_get_encodings_cp850_toplevel(void);
+extern PyObject *_Py_get_encodings_cp852_toplevel(void);
+extern PyObject *_Py_get_encodings_cp855_toplevel(void);
+extern PyObject *_Py_get_encodings_cp856_toplevel(void);
+extern PyObject *_Py_get_encodings_cp857_toplevel(void);
+extern PyObject *_Py_get_encodings_cp858_toplevel(void);
+extern PyObject *_Py_get_encodings_cp860_toplevel(void);
+extern PyObject *_Py_get_encodings_cp861_toplevel(void);
+extern PyObject *_Py_get_encodings_cp862_toplevel(void);
+extern PyObject *_Py_get_encodings_cp863_toplevel(void);
+extern PyObject *_Py_get_encodings_cp864_toplevel(void);
+extern PyObject *_Py_get_encodings_cp865_toplevel(void);
+extern PyObject *_Py_get_encodings_cp866_toplevel(void);
+extern PyObject *_Py_get_encodings_cp869_toplevel(void);
+extern PyObject *_Py_get_encodings_cp874_toplevel(void);
+extern PyObject *_Py_get_encodings_cp875_toplevel(void);
+extern PyObject *_Py_get_encodings_cp932_toplevel(void);
+extern PyObject *_Py_get_encodings_cp949_toplevel(void);
+extern PyObject *_Py_get_encodings_cp950_toplevel(void);
+extern PyObject *_Py_get_encodings_euc_jis_2004_toplevel(void);
+extern PyObject *_Py_get_encodings_euc_jisx0213_toplevel(void);
+extern PyObject *_Py_get_encodings_euc_jp_toplevel(void);
+extern PyObject *_Py_get_encodings_euc_kr_toplevel(void);
+extern PyObject *_Py_get_encodings_gb18030_toplevel(void);
+extern PyObject *_Py_get_encodings_gb2312_toplevel(void);
+extern PyObject *_Py_get_encodings_gbk_toplevel(void);
+extern PyObject *_Py_get_encodings_hex_codec_toplevel(void);
+extern PyObject *_Py_get_encodings_hp_roman8_toplevel(void);
+extern PyObject *_Py_get_encodings_hz_toplevel(void);
+extern PyObject *_Py_get_encodings_idna_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_jp_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_jp_1_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_jp_2_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_jp_2004_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_jp_3_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_jp_ext_toplevel(void);
+extern PyObject *_Py_get_encodings_iso2022_kr_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_1_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_10_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_11_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_13_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_14_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_15_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_16_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_2_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_3_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_4_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_5_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_6_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_7_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_8_toplevel(void);
+extern PyObject *_Py_get_encodings_iso8859_9_toplevel(void);
+extern PyObject *_Py_get_encodings_johab_toplevel(void);
+extern PyObject *_Py_get_encodings_koi8_r_toplevel(void);
+extern PyObject *_Py_get_encodings_koi8_t_toplevel(void);
+extern PyObject *_Py_get_encodings_koi8_u_toplevel(void);
+extern PyObject *_Py_get_encodings_kz1048_toplevel(void);
+extern PyObject *_Py_get_encodings_latin_1_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_arabic_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_croatian_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_cyrillic_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_farsi_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_greek_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_iceland_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_latin2_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_roman_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_romanian_toplevel(void);
+extern PyObject *_Py_get_encodings_mac_turkish_toplevel(void);
+extern PyObject *_Py_get_encodings_mbcs_toplevel(void);
+extern PyObject *_Py_get_encodings_oem_toplevel(void);
+extern PyObject *_Py_get_encodings_palmos_toplevel(void);
+extern PyObject *_Py_get_encodings_ptcp154_toplevel(void);
+extern PyObject *_Py_get_encodings_punycode_toplevel(void);
+extern PyObject *_Py_get_encodings_quopri_codec_toplevel(void);
+extern PyObject *_Py_get_encodings_raw_unicode_escape_toplevel(void);
+extern PyObject *_Py_get_encodings_rot_13_toplevel(void);
+extern PyObject *_Py_get_encodings_shift_jis_toplevel(void);
+extern PyObject *_Py_get_encodings_shift_jis_2004_toplevel(void);
+extern PyObject *_Py_get_encodings_shift_jisx0213_toplevel(void);
+extern PyObject *_Py_get_encodings_tis_620_toplevel(void);
+extern PyObject *_Py_get_encodings_undefined_toplevel(void);
+extern PyObject *_Py_get_encodings_unicode_escape_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_16_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_16_be_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_16_le_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_32_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_32_be_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_32_le_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_7_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_8_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_8_sig_toplevel(void);
+extern PyObject *_Py_get_encodings_uu_codec_toplevel(void);
+extern PyObject *_Py_get_encodings_zlib_codec_toplevel(void);
 extern PyObject *_Py_get_io_toplevel(void);
 extern PyObject *_Py_get__collections_abc_toplevel(void);
 extern PyObject *_Py_get__sitebuiltins_toplevel(void);
@@ -95,46 +194,169 @@ extern PyObject *_Py_get_frozen_only_toplevel(void);
 /* End extern declarations */
 
 static const struct _frozen bootstrap_modules[] = {
-    {"_frozen_importlib", _Py_M__importlib__bootstrap, (int)sizeof(_Py_M__importlib__bootstrap), false, GET_CODE(importlib__bootstrap)},
-    {"_frozen_importlib_external", _Py_M__importlib__bootstrap_external, (int)sizeof(_Py_M__importlib__bootstrap_external), false, GET_CODE(importlib__bootstrap_external)},
-    {"zipimport", _Py_M__zipimport, (int)sizeof(_Py_M__zipimport), false, GET_CODE(zipimport)},
+    {"_frozen_importlib", NULL, 0, false, GET_CODE(importlib__bootstrap)},
+    {"_frozen_importlib_external", NULL, 0, false, GET_CODE(importlib__bootstrap_external)},
+    {"zipimport", NULL, 0, false, GET_CODE(zipimport)},
     {0, 0, 0} /* bootstrap sentinel */
 };
 static const struct _frozen stdlib_modules[] = {
     /* stdlib - startup, without site (python -S) */
-    {"abc", _Py_M__abc, (int)sizeof(_Py_M__abc), false, GET_CODE(abc)},
-    {"codecs", _Py_M__codecs, (int)sizeof(_Py_M__codecs), false, GET_CODE(codecs)},
-    {"io", _Py_M__io, (int)sizeof(_Py_M__io), false, GET_CODE(io)},
+    {"abc", NULL, 0, false, GET_CODE(abc)},
+    {"codecs", NULL, 0, false, GET_CODE(codecs)},
+    {"encodings", NULL, 0, true, GET_CODE(encodings)},
+    {"encodings.__init__", NULL, 0, false, GET_CODE(encodings)},
+    {"encodings.aliases", NULL, 0, false, GET_CODE(encodings_aliases)},
+    {"encodings.ascii", NULL, 0, false, GET_CODE(encodings_ascii)},
+    {"encodings.base64_codec", NULL, 0, false, GET_CODE(encodings_base64_codec)},
+    {"encodings.big5", NULL, 0, false, GET_CODE(encodings_big5)},
+    {"encodings.big5hkscs", NULL, 0, false, GET_CODE(encodings_big5hkscs)},
+    {"encodings.bz2_codec", NULL, 0, false, GET_CODE(encodings_bz2_codec)},
+    {"encodings.charmap", NULL, 0, false, GET_CODE(encodings_charmap)},
+    {"encodings.cp037", NULL, 0, false, GET_CODE(encodings_cp037)},
+    {"encodings.cp1006", NULL, 0, false, GET_CODE(encodings_cp1006)},
+    {"encodings.cp1026", NULL, 0, false, GET_CODE(encodings_cp1026)},
+    {"encodings.cp1125", NULL, 0, false, GET_CODE(encodings_cp1125)},
+    {"encodings.cp1140", NULL, 0, false, GET_CODE(encodings_cp1140)},
+    {"encodings.cp1250", NULL, 0, false, GET_CODE(encodings_cp1250)},
+    {"encodings.cp1251", NULL, 0, false, GET_CODE(encodings_cp1251)},
+    {"encodings.cp1252", NULL, 0, false, GET_CODE(encodings_cp1252)},
+    {"encodings.cp1253", NULL, 0, false, GET_CODE(encodings_cp1253)},
+    {"encodings.cp1254", NULL, 0, false, GET_CODE(encodings_cp1254)},
+    {"encodings.cp1255", NULL, 0, false, GET_CODE(encodings_cp1255)},
+    {"encodings.cp1256", NULL, 0, false, GET_CODE(encodings_cp1256)},
+    {"encodings.cp1257", NULL, 0, false, GET_CODE(encodings_cp1257)},
+    {"encodings.cp1258", NULL, 0, false, GET_CODE(encodings_cp1258)},
+    {"encodings.cp273", NULL, 0, false, GET_CODE(encodings_cp273)},
+    {"encodings.cp424", NULL, 0, false, GET_CODE(encodings_cp424)},
+    {"encodings.cp437", NULL, 0, false, GET_CODE(encodings_cp437)},
+    {"encodings.cp500", NULL, 0, false, GET_CODE(encodings_cp500)},
+    {"encodings.cp720", NULL, 0, false, GET_CODE(encodings_cp720)},
+    {"encodings.cp737", NULL, 0, false, GET_CODE(encodings_cp737)},
+    {"encodings.cp775", NULL, 0, false, GET_CODE(encodings_cp775)},
+    {"encodings.cp850", NULL, 0, false, GET_CODE(encodings_cp850)},
+    {"encodings.cp852", NULL, 0, false, GET_CODE(encodings_cp852)},
+    {"encodings.cp855", NULL, 0, false, GET_CODE(encodings_cp855)},
+    {"encodings.cp856", NULL, 0, false, GET_CODE(encodings_cp856)},
+    {"encodings.cp857", NULL, 0, false, GET_CODE(encodings_cp857)},
+    {"encodings.cp858", NULL, 0, false, GET_CODE(encodings_cp858)},
+    {"encodings.cp860", NULL, 0, false, GET_CODE(encodings_cp860)},
+    {"encodings.cp861", NULL, 0, false, GET_CODE(encodings_cp861)},
+    {"encodings.cp862", NULL, 0, false, GET_CODE(encodings_cp862)},
+    {"encodings.cp863", NULL, 0, false, GET_CODE(encodings_cp863)},
+    {"encodings.cp864", NULL, 0, false, GET_CODE(encodings_cp864)},
+    {"encodings.cp865", NULL, 0, false, GET_CODE(encodings_cp865)},
+    {"encodings.cp866", NULL, 0, false, GET_CODE(encodings_cp866)},
+    {"encodings.cp869", NULL, 0, false, GET_CODE(encodings_cp869)},
+    {"encodings.cp874", NULL, 0, false, GET_CODE(encodings_cp874)},
+    {"encodings.cp875", NULL, 0, false, GET_CODE(encodings_cp875)},
+    {"encodings.cp932", NULL, 0, false, GET_CODE(encodings_cp932)},
+    {"encodings.cp949", NULL, 0, false, GET_CODE(encodings_cp949)},
+    {"encodings.cp950", NULL, 0, false, GET_CODE(encodings_cp950)},
+    {"encodings.euc_jis_2004", NULL, 0, false, GET_CODE(encodings_euc_jis_2004)},
+    {"encodings.euc_jisx0213", NULL, 0, false, GET_CODE(encodings_euc_jisx0213)},
+    {"encodings.euc_jp", NULL, 0, false, GET_CODE(encodings_euc_jp)},
+    {"encodings.euc_kr", NULL, 0, false, GET_CODE(encodings_euc_kr)},
+    {"encodings.gb18030", NULL, 0, false, GET_CODE(encodings_gb18030)},
+    {"encodings.gb2312", NULL, 0, false, GET_CODE(encodings_gb2312)},
+    {"encodings.gbk", NULL, 0, false, GET_CODE(encodings_gbk)},
+    {"encodings.hex_codec", NULL, 0, false, GET_CODE(encodings_hex_codec)},
+    {"encodings.hp_roman8", NULL, 0, false, GET_CODE(encodings_hp_roman8)},
+    {"encodings.hz", NULL, 0, false, GET_CODE(encodings_hz)},
+    {"encodings.idna", NULL, 0, false, GET_CODE(encodings_idna)},
+    {"encodings.iso2022_jp", NULL, 0, false, GET_CODE(encodings_iso2022_jp)},
+    {"encodings.iso2022_jp_1", NULL, 0, false, GET_CODE(encodings_iso2022_jp_1)},
+    {"encodings.iso2022_jp_2", NULL, 0, false, GET_CODE(encodings_iso2022_jp_2)},
+    {"encodings.iso2022_jp_2004", NULL, 0, false, GET_CODE(encodings_iso2022_jp_2004)},
+    {"encodings.iso2022_jp_3", NULL, 0, false, GET_CODE(encodings_iso2022_jp_3)},
+    {"encodings.iso2022_jp_ext", NULL, 0, false, GET_CODE(encodings_iso2022_jp_ext)},
+    {"encodings.iso2022_kr", NULL, 0, false, GET_CODE(encodings_iso2022_kr)},
+    {"encodings.iso8859_1", NULL, 0, false, GET_CODE(encodings_iso8859_1)},
+    {"encodings.iso8859_10", NULL, 0, false, GET_CODE(encodings_iso8859_10)},
+    {"encodings.iso8859_11", NULL, 0, false, GET_CODE(encodings_iso8859_11)},
+    {"encodings.iso8859_13", NULL, 0, false, GET_CODE(encodings_iso8859_13)},
+    {"encodings.iso8859_14", NULL, 0, false, GET_CODE(encodings_iso8859_14)},
+    {"encodings.iso8859_15", NULL, 0, false, GET_CODE(encodings_iso8859_15)},
+    {"encodings.iso8859_16", NULL, 0, false, GET_CODE(encodings_iso8859_16)},
+    {"encodings.iso8859_2", NULL, 0, false, GET_CODE(encodings_iso8859_2)},
+    {"encodings.iso8859_3", NULL, 0, false, GET_CODE(encodings_iso8859_3)},
+    {"encodings.iso8859_4", NULL, 0, false, GET_CODE(encodings_iso8859_4)},
+    {"encodings.iso8859_5", NULL, 0, false, GET_CODE(encodings_iso8859_5)},
+    {"encodings.iso8859_6", NULL, 0, false, GET_CODE(encodings_iso8859_6)},
+    {"encodings.iso8859_7", NULL, 0, false, GET_CODE(encodings_iso8859_7)},
+    {"encodings.iso8859_8", NULL, 0, false, GET_CODE(encodings_iso8859_8)},
+    {"encodings.iso8859_9", NULL, 0, false, GET_CODE(encodings_iso8859_9)},
+    {"encodings.johab", NULL, 0, false, GET_CODE(encodings_johab)},
+    {"encodings.koi8_r", NULL, 0, false, GET_CODE(encodings_koi8_r)},
+    {"encodings.koi8_t", NULL, 0, false, GET_CODE(encodings_koi8_t)},
+    {"encodings.koi8_u", NULL, 0, false, GET_CODE(encodings_koi8_u)},
+    {"encodings.kz1048", NULL, 0, false, GET_CODE(encodings_kz1048)},
+    {"encodings.latin_1", NULL, 0, false, GET_CODE(encodings_latin_1)},
+    {"encodings.mac_arabic", NULL, 0, false, GET_CODE(encodings_mac_arabic)},
+    {"encodings.mac_croatian", NULL, 0, false, GET_CODE(encodings_mac_croatian)},
+    {"encodings.mac_cyrillic", NULL, 0, false, GET_CODE(encodings_mac_cyrillic)},
+    {"encodings.mac_farsi", NULL, 0, false, GET_CODE(encodings_mac_farsi)},
+    {"encodings.mac_greek", NULL, 0, false, GET_CODE(encodings_mac_greek)},
+    {"encodings.mac_iceland", NULL, 0, false, GET_CODE(encodings_mac_iceland)},
+    {"encodings.mac_latin2", NULL, 0, false, GET_CODE(encodings_mac_latin2)},
+    {"encodings.mac_roman", NULL, 0, false, GET_CODE(encodings_mac_roman)},
+    {"encodings.mac_romanian", NULL, 0, false, GET_CODE(encodings_mac_romanian)},
+    {"encodings.mac_turkish", NULL, 0, false, GET_CODE(encodings_mac_turkish)},
+    {"encodings.mbcs", NULL, 0, false, GET_CODE(encodings_mbcs)},
+    {"encodings.oem", NULL, 0, false, GET_CODE(encodings_oem)},
+    {"encodings.palmos", NULL, 0, false, GET_CODE(encodings_palmos)},
+    {"encodings.ptcp154", NULL, 0, false, GET_CODE(encodings_ptcp154)},
+    {"encodings.punycode", NULL, 0, false, GET_CODE(encodings_punycode)},
+    {"encodings.quopri_codec", NULL, 0, false, GET_CODE(encodings_quopri_codec)},
+    {"encodings.raw_unicode_escape", NULL, 0, false, GET_CODE(encodings_raw_unicode_escape)},
+    {"encodings.rot_13", NULL, 0, false, GET_CODE(encodings_rot_13)},
+    {"encodings.shift_jis", NULL, 0, false, GET_CODE(encodings_shift_jis)},
+    {"encodings.shift_jis_2004", NULL, 0, false, GET_CODE(encodings_shift_jis_2004)},
+    {"encodings.shift_jisx0213", NULL, 0, false, GET_CODE(encodings_shift_jisx0213)},
+    {"encodings.tis_620", NULL, 0, false, GET_CODE(encodings_tis_620)},
+    {"encodings.undefined", NULL, 0, false, GET_CODE(encodings_undefined)},
+    {"encodings.unicode_escape", NULL, 0, false, GET_CODE(encodings_unicode_escape)},
+    {"encodings.utf_16", NULL, 0, false, GET_CODE(encodings_utf_16)},
+    {"encodings.utf_16_be", NULL, 0, false, GET_CODE(encodings_utf_16_be)},
+    {"encodings.utf_16_le", NULL, 0, false, GET_CODE(encodings_utf_16_le)},
+    {"encodings.utf_32", NULL, 0, false, GET_CODE(encodings_utf_32)},
+    {"encodings.utf_32_be", NULL, 0, false, GET_CODE(encodings_utf_32_be)},
+    {"encodings.utf_32_le", NULL, 0, false, GET_CODE(encodings_utf_32_le)},
+    {"encodings.utf_7", NULL, 0, false, GET_CODE(encodings_utf_7)},
+    {"encodings.utf_8", NULL, 0, false, GET_CODE(encodings_utf_8)},
+    {"encodings.utf_8_sig", NULL, 0, false, GET_CODE(encodings_utf_8_sig)},
+    {"encodings.uu_codec", NULL, 0, false, GET_CODE(encodings_uu_codec)},
+    {"encodings.zlib_codec", NULL, 0, false, GET_CODE(encodings_zlib_codec)},
+    {"io", NULL, 0, false, GET_CODE(io)},
 
     /* stdlib - startup, with site */
-    {"_collections_abc", _Py_M___collections_abc, (int)sizeof(_Py_M___collections_abc), false, GET_CODE(_collections_abc)},
-    {"_sitebuiltins", _Py_M___sitebuiltins, (int)sizeof(_Py_M___sitebuiltins), false, GET_CODE(_sitebuiltins)},
-    {"genericpath", _Py_M__genericpath, (int)sizeof(_Py_M__genericpath), false, GET_CODE(genericpath)},
-    {"ntpath", _Py_M__ntpath, (int)sizeof(_Py_M__ntpath), false, GET_CODE(ntpath)},
-    {"posixpath", _Py_M__posixpath, (int)sizeof(_Py_M__posixpath), false, GET_CODE(posixpath)},
-    {"os.path", _Py_M__posixpath, (int)sizeof(_Py_M__posixpath), false, GET_CODE(posixpath)},
-    {"os", _Py_M__os, (int)sizeof(_Py_M__os), false, GET_CODE(os)},
-    {"site", _Py_M__site, (int)sizeof(_Py_M__site), false, GET_CODE(site)},
-    {"stat", _Py_M__stat, (int)sizeof(_Py_M__stat), false, GET_CODE(stat)},
+    {"_collections_abc", NULL, 0, false, GET_CODE(_collections_abc)},
+    {"_sitebuiltins", NULL, 0, false, GET_CODE(_sitebuiltins)},
+    {"genericpath", NULL, 0, false, GET_CODE(genericpath)},
+    {"ntpath", NULL, 0, false, GET_CODE(ntpath)},
+    {"posixpath", NULL, 0, false, GET_CODE(posixpath)},
+    {"os.path", NULL, 0, false, GET_CODE(ntpath)},
+    {"os", NULL, 0, false, GET_CODE(os)},
+    {"site", NULL, 0, false, GET_CODE(site)},
+    {"stat", NULL, 0, false, GET_CODE(stat)},
 
     /* runpy - run module with -m */
-    {"importlib.util", _Py_M__importlib_util, (int)sizeof(_Py_M__importlib_util), false, GET_CODE(importlib_util)},
-    {"importlib.machinery", _Py_M__importlib_machinery, (int)sizeof(_Py_M__importlib_machinery), false, GET_CODE(importlib_machinery)},
-    {"runpy", _Py_M__runpy, (int)sizeof(_Py_M__runpy), false, GET_CODE(runpy)},
+    {"importlib.util", NULL, 0, false, GET_CODE(importlib_util)},
+    {"importlib.machinery", NULL, 0, false, GET_CODE(importlib_machinery)},
+    {"runpy", NULL, 0, false, GET_CODE(runpy)},
     {0, 0, 0} /* stdlib sentinel */
 };
 static const struct _frozen test_modules[] = {
-    {"__hello__", _Py_M____hello__, (int)sizeof(_Py_M____hello__), false, GET_CODE(__hello__)},
-    {"__hello_alias__", _Py_M____hello__, (int)sizeof(_Py_M____hello__), false, GET_CODE(__hello__)},
-    {"__phello_alias__", _Py_M____hello__, (int)sizeof(_Py_M____hello__), true, GET_CODE(__hello__)},
-    {"__phello_alias__.spam", _Py_M____hello__, (int)sizeof(_Py_M____hello__), false, GET_CODE(__hello__)},
-    {"__phello__", _Py_M____phello__, (int)sizeof(_Py_M____phello__), true, GET_CODE(__phello__)},
-    {"__phello__.__init__", _Py_M____phello__, (int)sizeof(_Py_M____phello__), false, GET_CODE(__phello__)},
-    {"__phello__.ham", _Py_M____phello___ham, (int)sizeof(_Py_M____phello___ham), true, GET_CODE(__phello___ham)},
-    {"__phello__.ham.__init__", _Py_M____phello___ham, (int)sizeof(_Py_M____phello___ham), false, GET_CODE(__phello___ham)},
-    {"__phello__.ham.eggs", _Py_M____phello___ham_eggs, (int)sizeof(_Py_M____phello___ham_eggs), false, GET_CODE(__phello___ham_eggs)},
-    {"__phello__.spam", _Py_M____phello___spam, (int)sizeof(_Py_M____phello___spam), false, GET_CODE(__phello___spam)},
-    {"__hello_only__", _Py_M__frozen_only, (int)sizeof(_Py_M__frozen_only), false, GET_CODE(frozen_only)},
+    {"__hello__", NULL, 0, false, GET_CODE(__hello__)},
+    {"__hello_alias__", NULL, 0, false, GET_CODE(__hello__)},
+    {"__phello_alias__", NULL, 0, true, GET_CODE(__hello__)},
+    {"__phello_alias__.spam", NULL, 0, false, GET_CODE(__hello__)},
+    {"__phello__", NULL, 0, true, GET_CODE(__phello__)},
+    {"__phello__.__init__", NULL, 0, false, GET_CODE(__phello__)},
+    {"__phello__.ham", NULL, 0, true, GET_CODE(__phello___ham)},
+    {"__phello__.ham.__init__", NULL, 0, false, GET_CODE(__phello___ham)},
+    {"__phello__.ham.eggs", NULL, 0, false, GET_CODE(__phello___ham_eggs)},
+    {"__phello__.spam", NULL, 0, false, GET_CODE(__phello___spam)},
+    {"__hello_only__", NULL, 0, false, GET_CODE(frozen_only)},
     {0, 0, 0} /* test sentinel */
 };
 const struct _frozen *_PyImport_FrozenBootstrap = bootstrap_modules;
@@ -144,7 +366,8 @@ const struct _frozen *_PyImport_FrozenTest = test_modules;
 static const struct _module_alias aliases[] = {
     {"_frozen_importlib", "importlib._bootstrap"},
     {"_frozen_importlib_external", "importlib._bootstrap_external"},
-    {"os.path", "posixpath"},
+    {"encodings.__init__", "<encodings"},
+    {"os.path", "ntpath"},
     {"__hello_alias__", "__hello__"},
     {"__phello_alias__", "__hello__"},
     {"__phello_alias__.spam", "__hello__"},

--- a/Tools/build/freeze_modules.py
+++ b/Tools/build/freeze_modules.py
@@ -52,10 +52,7 @@ FROZEN = [
     ('stdlib - startup, without site (python -S)', [
         'abc',
         'codecs',
-        # For now we do not freeze the encodings, due # to the noise all
-        # those extra modules add to the text printed during the build.
-        # (See https://github.com/python/cpython/pull/28398#pullrequestreview-756856469.)
-        #'<encodings.*>',
+        '<encodings.*>',
         'io',
         ]),
     ('stdlib - startup, with site', [


### PR DESCRIPTION
## Summary

Optimize CPython 3.12 boot time on Nanvix microvm (Windows/WHP) from **1998ms to 172ms (p50)**.

## Changes

### Freeze encodings into binary
- Uncomment `<encodings.*>` in `Tools/build/freeze_modules.py` to freeze all encoding modules
- Eliminates ramfs I/O at startup (was ~50% of boot time)

### Reduce binary size (47MB -> 12MB)
- Remove unused static libraries: sqlite3, openssl, bzip2 from `Makefile.nanvix`
- Update `.nanvix/nanvix.toml` to drop corresponding dependencies

### Add cross-compilation sizeof cache
- Add 18 `ac_cv_sizeof_*` variables to `Makefile.nanvix` for proper cross-compilation

### VM snapshot support
- Add snapshot trigger after `Py_Initialize` in `Modules/main.c`
- Standalone assembly file `Modules/nanvix_snapshot.S` survives LTO elimination
- On first boot, creates VM snapshot; subsequent boots restore in ~35ms

## Performance

| Configuration | p50 | p95 |
|---|---|---|
| Baseline (47MB, ramfs) | 1998 ms | 5256 ms |
| Optimized cold (12MB, frozen) | 825 ms | 860 ms |
| **Snapshot restore** | **172 ms** | **193 ms** |

Companion PR: nanvix/nanvix (snapshot restore CLI flag)