### PR TITLE
build: remove unused static library dependencies (sqlite3, openssl, bzip2)

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -5,7 +5,4 @@ nanvix-version = "latest"
 
 [dependencies]
 zlib = "1.3.1"
-sqlite = "3.49.0"
-openssl = "3.5.0"
-bzip2 = "1.0.8"
 libffi = "3.4.6"

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -87,9 +87,6 @@ ifdef CONFIG_NANVIX
     LIBM := $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libm.a
     LIBPOSIX := $(DOCKER_SYSROOT_PATH)/lib/libposix.a
     LIBZ := $(DOCKER_SYSROOT_PATH)/lib/libz.a
-    LIBSQLITE3 := $(DOCKER_SYSROOT_PATH)/lib/libsqlite3.a
-    LIBSSL := $(DOCKER_SYSROOT_PATH)/lib/libssl.a
-    LIBCRYPTO := $(DOCKER_SYSROOT_PATH)/lib/libcrypto.a
     BUILD_PYTHON := $(DOCKER_TOOLCHAIN_PATH)/bin/python3
   else
     # Native toolchain paths
@@ -101,9 +98,6 @@ ifdef CONFIG_NANVIX
     LIBM := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a
     LIBPOSIX := $(abspath $(NANVIX_HOME))/lib/libposix.a
     LIBZ := $(abspath $(NANVIX_HOME))/lib/libz.a
-    LIBSQLITE3 := $(abspath $(NANVIX_HOME))/lib/libsqlite3.a
-    LIBSSL := $(abspath $(NANVIX_HOME))/lib/libssl.a
-    LIBCRYPTO := $(abspath $(NANVIX_HOME))/lib/libcrypto.a
     BUILD_PYTHON := $(NANVIX_TOOLCHAIN)/bin/python3
   endif
 
@@ -136,13 +130,9 @@ CONFIGURE_ENV = \
 	CFLAGS="-L$(SYSROOT_PATH)/lib -I$(SYSROOT_PATH)/include" \
 	CFLAGS_NODIST="-fno-semantic-interposition" \
 	LDFLAGS="-T$(SYSROOT_PATH)/lib/user.ld -Wl,--allow-multiple-definition -Wl,-pie -Wl,--export-dynamic -Wl,--no-dynamic-linker" \
-	LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) -lsqlite3 -lssl -lcrypto -lz -lbz2 -lffi -Wl,--end-group" \
-	LIBSQLITE3_LIBS="-L$(SYSROOT_PATH)/lib -lsqlite3" \
-	LIBSQLITE3_CFLAGS="-I$(SYSROOT_PATH)/include" \
+	LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) -lz -lffi -Wl,--end-group" \
 	ZLIB_LIBS="-L$(SYSROOT_PATH)/lib -lz" \
 	ZLIB_CFLAGS="-I$(SYSROOT_PATH)/include" \
-	BZIP2_LIBS="-L$(SYSROOT_PATH)/lib -lbz2" \
-	BZIP2_CFLAGS="-I$(SYSROOT_PATH)/include" \
 	LIBFFI_LIBS="-L$(SYSROOT_PATH)/lib -lffi" \
 	LIBFFI_CFLAGS="-I$(SYSROOT_PATH)/include"
 
@@ -160,7 +150,6 @@ CONFIGURE_OPTS = \
 	--exec-prefix="$(INSTALL_PREFIX)" \
 	--with-ensurepip=no \
 	--with-pkg-config=no \
-	--with-openssl="$(SYSROOT_PATH)" \
 	--disable-ipv6 \
 	ac_cv_file__dev_ptmx=no \
 	ac_cv_file__dev_ptc=no \


### PR DESCRIPTION
## Summary

Drop sqlite3, openssl, and bzip2 from the Nanvix cross-compilation build. These libraries are unused at runtime and removing them shrinks the final binary significantly (47 MB → ~12 MB).

## Changes

- `.nanvix/nanvix.toml`: Remove `sqlite`, `openssl`, `bzip2` from `[dependencies]`
- `Makefile.nanvix`:
  - Remove `-lsqlite3 -lssl -lcrypto -lbz2` from `LIBS`
  - Remove `LIBSQLITE3_*`, `BZIP2_*`, `LIBSSL`, `LIBCRYPTO` variable definitions
  - Remove `--with-openssl` from `CONFIGURE_OPTS`

Split from #314.