### PR TITLE
build: add cross-compilation sizeof cache for Nanvix i686 target

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -168,7 +168,25 @@ CONFIGURE_OPTS = \
 	ac_cv_pthread=yes \
 	ac_cv_kthread=no \
 	ac_cv_func_dlopen=yes \
-	ac_cv_header_dlfcn_h=yes
+	ac_cv_header_dlfcn_h=yes \
+	ac_cv_sizeof_double=8 \
+	ac_cv_sizeof_float=4 \
+	ac_cv_sizeof_fpos_t=4 \
+	ac_cv_sizeof_int=4 \
+	ac_cv_sizeof_long=4 \
+	ac_cv_sizeof_long_double=12 \
+	ac_cv_sizeof_long_long=8 \
+	ac_cv_sizeof_off_t=8 \
+	ac_cv_sizeof_pid_t=4 \
+	ac_cv_sizeof_pthread_key_t=4 \
+	ac_cv_sizeof_pthread_t=4 \
+	ac_cv_sizeof_short=2 \
+	ac_cv_sizeof_size_t=4 \
+	ac_cv_sizeof_time_t=8 \
+	ac_cv_sizeof_uintptr_t=4 \
+	ac_cv_sizeof_void_p=4 \
+	ac_cv_sizeof_wchar_t=4 \
+	ac_cv_sizeof__bool=1
 
 # Marker file to track if configure has been run
 CONFIGURED_MARKER = .nanvix-configured


### PR DESCRIPTION
## Summary

Add 18 `ac_cv_sizeof_*` variables to `CONFIGURE_OPTS` in `Makefile.nanvix` so that `./configure` does not attempt to run sizeof test programs on the build host during cross-compilation. Values are for the i686-nanvix target (ILP32).

## Changes

- `Makefile.nanvix`: Add `ac_cv_sizeof_double=8` through `ac_cv_sizeof__bool=1` (18 variables) to `CONFIGURE_OPTS`

Split from #314.