### PR TITLE
[build] Freeze startup encoding modules into CPython binary

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1108,6 +1108,11 @@ FROZEN_FILES_IN = \
 		Lib/zipimport.py \
 		Lib/abc.py \
 		Lib/codecs.py \
+		Lib/encodings/__init__.py \
+		Lib/encodings/aliases.py \
+		Lib/encodings/ascii.py \
+		Lib/encodings/latin_1.py \
+		Lib/encodings/utf_8.py \
 		Lib/io.py \
 		Lib/_collections_abc.py \
 		Lib/_sitebuiltins.py \
@@ -1133,6 +1138,11 @@ FROZEN_FILES_OUT = \
 		Python/frozen_modules/zipimport.h \
 		Python/frozen_modules/abc.h \
 		Python/frozen_modules/codecs.h \
+		Python/frozen_modules/encodings.h \
+		Python/frozen_modules/encodings.aliases.h \
+		Python/frozen_modules/encodings.ascii.h \
+		Python/frozen_modules/encodings.latin_1.h \
+		Python/frozen_modules/encodings.utf_8.h \
 		Python/frozen_modules/io.h \
 		Python/frozen_modules/_collections_abc.h \
 		Python/frozen_modules/_sitebuiltins.h \
@@ -1180,6 +1190,21 @@ Python/frozen_modules/abc.h: Lib/abc.py $(FREEZE_MODULE_DEPS)
 
 Python/frozen_modules/codecs.h: Lib/codecs.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) codecs $(srcdir)/Lib/codecs.py Python/frozen_modules/codecs.h
+
+Python/frozen_modules/encodings.h: Lib/encodings/__init__.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings $(srcdir)/Lib/encodings/__init__.py Python/frozen_modules/encodings.h
+
+Python/frozen_modules/encodings.aliases.h: Lib/encodings/aliases.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.aliases $(srcdir)/Lib/encodings/aliases.py Python/frozen_modules/encodings.aliases.h
+
+Python/frozen_modules/encodings.ascii.h: Lib/encodings/ascii.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.ascii $(srcdir)/Lib/encodings/ascii.py Python/frozen_modules/encodings.ascii.h
+
+Python/frozen_modules/encodings.latin_1.h: Lib/encodings/latin_1.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.latin_1 $(srcdir)/Lib/encodings/latin_1.py Python/frozen_modules/encodings.latin_1.h
+
+Python/frozen_modules/encodings.utf_8.h: Lib/encodings/utf_8.py $(FREEZE_MODULE_DEPS)
+	$(FREEZE_MODULE) encodings.utf_8 $(srcdir)/Lib/encodings/utf_8.py Python/frozen_modules/encodings.utf_8.h
 
 Python/frozen_modules/io.h: Lib/io.py $(FREEZE_MODULE_DEPS)
 	$(FREEZE_MODULE) io $(srcdir)/Lib/io.py Python/frozen_modules/io.h
@@ -1260,6 +1285,11 @@ $(DEEPFREEZE_C): $(DEEPFREEZE_DEPS)
 	Python/frozen_modules/zipimport.h:zipimport \
 	Python/frozen_modules/abc.h:abc \
 	Python/frozen_modules/codecs.h:codecs \
+	Python/frozen_modules/encodings.h:encodings \
+	Python/frozen_modules/encodings.aliases.h:encodings.aliases \
+	Python/frozen_modules/encodings.ascii.h:encodings.ascii \
+	Python/frozen_modules/encodings.latin_1.h:encodings.latin_1 \
+	Python/frozen_modules/encodings.utf_8.h:encodings.utf_8 \
 	Python/frozen_modules/io.h:io \
 	Python/frozen_modules/_collections_abc.h:_collections_abc \
 	Python/frozen_modules/_sitebuiltins.h:_sitebuiltins \

--- a/PCbuild/_freeze_module.vcxproj
+++ b/PCbuild/_freeze_module.vcxproj
@@ -271,6 +271,31 @@
       <IntFile>$(IntDir)codecs.g.h</IntFile>
       <OutFile>$(PySourcePath)Python\frozen_modules\codecs.h</OutFile>
     </None>
+    <None Include="..\Lib\encodings\__init__.py">
+      <ModName>encodings</ModName>
+      <IntFile>$(IntDir)encodings.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\aliases.py">
+      <ModName>encodings.aliases</ModName>
+      <IntFile>$(IntDir)encodings.aliases.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.aliases.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\ascii.py">
+      <ModName>encodings.ascii</ModName>
+      <IntFile>$(IntDir)encodings.ascii.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.ascii.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\latin_1.py">
+      <ModName>encodings.latin_1</ModName>
+      <IntFile>$(IntDir)encodings.latin_1.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.latin_1.h</OutFile>
+    </None>
+    <None Include="..\Lib\encodings\utf_8.py">
+      <ModName>encodings.utf_8</ModName>
+      <IntFile>$(IntDir)encodings.utf_8.g.h</IntFile>
+      <OutFile>$(PySourcePath)Python\frozen_modules\encodings.utf_8.h</OutFile>
+    </None>
     <None Include="..\Lib\io.py">
       <ModName>io</ModName>
       <IntFile>$(IntDir)io.g.h</IntFile>
@@ -409,6 +434,11 @@
 		 "$(PySourcePath)Python\frozen_modules\zipimport.h:zipimport" ^
 		 "$(PySourcePath)Python\frozen_modules\abc.h:abc" ^
 		 "$(PySourcePath)Python\frozen_modules\codecs.h:codecs" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.h:encodings" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.aliases.h:encodings.aliases" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.ascii.h:encodings.ascii" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.latin_1.h:encodings.latin_1" ^
+		 "$(PySourcePath)Python\frozen_modules\encodings.utf_8.h:encodings.utf_8" ^
 		 "$(PySourcePath)Python\frozen_modules\io.h:io" ^
 		 "$(PySourcePath)Python\frozen_modules\_collections_abc.h:_collections_abc" ^
 		 "$(PySourcePath)Python\frozen_modules\_sitebuiltins.h:_sitebuiltins" ^

--- a/PCbuild/_freeze_module.vcxproj.filters
+++ b/PCbuild/_freeze_module.vcxproj.filters
@@ -444,6 +444,21 @@
     <None Include="..\Lib\codecs.py">
       <Filter>Python Files</Filter>
     </None>
+    <None Include="..\Lib\encodings\__init__.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\aliases.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\ascii.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\latin_1.py">
+      <Filter>Python Files</Filter>
+    </None>
+    <None Include="..\Lib\encodings\utf_8.py">
+      <Filter>Python Files</Filter>
+    </None>
     <None Include="..\Lib\io.py">
       <Filter>Python Files</Filter>
     </None>

--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -46,6 +46,11 @@
 #include "frozen_modules/zipimport.h"
 #include "frozen_modules/abc.h"
 #include "frozen_modules/codecs.h"
+#include "frozen_modules/encodings.h"
+#include "frozen_modules/encodings.aliases.h"
+#include "frozen_modules/encodings.ascii.h"
+#include "frozen_modules/encodings.latin_1.h"
+#include "frozen_modules/encodings.utf_8.h"
 #include "frozen_modules/io.h"
 #include "frozen_modules/_collections_abc.h"
 #include "frozen_modules/_sitebuiltins.h"
@@ -74,6 +79,11 @@ extern PyObject *_Py_get_importlib__bootstrap_external_toplevel(void);
 extern PyObject *_Py_get_zipimport_toplevel(void);
 extern PyObject *_Py_get_abc_toplevel(void);
 extern PyObject *_Py_get_codecs_toplevel(void);
+extern PyObject *_Py_get_encodings_toplevel(void);
+extern PyObject *_Py_get_encodings_aliases_toplevel(void);
+extern PyObject *_Py_get_encodings_ascii_toplevel(void);
+extern PyObject *_Py_get_encodings_latin_1_toplevel(void);
+extern PyObject *_Py_get_encodings_utf_8_toplevel(void);
 extern PyObject *_Py_get_io_toplevel(void);
 extern PyObject *_Py_get__collections_abc_toplevel(void);
 extern PyObject *_Py_get__sitebuiltins_toplevel(void);
@@ -104,6 +114,11 @@ static const struct _frozen stdlib_modules[] = {
     /* stdlib - startup, without site (python -S) */
     {"abc", _Py_M__abc, (int)sizeof(_Py_M__abc), false, GET_CODE(abc)},
     {"codecs", _Py_M__codecs, (int)sizeof(_Py_M__codecs), false, GET_CODE(codecs)},
+    {"encodings", _Py_M__encodings, (int)sizeof(_Py_M__encodings), true, GET_CODE(encodings)},
+    {"encodings.aliases", _Py_M__encodings_aliases, (int)sizeof(_Py_M__encodings_aliases), false, GET_CODE(encodings_aliases)},
+    {"encodings.ascii", _Py_M__encodings_ascii, (int)sizeof(_Py_M__encodings_ascii), false, GET_CODE(encodings_ascii)},
+    {"encodings.latin_1", _Py_M__encodings_latin_1, (int)sizeof(_Py_M__encodings_latin_1), false, GET_CODE(encodings_latin_1)},
+    {"encodings.utf_8", _Py_M__encodings_utf_8, (int)sizeof(_Py_M__encodings_utf_8), false, GET_CODE(encodings_utf_8)},
     {"io", _Py_M__io, (int)sizeof(_Py_M__io), false, GET_CODE(io)},
 
     /* stdlib - startup, with site */

--- a/Tools/build/freeze_modules.py
+++ b/Tools/build/freeze_modules.py
@@ -52,10 +52,14 @@ FROZEN = [
     ('stdlib - startup, without site (python -S)', [
         'abc',
         'codecs',
-        # For now we do not freeze the encodings, due # to the noise all
-        # those extra modules add to the text printed during the build.
-        # (See https://github.com/python/cpython/pull/28398#pullrequestreview-756856469.)
-        #'<encodings.*>',
+        # Freeze the encodings package and the codecs imported during every
+        # interpreter start-up. This eliminates filesystem I/O that is
+        # prohibitively slow on Nanvix ramfs/microvm.
+        '<encodings>',
+        'encodings.aliases',
+        'encodings.ascii',
+        'encodings.latin_1',
+        'encodings.utf_8',
         'io',
         ]),
     ('stdlib - startup, with site', [


### PR DESCRIPTION
## Summary

Freeze the five encoding modules imported during every interpreter startup into
the CPython binary, eliminating filesystem I/O that is prohibitively slow on
Nanvix ramfs/microvm.

## Motivation

During CPython startup, 25 modules are imported.  Prior to this change, 20 were
frozen/builtin but the encodings package and its codecs required filesystem reads
from ramfs.  On Nanvix each file open/read/close involves VM exits, adding
measurable latency to startup.

## Changes

- `Tools/build/freeze_modules.py`: Add encodings package + 4 codec modules to FROZEN list
- `Python/frozen.c`: Auto-regenerated with 5 new frozen module entries
- `Makefile.pre.in`: Auto-regenerated with freeze targets for encoding modules
- `PCbuild/_freeze_module.vcxproj{,.filters}`: Auto-regenerated for Windows builds

## Design Decision

Only the 5 startup-critical codecs are frozen (not all ~100 encoding modules):
`encodings`, `encodings.aliases`, `encodings.ascii`, `encodings.latin_1`, and
`encodings.utf_8`.  Binary growth is ~92 KB.

## Benchmark

Platform: microvm/standalone, 128 MB, Nanvix v0.12.364
Method: 20 A/B interleaved pairs on WSL2 (i9-12900H, KVM)

| Metric | Baseline | Frozen | Delta |
|--------|----------|--------|-------|
| **Mean** | 79.8 ms | 78.0 ms | **-1.8 ms (2.3%)** |
| **Median** | 79.0 ms | 70.5 ms | **-8.5 ms (10.8%)** |
| P10 | 64 ms | 58 ms | -6 ms |
| P90 | 109 ms | 119 ms | +10 ms |
| Binary size | 15.8 MB | 15.9 MB | **+92 KB** |
| Frozen wins | - | - | **13/20 pairs** |

The improvement is modest on a fast KVM host (~80 ms total startup).
On production Nanvix deployments with higher VM-exit latency the saving
scales proportionally.

Supersedes the earlier revision of #317 which included pre-compiled .h
headers in the commit.  This version relies on the build system to
generate them, matching upstream CPython conventions.