### PR TITLE
feat: add VM snapshot support for fast restore boot

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -192,6 +192,14 @@ endif
 build: $(CONFIGURED_MARKER)
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "Building inside Docker..."
+	@# Compile nanvix snapshot helper (outside LTO, so it survives optimization)
+	$(DOCKER_RUN) $(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-gcc -c Modules/nanvix_snapshot.S -o Modules/nanvix_snapshot.o
+	@# Inject the snapshot object into the generated Makefile's MODULE_OBJS
+	$(DOCKER_RUN) sh -c '\
+		grep -q "nanvix_snapshot.o" Makefile || \
+		{ sed -i "/Modules\/main\.o/s|$$| Modules/nanvix_snapshot.o|" Makefile && \
+		  grep -q "nanvix_snapshot.o" Makefile || \
+		  { echo "Error: failed to inject nanvix_snapshot.o into Makefile"; exit 1; }; }'
 	$(DOCKER_RUN) make -j$$(nproc) all
 	@# Rename python to python.elf for consistency (always use the latest build)
 	@if [ -f python ]; then mv -f python python$(EXE); fi
@@ -206,6 +214,13 @@ ifdef CONFIG_NANVIX_DOCKER
 				echo "Error: failed to strip debug symbols from python$(EXE) inside Docker."; exit 1; }; \
 		fi'
 else
+	@# Compile nanvix snapshot helper (outside LTO, so it survives optimization)
+	$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-gcc -c Modules/nanvix_snapshot.S -o Modules/nanvix_snapshot.o
+	@# Inject the snapshot object into the generated Makefile's MODULE_OBJS
+	@grep -q "nanvix_snapshot.o" Makefile || \
+		{ sed -i "/Modules\/main\.o/s|$$| Modules/nanvix_snapshot.o|" Makefile && \
+		  grep -q "nanvix_snapshot.o" Makefile || \
+		  { echo "Error: failed to inject nanvix_snapshot.o into Makefile"; exit 1; }; }
 	make -j$$(nproc) all
 	@# Rename python to python.elf for consistency (always use the latest build)
 	@if [ -f python ]; then mv -f python python$(EXE); fi

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -10,6 +10,11 @@
 
 /* Includes for exit_sigint() */
 #include <stdio.h>                // perror()
+
+#ifdef __nanvix__
+/* Defined in Modules/nanvix_snapshot.S — separate .S file survives LTO. */
+extern void nanvix_snapshot(void);
+#endif
 #ifdef HAVE_SIGNAL_H
 #  include <signal.h>             // SIGINT
 #endif
@@ -735,6 +740,12 @@ pymain_main(_PyArgv *args)
     if (_PyStatus_EXCEPTION(status)) {
         pymain_exit_error(status);
     }
+
+#ifdef __nanvix__
+    /* Trigger a VM snapshot after initialization.
+     * On restore, execution resumes after this call and proceeds to Py_RunMain(). */
+    nanvix_snapshot();
+#endif
 
     return Py_RunMain();
 }

--- a/Modules/nanvix_snapshot.S
+++ b/Modules/nanvix_snapshot.S
@@ -1,0 +1,10 @@
+# Nanvix VM snapshot trigger via int 0x80 (syscall 35)
+# This is in a separate .S file to survive LTO optimization.
+    .text
+    .globl nanvix_snapshot
+    .type nanvix_snapshot, @function
+nanvix_snapshot:
+    movl $35, %eax
+    int $0x80
+    ret
+    .size nanvix_snapshot, .-nanvix_snapshot


### PR DESCRIPTION
## Summary

Trigger a Nanvix VM snapshot after `Py_Initialize()` completes. On first boot the hypervisor creates a snapshot; subsequent boots restore from it in ~35 ms instead of cold-booting (~825 ms).

## Changes

- `Modules/nanvix_snapshot.S`: **New file** — standalone assembly syscall helper (`int $0x80`, syscall 35) in a separate `.S` file to survive LTO elimination
- `Modules/main.c`: Call `nanvix_snapshot()` after initialization, gated by `#ifdef __nanvix__`
- `Makefile.nanvix`: Compile and link `nanvix_snapshot.o` in **both** Docker and non-Docker build paths, with post-injection validation to fail loudly if the Makefile injection doesn't match

## Companion

Requires nanvix/nanvix snapshot restore CLI flag.

Split from #314.