### PR TITLE
feat/cpython test infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,10 +160,5 @@ Python/frozen_modules/MANIFEST
 .z.cache
 
 # Nanvix build state (keep .nanvix/z.py tracked)
-.nanvix/venv/
-.nanvix/cache/
-.nanvix/sysroot/
-.nanvix/buildroot/
-.nanvix/env.json
-.nanvix/nanvix.lock
 python.elf
+.nanvix-configured

--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -1,0 +1,6 @@
+venv/
+cache/
+sysroot/
+buildroot/
+env.json
+nanvix.lock

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,6 +11,7 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
+import os
 import shutil
 from pathlib import Path
 
@@ -24,6 +25,7 @@ _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 _MAKE_VAR_INSTALL_PREFIX = "INSTALL_PREFIX"
+_MAKE_VAR_RELEASE = "NANVIX_RELEASE"
 
 # CPython embeds --prefix into the binary (sys.prefix, sys.path).
 # Use /sysroot so that release tarballs don't contain ephemeral runner paths.
@@ -63,6 +65,9 @@ class CPythonBuild(ZScript):
 
         if with_install_prefix:
             args.append(f"{_MAKE_VAR_INSTALL_PREFIX}={_DEFAULT_INSTALL_PREFIX}")
+
+        release = os.environ.get(_MAKE_VAR_RELEASE, "no")
+        args.append(f"{_MAKE_VAR_RELEASE}={release}")
 
         args.extend(targets)
         return args
@@ -112,7 +117,12 @@ class CPythonBuild(ZScript):
         self.run(*self._make_args(*targets), cwd=self.repo_root)
 
     def release(self) -> None:
-        """Package the CPython release tarballs and verify them."""
+        """Package the CPython release tarballs and verify them.
+
+        Release builds always set NANVIX_RELEASE=yes to strip C test extension
+        modules and skip regrtest, producing a trimmed production artifact.
+        """
+        os.environ[_MAKE_VAR_RELEASE] = "yes"
         self.run(*self._make_args("package"), cwd=self.repo_root)
         self.run(*self._make_args("verify-package"), cwd=self.repo_root)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
     "check_disallow_instantiation", "check_sanitizer", "skip_if_sanitizer",
     "requires_limited_api", "requires_specialization",
     # sys
-    "MS_WINDOWS", "is_jython", "is_android", "is_emscripten", "is_wasi",
+    "MS_WINDOWS", "is_jython", "is_android", "is_emscripten", "is_wasi", "is_nanvix",
     "check_impl_detail", "unix_shell", "setswitchinterval",
     # os
     "get_pagesize",
@@ -535,24 +535,27 @@ if sys.platform not in ('win32', 'vxworks'):
 else:
     unix_shell = None
 
-# wasm32-emscripten and -wasi are POSIX-like but do not
+# wasm32-emscripten, -wasi, and nanvix are POSIX-like but do not
 # have subprocess or fork support.
 is_emscripten = sys.platform == "emscripten"
 is_wasi = sys.platform == "wasi"
+is_nanvix = sys.platform == "nanvix"
 
-has_fork_support = hasattr(os, "fork") and not is_emscripten and not is_wasi
+# TODO: enable fork support once nanvix implements it
+# (https://github.com/nanvix/nanvix/issues/321)
+has_fork_support = hasattr(os, "fork") and not is_emscripten and not is_wasi and not is_nanvix
 
 def requires_fork():
     return unittest.skipUnless(has_fork_support, "requires working os.fork()")
 
-has_subprocess_support = not is_emscripten and not is_wasi
+has_subprocess_support = not is_emscripten and not is_wasi and not is_nanvix
 
 def requires_subprocess():
     """Used for subprocess, os.spawn calls, fd inheritance"""
     return unittest.skipUnless(has_subprocess_support, "requires subprocess support")
 
 # Emscripten's socket emulation and WASI sockets have limitations.
-has_socket_support = not is_emscripten and not is_wasi
+has_socket_support = not is_emscripten and not is_wasi and not is_nanvix
 
 def requires_working_socket(*, module=False):
     """Skip tests or modules that require working sockets

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -430,7 +430,13 @@ else:
                 else:
                     _force_run(path, os.unlink, fullname)
         _rmtree_inner(path)
-        os.rmdir(path)
+        # Nanvix does not implement rmdir (returns ENOSYS). Cleanup code
+        # should never crash the test run, so swallow all OSError here.
+        # https://github.com/nanvix/nanvix/issues/348
+        try:
+            os.rmdir(path)
+        except OSError:
+            pass
 
     def _longpath(path):
         return path
@@ -440,6 +446,11 @@ def rmdir(dirname):
     try:
         _rmdir(dirname)
     except FileNotFoundError:
+        pass
+    except OSError:
+        # Nanvix does not implement rmdir (returns ENOSYS). Cleanup code
+        # should never crash the test run, so swallow all OSError here.
+        # https://github.com/nanvix/nanvix/issues/348
         pass
 
 

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -25,6 +25,26 @@ PLATFORM ?= hyperlight
 PROCESS_MODE ?= multi-process
 MEMORY_SIZE ?= 128mb
 
+# Set to 'yes' for release packaging: disables C test extension modules and
+# skips regrtest.  Dev builds (the default) compile test extensions and run
+# regrtest so that every `./z test` invocation exercises the test suite.
+# NOTE: changing this between builds requires 'make -f Makefile.nanvix distclean'
+# followed by a full rebuild so the new configure flags are picked up.
+NANVIX_RELEASE ?= no
+
+# Space-separated list of stdlib test modules to run via 'python3 -m test'.
+# Keep this list to pure-Python, non-networking tests known to pass on Nanvix.
+# Expand it as more tests are enabled (see issues linked from #320).
+#
+# Trimmed to validated-green modules only. The remaining modules fail due to
+# missing platform capabilities (fork/exec, tempdir, asyncio event loop) or
+# memory limits (test_json MemoryError). Those belong to #321 and #322 where
+# each module gets individual skip/xfail annotations before being re-added.
+#   Deferred: test_builtin test_dict test_list test_str test_tuple test_set
+#             test_bytes test_int test_json test_datetime test_os test_pathlib
+#             test_io
+NANVIX_TEST_LIST ?= test_float test_complex test_bool test_struct
+
 # Nanvix cross-compilation configuration
 ifdef CONFIG_NANVIX
   NANVIX_TOOLCHAIN ?= /opt/nanvix
@@ -153,7 +173,7 @@ CONFIGURE_OPTS = \
 	--build=x86_64-pc-linux-gnux32 \
 	--host=i686-nanvix \
 	--with-build-python="$(BUILD_PYTHON)" \
-	--disable-test-modules \
+	$(if $(filter yes,$(NANVIX_RELEASE)),--disable-test-modules,) \
 	--with-libc="$(LIBC)" \
 	--with-libm="$(LIBM)" \
 	--prefix="$(INSTALL_PREFIX)" \
@@ -257,6 +277,7 @@ ifeq ($(PROCESS_MODE),standalone)
 	@rm -rf $(TEST_STAGING)/sysroot/lib/python3.12/venv
 	@rm -rf $(TEST_STAGING)/sysroot/lib/python3.12/site-packages
 	@rm -rf $(TEST_STAGING)/sysroot/lib/python3.12/__phello__
+	@rm -rf $(TEST_STAGING)/sysroot/lib/python3.12/test
 	@rm -f $(TEST_STAGING)/sysroot/lib/libpython3.12.a
 	@rm -rf $(TEST_STAGING)/sysroot/include
 	@rm -rf $(TEST_STAGING)/sysroot/share
@@ -322,7 +343,28 @@ else
 			fi; \
 		}
 endif
-	@rm -rf $(TEST_STAGING) /tmp/cpython_test.log
+ifneq ($(NANVIX_RELEASE),yes)
+	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
+ifeq ($(PROCESS_MODE),standalone)
+	@echo "  SKIP: regrtest skipped for standalone mode (ramfs memory limit)"
+else
+	cd $(TEST_STAGING)/sysroot && \
+		{ \
+			: > /tmp/cpython_regrtest.log; \
+			timeout 600 ./bin/nanvixd.elf -- ./bin/python3.12 -m test \
+			  --timeout=120 $(NANVIX_TEST_LIST) \
+			  < /dev/null > /tmp/cpython_regrtest.log 2>&1; \
+			regrtest_status=$$?; \
+			if [ $$regrtest_status -ne 0 ]; then \
+				echo "  FAIL: regrtest exited with status $$regrtest_status"; cat /tmp/cpython_regrtest.log; exit 1; \
+			fi; \
+			echo "  PASS: regrtest completed"; \
+		}
+endif
+else
+	@echo "Test: regrtest skipped (NANVIX_RELEASE=yes)"
+endif
+	@rm -rf $(TEST_STAGING) /tmp/cpython_test.log /tmp/cpython_regrtest.log
 	@echo "		*** CPython tests PASSED ***"
 
 # Clean target


### PR DESCRIPTION
Closes #320. Enables CPython test infrastructure for Nanvix.

### `Lib/test/support/__init__.py`
- Adds `is_nanvix = sys.platform == "nanvix"` alongside the existing `is_wasi`/`is_emscripten` sentinels, and exports it in `__all__`
- Gates `has_fork_support`, `has_subprocess_support`, and `has_socket_support` on `not is_nanvix` — Nanvix doesn't support fork/exec, so tests decorated with `@requires_fork`, `@requires_subprocess`, or `@requires_working_socket` are now skipped instead of hanging or erroring

### `Makefile.nanvix` — `NANVIX_RELEASE` opt-out
- Adds `NANVIX_RELEASE ?= no` to control the `--disable-test-modules` configure flag; when set to `yes` (release mode), C test extension modules are excluded and regrtest is skipped
- Default is `no` (dev mode) — test modules are compiled and regrtest runs on every `./z test`
- Changing the value requires `make distclean` + full rebuild since configure results are cached

### `Makefile.nanvix` — regrtest phase in `make test`
- Adds `NANVIX_TEST_LIST` with 4 validated pure-Python stdlib test modules (`test_float`, `test_complex`, `test_bool`, `test_struct`)
- In dev mode, `make test` invokes `python3 -m test` (regrtest) after the hello-world smoke test
- Runs sequentially (no `-j` flag) since Nanvix doesn't support fork/exec for worker subprocesses

### `z.sh` / `z.ps1` — bootstrapper rewrite
- Rewrites bootstrapping to prefer local `.nanvix/venv/` editable install over system-wide `nanvix-zutil`
- Adds broken-venv recovery and global version capture for comparison

### `.nanvix/z.py` — env var forwarding
- Forwards `NANVIX_RELEASE` from environment to `Makefile.nanvix` via make arguments

---

## Design decisions

### Sequential regrtest: omit `-j` entirely (not `-j1`, not `-j0`)

Nanvix doesn't support `fork()`/`exec()`. regrtest's `-j` flag always spawns worker subprocesses — even `-j1` uses `_fork_exec` for one worker, and `-j0` auto-detects CPU count. The only way to get in-process sequential execution is to omit `-j` entirely, selecting `run_tests_sequentially()`. This matches how WASI/Emscripten handle the same constraint.

Additional hazards documented: `--rerun`/`-w` forces `num_workers=1` for re-runs (subprocess), and `Tools/scripts/run_tests.py` injects `-j0` or `-j2` when no `-j` is present. Neither is hit by our Makefile invocations.

### `NANVIX_RELEASE` opt-out vs `NANVIX_TEST_MODULES` opt-in

Originally `NANVIX_TEST_MODULES=yes` enabled tests. This meant dev builds skipped regrtest by default. We inverted to `NANVIX_RELEASE=yes` so dev builds always exercise the test suite, making regressions visible immediately. The `package` target already strips test directories from release artifacts (lines 461-462 of Makefile.nanvix), so the flag just avoids compiling C test extensions unnecessarily.

### Test list trimmed to 4 validated modules

Of ~17 candidates, only `test_float`, `test_complex`, `test_bool`, `test_struct` pass on Nanvix. Others fail due to fork/exec requirements, temp directory creation, asyncio event loops, or memory limits (128MB). Deferred to #321 and #322.

### Bootstrapper venv-first priority

The old `z.sh` checked `command -v nanvix-zutil` first, picking up stale system-wide installs over the local `.nanvix/venv/` editable install. Fixed with a venv-first priority order.

## Future work (deferred)

1. **zutils `--release` CLI flag** — Replace env var with `./z build --release`. Requires `nanvix/zutils` changes.
2. **CI dev/release split** — Separate dev job (build + test) from release job (`NANVIX_RELEASE=yes`). Requires `nanvix/workflows` changes.
3. **regrtest defense-in-depth** — Guard in `libregrtest/main.py` that falls back to sequential when `has_subprocess_support == False`. Would benefit WASI/Emscripten too.
4. **`_PYTHON_HOSTRUNNER` safety** — Verify these env vars are never set in Nanvix builds; `libregrtest` forcibly adds `-j 2` when a hostrunner is detected.