### PR TITLE
[ci] E: Update zutil-version to v0.5.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.2.0
     with:
-      zutil-version: "v0.4.2"
+      zutil-version: "v0.5.0"
       platforms: '["microvm"]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}


### PR DESCRIPTION
Automated bump of `zutil-version` to [`v0.5.0`](https://github.com/nanvix/zutils/releases/tag/v0.5.0).

Generated by the [Update Zutils Version](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.