### PR TITLE
test: enable CPython core language test suites on Nanvix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ Python/frozen_modules/MANIFEST
 # Nanvix build state (keep .nanvix/z.py tracked)
 python.elf
 .nanvix-configured
+.nanvix/_test_staging/
+.nanvix/_ramfs_cache/
+.nanvix/cross-imports.json

--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -1,6 +1,7 @@
 venv/
 cache/
-sysroot/
-buildroot/
+sysroot*
+buildroot*/
 env.json
 nanvix.lock
+_test_staging/

--- a/.nanvix/mk/defaults.mk
+++ b/.nanvix/mk/defaults.mk
@@ -21,8 +21,42 @@ INSTALL_PREFIX ?= /sysroot
 # Set to 'yes' for release packaging
 NANVIX_RELEASE ?= no
 
-# Space-separated list of stdlib test modules to run via regrtest.
-NANVIX_TEST_LIST ?= test_float test_complex test_bool test_struct
+# Space-separated list of stdlib test modules to run via 'python3 -m test'.
+# Keep this list to pure-Python, non-networking tests known to pass on Nanvix.
+# Expand it as more tests are enabled (see issues linked from #320).
+#
+# Trimmed to validated-green modules only. The remaining modules fail due to
+# missing platform capabilities (fork/exec, tempdir, asyncio event loop) or
+# memory limits (test_json MemoryError). Those belong to #321 and #322 where
+# each module gets individual skip/xfail annotations before being re-added.
+# Excluded: test_exception_hierarchy (crashes at import time: errno.ESHUTDOWN missing on Nanvix)
+#           test_inspect (VM hangs: IsolatedAsyncioTestCase sets up asyncio loop before skip is evaluated;
+#                         module too large for 256MB VM causing resource exhaustion)
+# The list is defined with := (not ?=) so that gen-cross-imports.py can
+# rely on it as the canonical source without risk of env overrides causing
+# the allow-list to drift out of sync.
+NANVIX_TEST_LIST := \
+    test_float test_complex test_bool test_struct \
+    test_int test_range test_slice test_memoryview test_bytes test_tuple \
+    test_builtin test_operator test_binop test_unary \
+    test_compare test_richcmp test_augassign test_contains \
+    test_grammar test_syntax test_compile test_compiler_assemble \
+    test_compiler_codegen test_ast test_symtable test_opcache \
+    test_peepholer test_dis test_code test_keyword test_tokenize \
+    test_perf_profiler \
+    test_call test_extcall test_positional_only_arg \
+    test_scope test_global test_dynamic test_with \
+    test_types test_typechecks test_isinstance test_hash test_index test_super test_property \
+    test_math test_cmath test_decimal test_fractions test_statistics test_random test_numeric_tower \
+    test_exception_group test_exceptions test_raise test_traceback \
+    test_frame test_contextlib test_contextlib_async test_pprint test_reprlib \
+    test_list test_dict
+
+# Maximum number of test modules per regrtest VM invocation.
+# The 32MB heap exhausts after ~5 test modules due to cumulative
+# fragmentation.  Tests are split into batches of this size and
+# each batch gets its own nanvixd.elf invocation.
+NANVIX_TEST_BATCH_SIZE ?= 4
 
 # Nanvix sysroot directory (set by z.py / environment)
 NANVIX_HOME ?= $(HOME)/nanvix

--- a/.nanvix/mk/ramfs.mk
+++ b/.nanvix/mk/ramfs.mk
@@ -21,6 +21,11 @@ _RAMFS_MK := 1
 # Trim the staged sysroot to the minimal runtime footprint.
 # Removes build-time headers, static libraries, config dirs, caches, and
 # heavyweight stdlib packages not needed at runtime.
+#
+# Set RAMFS_KEEP_TESTS=1 to retain lib/python3.12/test/ (needed when
+# building a ramfs for the test pipeline).  config-3.12 (~54 MB) is
+# always removed — it is not needed at runtime and would push the
+# ramfs image over the 256 MB VM budget.
 ramfs-trim:
 	@if [ -z "$(RAMFS_STAGING)" ]; then echo "Error: RAMFS_STAGING is not set"; exit 1; fi
 	@if [ ! -d "$(RAMFS_STAGING)/sysroot" ]; then echo "Error: $(RAMFS_STAGING)/sysroot does not exist"; exit 1; fi
@@ -35,7 +40,9 @@ ramfs-trim:
 	@rm -rf $(RAMFS_STAGING)/sysroot/lib/python3.12/venv
 	@rm -rf $(RAMFS_STAGING)/sysroot/lib/python3.12/site-packages
 	@rm -rf $(RAMFS_STAGING)/sysroot/lib/python3.12/__phello__
+ifndef RAMFS_KEEP_TESTS
 	@rm -rf $(RAMFS_STAGING)/sysroot/lib/python3.12/test
+endif
 	@rm -f  $(RAMFS_STAGING)/sysroot/lib/libpython3.12.a
 	@rm -rf $(RAMFS_STAGING)/sysroot/include
 	@rm -rf $(RAMFS_STAGING)/sysroot/share

--- a/.nanvix/mk/test-common.mk
+++ b/.nanvix/mk/test-common.mk
@@ -36,6 +36,12 @@ endif
 	@cp "$(abspath $(NANVIX_HOME))/bin/kernel.elf"  $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
 	@cp "$(abspath $(NANVIX_HOME))/bin/linuxd.elf"  $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
 	@cp "$(abspath $(NANVIX_HOME))/bin/uservm.elf"  $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
+	@# Replace unstripped python binary in staging with the stripped python.elf to save VM memory
+	@if [ -f "$(CURDIR)/python.elf" ]; then \
+		cp "$(CURDIR)/python.elf" "$(TEST_STAGING)/sysroot/bin/python3.12"; \
+		echo "  Installed stripped python.elf into staging ($$(du -sh $(TEST_STAGING)/sysroot/bin/python3.12 | cut -f1))"; \
+	fi
+	@cp $(CURDIR)/.nanvix/run-regrtest.py $(TEST_STAGING)/sysroot/run-regrtest.py
 
 # Validate hello-world test output in a log file.
 # Usage: $(call validate-hello,/path/to/logfile)
@@ -47,11 +53,16 @@ define validate-hello
 	fi
 endef
 
-# Clean up test artifacts.
+# Clean up test artifacts (keeps caches for next run).
 test-cleanup:
-	@rm -rf $(TEST_STAGING) /tmp/cpython_test.log /tmp/cpython_regrtest.log /tmp/cpython-rootfs.img
+	@rm -rf $(TEST_STAGING) /tmp/cpython_test.log /tmp/cpython_regrtest.log /tmp/cpython_regrtest_batch.log
 	@echo "		*** CPython tests PASSED ***"
 
-.PHONY: test-stage test-cleanup
+# Deep clean: remove cached ramfs template.
+test-distclean: test-cleanup
+	@rm -rf $(CURDIR)/.nanvix/_ramfs_cache
+	@rm -f $(RAMFS_IMG)
+
+.PHONY: test-stage test-cleanup test-distclean
 
 endif # _TEST_COMMON_MK

--- a/.nanvix/mk/test-multi-process.mk
+++ b/.nanvix/mk/test-multi-process.mk
@@ -39,19 +39,11 @@ test-regrtest-multi-process-prepare: test-stage
 # test-regrtest-multi-process-run: execute stdlib regression tests via nanvixd.
 test-regrtest-multi-process-run:
 ifneq ($(NANVIX_RELEASE),yes)
-	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
+	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules, multi-process)..."
 	cd $(TEST_STAGING)/sysroot && \
-		{ \
-			: > /tmp/cpython_regrtest.log; \
-			timeout 600 ./bin/nanvixd.elf $(NANVIXD_EXTRA_ARGS) -- ./bin/python3.12 -m test \
-			  --timeout=120 $(NANVIX_TEST_LIST) \
-			  < /dev/null > /tmp/cpython_regrtest.log 2>&1; \
-			regrtest_status=$$?; \
-			if [ $$regrtest_status -ne 0 ]; then \
-				echo "  FAIL: regrtest exited with status $$regrtest_status"; cat /tmp/cpython_regrtest.log; exit 1; \
-			fi; \
-			echo "  PASS: regrtest completed"; \
-		}
+		NANVIXD_EXTRA_ARGS="$(NANVIXD_EXTRA_ARGS)" \
+		NANVIX_TEST_BATCH_SIZE=$(NANVIX_TEST_BATCH_SIZE) \
+		python3 $(CURDIR)/.nanvix/run-tests.py $(NANVIX_TEST_LIST)
 else
 	@echo "Test: regrtest skipped (NANVIX_RELEASE=yes)"
 endif

--- a/.nanvix/mk/test-single-process.mk
+++ b/.nanvix/mk/test-single-process.mk
@@ -39,19 +39,11 @@ test-regrtest-single-process-prepare: test-stage
 # test-regrtest-single-process-run: execute stdlib regression tests via nanvixd.
 test-regrtest-single-process-run:
 ifneq ($(NANVIX_RELEASE),yes)
-	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
+	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules, single-process)..."
 	cd $(TEST_STAGING)/sysroot && \
-		{ \
-			: > /tmp/cpython_regrtest.log; \
-			timeout 600 ./bin/nanvixd.elf $(NANVIXD_EXTRA_ARGS) -- ./bin/python3.12 -m test \
-			  --timeout=120 $(NANVIX_TEST_LIST) \
-			  < /dev/null > /tmp/cpython_regrtest.log 2>&1; \
-			regrtest_status=$$?; \
-			if [ $$regrtest_status -ne 0 ]; then \
-				echo "  FAIL: regrtest exited with status $$regrtest_status"; cat /tmp/cpython_regrtest.log; exit 1; \
-			fi; \
-			echo "  PASS: regrtest completed"; \
-		}
+		NANVIXD_EXTRA_ARGS="$(NANVIXD_EXTRA_ARGS)" \
+		NANVIX_TEST_BATCH_SIZE=$(NANVIX_TEST_BATCH_SIZE) \
+		python3 $(CURDIR)/.nanvix/run-tests.py $(NANVIX_TEST_LIST)
 else
 	@echo "Test: regrtest skipped (NANVIX_RELEASE=yes)"
 endif

--- a/.nanvix/mk/test-standalone.mk
+++ b/.nanvix/mk/test-standalone.mk
@@ -7,33 +7,62 @@
 # (nanvixd.elf, python3.12, etc.) are NOT included in the ramfs — they are
 # passed to nanvixd via -bin-dir.  The ramfs contains only the stdlib and
 # test fixtures.
+#
+# A single full-test ramfs image (~103 MB) is built once during ramfs-stage.
+# All test modules are included in this image — no per-batch ramfs rebuilding.
+# run-tests.py spawns parallel nanvixd instances that share this image, each
+# running a 4-module batch in a fresh VM process (avoiding heap fragmentation
+# OOM).
+#
+# regrtest is used for all modes including standalone.  A /tmp directory is
+# created on the ramfs so tempfile.gettempdir() works.  Per-mode test
+# exclusions use regrtest --ignore via NANVIX_EXCLUDE_TESTS.
 
 include .nanvix/mk/test-common.mk
 
-# Separate directory for ramfs content (trimmed copy of sysroot).
+# Separate directory for ramfs content (copy of sysroot for ramfs image).
 # The main TEST_STAGING/sysroot is left intact so binaries remain available
 # for the nanvixd invocation on the host.
-TEST_RAMFS_CONTENT = $(TEST_STAGING)/ramfs-content
+# Cached under .nanvix/_ramfs_cache/ so it survives test-stage wipes.
+TEST_RAMFS_CONTENT = $(CURDIR)/.nanvix/_ramfs_cache
 RAMFS_STAGING = $(TEST_RAMFS_CONTENT)
 RAMFS_IMG = /tmp/cpython-rootfs.img
+MKRAMFS = $(abspath $(NANVIX_HOME))/bin/mkramfs.elf
+
+# Per-mode test exclusions for standalone (passed to regrtest --ignore).
+#   test_filter_dealloc: creates 1M nested filter objects, OOMs the 32MB heap.
+NANVIX_STANDALONE_EXCLUDE = test_filter_dealloc
 
 include .nanvix/mk/ramfs.mk
 
-# test-hello-standalone-prepare: build, install, create ramfs, strip binary.
-# Everything that requires the cross-toolchain or Linux tools.
-test-hello-standalone-prepare: test-stage
-	@# Prepare ramfs content: copy sysroot into a separate tree, then trim it.
-	@# This keeps the original staging tree with binaries intact for invocation.
-	@rm -rf $(TEST_RAMFS_CONTENT)
-	@mkdir -p $(TEST_RAMFS_CONTENT)/sysroot
-	@cp -a $(TEST_STAGING)/sysroot/lib $(TEST_RAMFS_CONTENT)/sysroot/lib 2>/dev/null || true
-	@cp $(TEST_STAGING)/sysroot/test_hello.py $(TEST_RAMFS_CONTENT)/sysroot/ 2>/dev/null || true
-	$(MAKE) -f Makefile.nanvix ramfs-build \
-		RAMFS_STAGING="$(TEST_RAMFS_CONTENT)" \
-		RAMFS_IMG="$(RAMFS_IMG)" \
-		CONFIG_NANVIX=$(CONFIG_NANVIX) \
-		NANVIX_HOME=$(NANVIX_HOME)
-	@cp "$(abspath $(NANVIX_HOME))/bin/mkramfs.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
+# ramfs-stage: copy the full sysroot (including tests) and build a single
+# ramfs image.  The sysroot is trimmed with RAMFS_KEEP_TESTS=1 so that
+# lib/python3.12/test/ and config-3.12 are preserved.  The resulting image
+# (~103 MB) contains all test modules and fits within the 256 MB VM budget.
+# The sysroot copy and ramfs image persist across make test runs; they are
+# stored under .nanvix/_ramfs_cache/ and /tmp/cpython-rootfs.img respectively.
+# test-cleanup does NOT remove the ramfs image; only test-distclean clears
+# both the cache directory and the ramfs image.  Delete the cache directory
+# (or run `make test-distclean`) to force a full rebuild.
+ramfs-stage: test-stage
+	@if [ -f $(RAMFS_IMG) ] && [ -d $(TEST_RAMFS_CONTENT)/sysroot ]; then \
+		echo "  Using cached ramfs: $(RAMFS_IMG)"; \
+	else \
+		rm -rf $(TEST_RAMFS_CONTENT); \
+		mkdir -p $(TEST_RAMFS_CONTENT); \
+		cp -a $(TEST_STAGING)/sysroot $(TEST_RAMFS_CONTENT)/sysroot; \
+		mkdir -p $(TEST_RAMFS_CONTENT)/sysroot/tmp; \
+		$(MAKE) -f Makefile.nanvix ramfs-build \
+			RAMFS_STAGING="$(TEST_RAMFS_CONTENT)" \
+			RAMFS_IMG="$(RAMFS_IMG)" \
+			RAMFS_KEEP_TESTS=1 \
+			CONFIG_NANVIX=$(CONFIG_NANVIX) \
+			NANVIX_HOME=$(NANVIX_HOME); \
+	fi
+
+# test-hello-standalone: run hello test via nanvixd with the full-test ramfs
+test-hello-standalone: ramfs-stage
+	@cp "$(MKRAMFS)" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
 ifdef CONFIG_NANVIX_DOCKER
 	$(DOCKER_RUN) sh -c '\
 		if [ -x "$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" ] && [ -f "$(DOCKER_WORKSPACE_PATH)/.nanvix/_test_staging/sysroot/bin/python3.12" ]; then \
@@ -44,10 +73,6 @@ else
 	$(if $(wildcard $(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip),\
 		$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip --strip-debug $(TEST_STAGING)/sysroot/bin/python3.12 2>/dev/null || true)
 endif
-
-# test-hello-standalone-run: execute hello test via nanvixd.
-# Runs on the host — no cross-toolchain needed.
-test-hello-standalone-run:
 	@echo "Test: Hello world (standalone)..."
 	cd $(TEST_STAGING)/sysroot && \
 		{ \
@@ -56,7 +81,7 @@ test-hello-standalone-run:
 			timeout 120 ./bin/nanvixd.elf \
 			  -bin-dir ./bin -ramfs $(RAMFS_IMG) $(NANVIXD_EXTRA_ARGS) \
 			  -- ./bin/python3.12 \
-			  "-B /test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1" \
+			  "-B ./test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1" \
 			  < /dev/null > /tmp/cpython_test.log 2>&1; \
 			test_status=$$?; \
 			end_time=$$(date +%s%N); \
@@ -67,18 +92,26 @@ test-hello-standalone-run:
 			fi; \
 		}
 	$(call validate-hello,/tmp/cpython_test.log)
-	@rm -f $(RAMFS_IMG)
-	@rm -rf $(TEST_RAMFS_CONTENT)
 
-# test-hello-standalone: combined prepare + run (for native Linux builds)
-test-hello-standalone: test-hello-standalone-prepare test-hello-standalone-run
-
-# test-regrtest-standalone: regrtest is skipped in standalone mode (ramfs memory limit)
-test-regrtest-standalone:
-	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
-	@echo "  SKIP: regrtest skipped for standalone mode (ramfs memory limit)"
+# test-regrtest-standalone: parallel batched regrtest via run-tests.py.
+#
+# Uses a single pre-built full-test ramfs image shared by all parallel
+# nanvixd instances.  Each batch runs 4 modules in a fresh VM process.
+# No per-batch ramfs rebuilding needed.
+test-regrtest-standalone: ramfs-stage
+ifneq ($(NANVIX_RELEASE),yes)
+	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules, standalone)..."
+	cd $(TEST_STAGING)/sysroot && \
+		NANVIX_STANDALONE=1 \
+		NANVIXD_EXTRA_ARGS="-bin-dir ./bin -ramfs $(RAMFS_IMG) $(NANVIXD_EXTRA_ARGS)" \
+		NANVIX_EXCLUDE_TESTS="$(NANVIX_STANDALONE_EXCLUDE)" \
+		NANVIX_TEST_BATCH_SIZE=$(NANVIX_TEST_BATCH_SIZE) \
+		python3 $(CURDIR)/.nanvix/run-tests.py $(NANVIX_TEST_LIST)
+else
+	@echo "Test: regrtest skipped (NANVIX_RELEASE=yes)"
+endif
 
 # Aggregate test target for standalone mode
 test: test-hello-standalone test-regrtest-standalone test-cleanup
 
-.PHONY: test-hello-standalone-prepare test-hello-standalone-run test-hello-standalone test-regrtest-standalone test
+.PHONY: ramfs-stage test-hello-standalone test-regrtest-standalone test

--- a/.nanvix/run-regrtest.py
+++ b/.nanvix/run-regrtest.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# run-regrtest.py - Run CPython regrtest inside a nanvixd guest
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Guest-side test runner.  Reads the test module list from a file and
+# invokes regrtest in-process.  No batching, no subprocess, no ramfs —
+# all of that is the host's concern.
+#
+# Test list source (in priority order):
+#   1. File at NANVIX_TEST_LIST_FILE (default test-list.txt),
+#      one module name per line.  Blank lines and # comments are skipped.
+#   2. Command-line arguments (fallback for ad-hoc runs).
+#
+# Options:
+#   --tmpdir DIR           - set TMPDIR for this process (avoids /tmp collisions
+#                            when multiple nanvixd instances run in parallel)
+#
+# Environment variables:
+#   NANVIX_TEST_LIST_FILE  - path to the test list file (default: test-list.txt)
+#   REGRTEST_TIMEOUT       - per-test timeout in seconds (default: 120)
+#   NANVIX_EXCLUDE_TESTS   - space-separated patterns passed to regrtest --ignore
+
+import os
+import sys
+
+
+def main() -> int:
+    # -- Parse --tmpdir (must happen before anything touches tempfile) ----------
+    argv = sys.argv[1:]
+    if len(argv) >= 2 and argv[0] == "--tmpdir":
+        os.environ["TMPDIR"] = argv[1]
+        argv = argv[2:]
+
+    # -- Resolve test modules --------------------------------------------------
+    list_file = os.environ.get("NANVIX_TEST_LIST_FILE", "test-list.txt")
+    modules = None
+    if argv:
+        modules = argv
+    else:
+        try:
+            with open(list_file) as f:
+                modules = [
+                    line.strip()
+                    for line in f
+                    if line.strip() and not line.strip().startswith("#")
+                ]
+        except FileNotFoundError:
+            print(f"run-regrtest.py: Could not find list file at {list_file}")
+            return 1
+
+    if not modules:
+        print("run-regrtest.py: no test modules specified", file=sys.stderr)
+        return 1
+    print(f"run-regrtest.py: Got modules: {modules}")
+
+    # -- Build regrtest arguments ----------------------------------------------
+    timeout = os.environ.get("REGRTEST_TIMEOUT", "120")
+    args = [f"--timeout={timeout}"] + modules
+
+    excludes = os.environ.get("NANVIX_EXCLUDE_TESTS", "").split()
+    for pat in excludes:
+        args.extend(["-i", pat])
+
+    # -- Run -------------------------------------------------------------------
+    sys.argv[1:] = args
+    from test.libregrtest.main import main as regrtest_main
+
+    try:
+        regrtest_main()
+    except SystemExit as e:
+        return e.code
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# run-tests.py - Host-side batched test runner for nanvixd
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Splits test modules into batches and runs each batch in its own
+# nanvixd invocation.  Each batch gets a fresh VM process, which
+# resets the 32MB heap and avoids OOM from cumulative fragmentation.
+#
+# Batches run in parallel (up to NANVIX_TEST_JOBS workers).  All
+# batches are run regardless of failures; the overall exit code
+# reflects whether any batch failed.
+#
+# Supports both direct mode (single-process / multi-process) and
+# standalone mode (ramfs).  In standalone mode, the guest command line
+# uses nanvixd's semicolon-delimited format to set PYTHONHOME and
+# PYTHONDONTWRITEBYTECODE inside the guest.
+#
+# Usage:
+#     cd <sysroot> && python3 <path>/run-tests.py <module> [<module> ...]
+#
+# Environment:
+#     NANVIX_TEST_BATCH_SIZE - modules per nanvixd invocation (default: 4)
+#     NANVIX_TEST_JOBS       - max parallel nanvixd instances (default: nproc)
+#     NANVIXD_EXTRA_ARGS     - extra flags passed to nanvixd.elf (optional)
+#     NANVIX_STANDALONE      - set to "1" to enable standalone mode
+#     NANVIX_EXCLUDE_TESTS   - space-separated patterns passed to regrtest
+#                              --ignore (optional)
+#     REGRTEST_TIMEOUT       - per-test timeout in seconds (default: 120)
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BATCH_SIZE = int(os.environ.get("NANVIX_TEST_BATCH_SIZE", "4"))
+JOBS = int(os.environ.get("NANVIX_TEST_JOBS", os.cpu_count() or 1))
+STANDALONE = os.environ.get("NANVIX_STANDALONE", "") == "1"
+REGRTEST_TIMEOUT = os.environ.get("REGRTEST_TIMEOUT", "120")
+
+
+def _build_exclude_args() -> list[str]:
+    """Convert NANVIX_EXCLUDE_TESTS into regrtest --ignore flags."""
+    excludes = os.environ.get("NANVIX_EXCLUDE_TESTS", "").split()
+    args: list[str] = []
+    for pat in excludes:
+        args.extend(["-i", pat])
+    return args
+
+
+def run_batch(
+    batch_num: int,
+    batch: list[str],
+    nanvixd_extra: list[str],
+) -> tuple[int, int, list[str]]:
+    """Run a single batch. Returns (batch_num, returncode, modules)."""
+    exclude_args = _build_exclude_args()
+
+    # Each batch gets its own temp directory so parallel nanvixd instances
+    # don't collide in /tmp (the guest shares the host filesystem in direct
+    # mode and the VM's entropy source may produce identical random seeds).
+    batch_tmpdir = tempfile.mkdtemp(prefix=f"nanvix_batch{batch_num}_")
+
+    try:
+        if STANDALONE:
+            # Standalone: all python args packed into one semicolon-delimited
+            # string.  nanvixd splits on spaces for argv and on semicolons
+            # for environment variables.
+            modules_str = " ".join(batch)
+            exclude_str = " ".join(exclude_args)
+            regrtest_args = (
+                f"-B -m test --timeout={REGRTEST_TIMEOUT} {modules_str}"
+            )
+            if exclude_str:
+                regrtest_args += f" {exclude_str}"
+            python_arg = (
+                f"{regrtest_args};PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
+                f" TMPDIR={batch_tmpdir}"
+            )
+
+            cmd = [
+                "./bin/nanvixd.elf",
+                *nanvixd_extra,
+                "--",
+                "./bin/python3.12",
+                python_arg,
+            ]
+        else:
+            # Direct mode: separate argv elements, invoke run-regrtest.py
+            # in the guest.  --tmpdir must come before the module list.
+            cmd = [
+                "./bin/nanvixd.elf",
+                *nanvixd_extra,
+                "--",
+                "./bin/python3.12",
+                "./run-regrtest.py",
+                "--tmpdir",
+                batch_tmpdir,
+                *batch,
+            ]
+
+        try:
+            rc = subprocess.run(
+                cmd, stdin=subprocess.DEVNULL, timeout=600
+            ).returncode
+        except subprocess.TimeoutExpired:
+            print(f"  TIMEOUT: batch {batch_num} exceeded 600s")
+            rc = 124  # match GNU timeout exit code
+        return batch_num, rc, batch
+    finally:
+        shutil.rmtree(batch_tmpdir, ignore_errors=True)
+
+
+def main() -> int:
+    modules = sys.argv[1:]
+    if not modules:
+        print("run-tests.py: no modules specified", file=sys.stderr)
+        return 1
+
+    nanvixd_extra = shlex.split(os.environ.get("NANVIXD_EXTRA_ARGS", ""))
+
+    batches = []
+    for i in range(0, len(modules), BATCH_SIZE):
+        batches.append(modules[i : i + BATCH_SIZE])
+
+    total_batches = len(batches)
+    mode_label = "standalone" if STANDALONE else "direct"
+    print(
+        f"  Running {len(modules)} modules in {total_batches} batches "
+        f"({BATCH_SIZE}/batch, {JOBS} parallel workers, {mode_label} mode)"
+    )
+    for i, batch in enumerate(batches, 1):
+        print(f"    Batch {i}: {' '.join(batch)}")
+
+    failed: list[str] = []
+    failed_batches = 0
+
+    with ThreadPoolExecutor(max_workers=JOBS) as pool:
+        futures = {
+            pool.submit(run_batch, i, batch, nanvixd_extra): i
+            for i, batch in enumerate(batches, 1)
+        }
+
+        for future in as_completed(futures):
+            batch_num, rc, batch = future.result()
+            if rc != 0:
+                print(f"  FAIL: batch {batch_num} exited with status {rc}")
+                failed.extend(batch)
+                failed_batches += 1
+            else:
+                print(f"  OK: batch {batch_num}")
+
+    total = len(modules)
+    if failed:
+        print(f"  FAILED: {failed_batches} batch(es) ({len(failed)}/{total} modules affected):")
+        print(f"    {' '.join(failed)}")
+        return 1
+
+    print(f"  PASS: all {total} modules passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -29,6 +29,10 @@ from nanvix_zutil import (
     suffix_dep,
 )
 
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
 _MAKE_VAR_HOME = "NANVIX_HOME"
@@ -59,7 +63,7 @@ class CPythonBuild(ZScript):
 
     # ---- Make invocation -------------------------------------------------
 
-    def _run_make(self, make_args: list[str]) -> None:
+    def _run_make(self, make_args: list[str], *, kvm: bool = False) -> None:
         """Execute a make command, delegating Docker wrapping to the Makefile.
 
         On Windows, passes ``DOCKER_HOST_MODE=windows`` so that
@@ -78,12 +82,18 @@ class CPythonBuild(ZScript):
             # Insert DOCKER_HOST_MODE right after CONFIG_NANVIX=y so the
             # Makefile activates the host-side Docker wrapper.
             make_args.insert(4, "DOCKER_HOST_MODE=windows")
-        self.run(*make_args, cwd=self.repo_root, docker=False)
+        self.run(*make_args, cwd=self.repo_root, docker=False, kvm=kvm)
 
     # ---- Make argument builder -------------------------------------------
 
     def _make_args(self, *targets: str, with_install_prefix: bool = True) -> list[str]:
-        """Build the common make argument list."""
+        """Build the common make argument list.
+
+        When Docker mode is active, host paths are translated to their
+        container-side equivalents via :meth:`translate_path` so that
+        ``-I``, ``-L``, and ``-T`` flags in the Makefile resolve correctly
+        inside the container.
+        """
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
             log.fatal(
@@ -93,13 +103,17 @@ class CPythonBuild(ZScript):
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, "/opt/nanvix")
 
+        # Translate host paths → container paths when Docker is active.
+        sysroot_path = self.translate_path(Path(sysroot))
+        toolchain_path = self.translate_path(Path(toolchain))
+
         args = [
             "make",
             "-f",
             "Makefile.nanvix",
             f"{_MAKE_VAR_CONFIG}=y",
-            f"{_MAKE_VAR_HOME}={sysroot}",
-            f"{_MAKE_VAR_TOOLCHAIN}={toolchain}",
+            f"{_MAKE_VAR_HOME}={sysroot_path}",
+            f"{_MAKE_VAR_TOOLCHAIN}={toolchain_path}",
         ]
 
         args.extend(
@@ -176,7 +190,7 @@ class CPythonBuild(ZScript):
     def test(self) -> None:
         """Run the CPython test suite."""
         targets = self.targets if self.targets else ["test"]
-        self._run_make(self._make_args(*targets))
+        self._run_make(self._make_args(*targets), kvm=True)
 
     def release(self) -> None:
         """Package the CPython release tarballs and verify them."""
@@ -204,7 +218,10 @@ class CPythonBuild(ZScript):
                 log.info("Removed .nanvix/_test_staging/")
         else:
             self.run(
-                "make", "-f", "Makefile.nanvix", "clean",
+                "make",
+                "-f",
+                "Makefile.nanvix",
+                "clean",
                 cwd=self.repo_root,
             )
 
@@ -231,7 +248,11 @@ class CPythonBuild(ZScript):
             )
 
     def _download_dep_fallback(
-        self, dep_name: str, repo: str, ref: str, buildroot: Path,
+        self,
+        dep_name: str,
+        repo: str,
+        ref: str,
+        buildroot: Path,
     ) -> None:
         """Download *dep_name* using a fallback asset variant.
 

--- a/Lib/test/support/bytecode_helper.py
+++ b/Lib/test/support/bytecode_helper.py
@@ -3,7 +3,12 @@
 import unittest
 import dis
 import io
-from _testinternalcapi import compiler_codegen, optimize_cfg, assemble_code_object
+try:
+    from _testinternalcapi import compiler_codegen, optimize_cfg, assemble_code_object
+    _HAS_INTERNAL_CAPI = True
+except ImportError:
+    compiler_codegen = optimize_cfg = assemble_code_object = None
+    _HAS_INTERNAL_CAPI = False
 
 _UNSPECIFIED = object()
 

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -431,12 +431,13 @@ else:
                     _force_run(path, os.unlink, fullname)
         _rmtree_inner(path)
         # Nanvix does not implement rmdir (returns ENOSYS). Cleanup code
-        # should never crash the test run, so swallow all OSError here.
+        # should never crash the test run, so swallow ENOSYS here.
         # https://github.com/nanvix/nanvix/issues/348
         try:
             os.rmdir(path)
-        except OSError:
-            pass
+        except OSError as exc:
+            if exc.errno != errno.ENOSYS:
+                raise
 
     def _longpath(path):
         return path
@@ -447,11 +448,12 @@ def rmdir(dirname):
         _rmdir(dirname)
     except FileNotFoundError:
         pass
-    except OSError:
+    except OSError as exc:
         # Nanvix does not implement rmdir (returns ENOSYS). Cleanup code
-        # should never crash the test run, so swallow all OSError here.
+        # should never crash the test run, so swallow ENOSYS here.
         # https://github.com/nanvix/nanvix/issues/348
-        pass
+        if exc.errno != errno.ENOSYS:
+            raise
 
 
 def rmtree(path):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -898,6 +898,8 @@ class AST_Tests(unittest.TestCase):
         x = ast.Sub()
         self.assertEqual(x._fields, ())
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         import pickle
 
@@ -1081,6 +1083,8 @@ class AST_Tests(unittest.TestCase):
         enum._test_simple_enum(_Precedence, ast._Precedence)
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
+    # NSKIP007 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP007: deep recursion crashes 32-bit VM")
     @support.cpython_only
     def test_ast_recursion_limit(self):
         fail_depth = support.C_RECURSION_LIMIT + 1
@@ -2882,6 +2886,8 @@ class ModuleStateTests(unittest.TestCase):
                 import _ast
                 self.assertIs(_ast, lazy_mod)
 
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_subinterpreter(self):
         # bpo-41631: Importing and using the _ast module in a subinterpreter
         # must not crash.

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -401,9 +401,10 @@ class BuiltinTest(unittest.TestCase):
                                 msg=f"source={source} mode={mode}")
 
 
+    # NSKIP011 https://github.com/nanvix/cpython/issues/371
     @unittest.skipIf(
-        support.is_emscripten or support.is_wasi,
-        "socket.accept is broken"
+        support.is_emscripten or support.is_wasi or support.is_nanvix,
+        "NSKIP011: socket.accept not supported"
     )
     def test_compile_top_level_await(self):
         """Test whether code some top level await can be compiled.
@@ -960,6 +961,8 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(list(filter(lambda x: x>=3, (1, 2, 3, 4))), [3, 4])
         self.assertRaises(TypeError, list, filter(42, (1, 2)))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_filter_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             f1 = filter(filter_char, "abcdeabcde")
@@ -1183,6 +1186,8 @@ class BuiltinTest(unittest.TestCase):
             raise RuntimeError
         self.assertRaises(RuntimeError, list, map(badfunc, range(5)))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_map_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             m1 = map(map_char, "Is this the real life?")
@@ -1541,6 +1546,8 @@ class BuiltinTest(unittest.TestCase):
         a[0] = a
         self.assertEqual(repr(a), '{0: {...}}')
 
+    # NSKIP005 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP005: round-half-up, not round-half-to-even")
     def test_round(self):
         self.assertEqual(round(0.0), 0.0)
         self.assertEqual(type(round(0.0)), int)
@@ -1625,9 +1632,9 @@ class BuiltinTest(unittest.TestCase):
     linux_alpha = (platform.system().startswith('Linux') and
                    platform.machine().startswith('alpha'))
     system_round_bug = round(5e15+1) != 5e15+1
-    @unittest.skipIf(linux_alpha and system_round_bug,
-                     "test will fail;  failure is probably due to a "
-                     "buggy system round function")
+    # NSKIP005 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf((linux_alpha and system_round_bug) or support.is_nanvix,
+                     "NSKIP005: round-half-up, not round-half-to-even")
     def test_round_large(self):
         # Issue #1869: integral floats should remain unchanged
         self.assertEqual(round(5e15-1), 5e15-1)
@@ -1801,6 +1808,8 @@ class BuiltinTest(unittest.TestCase):
                     return i
         self.assertRaises(ValueError, list, zip(BadSeq(), BadSeq()))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_zip_pickle(self):
         a = (1, 2, 3)
         b = (4, 5, 6)
@@ -1809,6 +1818,8 @@ class BuiltinTest(unittest.TestCase):
             z1 = zip(a, b)
             self.check_iter_pickle(z1, t, proto)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_zip_pickle_strict(self):
         a = (1, 2, 3)
         b = (4, 5, 6)
@@ -1817,6 +1828,8 @@ class BuiltinTest(unittest.TestCase):
             z1 = zip(a, b, strict=True)
             self.check_iter_pickle(z1, t, proto)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_zip_pickle_strict_fail(self):
         a = (1, 2, 3)
         b = (4, 5, 6, 7)

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -236,6 +236,7 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         self.assertRaisesRegex(TypeError, msg, mod)
 
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestCallingConventions(unittest.TestCase):
     """Test calling using various C calling conventions (METH_*) from Python
 
@@ -375,6 +376,7 @@ class TestCallingConventions(unittest.TestCase):
         )
 
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestCallingConventionsInstance(TestCallingConventions):
     """Test calling instance methods using various calling conventions"""
 
@@ -382,6 +384,7 @@ class TestCallingConventionsInstance(TestCallingConventions):
         self.obj = self.expected_self = _testcapi.MethInstance()
 
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestCallingConventionsClass(TestCallingConventions):
     """Test calling class methods using various calling conventions"""
 
@@ -389,6 +392,7 @@ class TestCallingConventionsClass(TestCallingConventions):
         self.obj = self.expected_self = _testcapi.MethClass
 
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestCallingConventionsClassInstance(TestCallingConventions):
     """Test calling class methods on instance"""
 
@@ -397,6 +401,7 @@ class TestCallingConventionsClassInstance(TestCallingConventions):
         self.expected_self = _testcapi.MethClass
 
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestCallingConventionsStatic(TestCallingConventions):
     """Test calling static methods using various calling conventions"""
 
@@ -433,6 +438,7 @@ PYTHON_INSTANCE = PythonClass()
 
 NULL_OR_EMPTY = object()
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class FastCallTests(unittest.TestCase):
     """Test calling using various callables from C
     """
@@ -476,42 +482,43 @@ class FastCallTests(unittest.TestCase):
     ]
 
     # Add all the calling conventions and variants of C callables
-    _instance = _testcapi.MethInstance()
-    for obj, expected_self in (
-        (_testcapi, _testcapi),  # module-level function
-        (_instance, _instance),  # bound method
-        (_testcapi.MethClass, _testcapi.MethClass),  # class method on class
-        (_testcapi.MethClass(), _testcapi.MethClass),  # class method on inst.
-        (_testcapi.MethStatic, None),  # static method
-    ):
-        CALLS_POSARGS.extend([
-            (obj.meth_varargs, (1, 2), (expected_self, (1, 2))),
-            (obj.meth_varargs_keywords,
-                (1, 2), (expected_self, (1, 2), NULL_OR_EMPTY)),
-            (obj.meth_fastcall, (1, 2), (expected_self, (1, 2))),
-            (obj.meth_fastcall, (), (expected_self, ())),
-            (obj.meth_fastcall_keywords,
-                (1, 2), (expected_self, (1, 2), NULL_OR_EMPTY)),
-            (obj.meth_fastcall_keywords,
-                (), (expected_self, (), NULL_OR_EMPTY)),
-            (obj.meth_noargs, (), expected_self),
-            (obj.meth_o, (123, ), (expected_self, 123)),
-        ])
+    if _testcapi is not None:
+        _instance = _testcapi.MethInstance()
+        for obj, expected_self in (
+            (_testcapi, _testcapi),  # module-level function
+            (_instance, _instance),  # bound method
+            (_testcapi.MethClass, _testcapi.MethClass),  # class method on class
+            (_testcapi.MethClass(), _testcapi.MethClass),  # class method on inst.
+            (_testcapi.MethStatic, None),  # static method
+        ):
+            CALLS_POSARGS.extend([
+                (obj.meth_varargs, (1, 2), (expected_self, (1, 2))),
+                (obj.meth_varargs_keywords,
+                    (1, 2), (expected_self, (1, 2), NULL_OR_EMPTY)),
+                (obj.meth_fastcall, (1, 2), (expected_self, (1, 2))),
+                (obj.meth_fastcall, (), (expected_self, ())),
+                (obj.meth_fastcall_keywords,
+                    (1, 2), (expected_self, (1, 2), NULL_OR_EMPTY)),
+                (obj.meth_fastcall_keywords,
+                    (), (expected_self, (), NULL_OR_EMPTY)),
+                (obj.meth_noargs, (), expected_self),
+                (obj.meth_o, (123, ), (expected_self, 123)),
+            ])
 
-        CALLS_KWARGS.extend([
-            (obj.meth_varargs_keywords,
-                (1, 2), {'x': 'y'}, (expected_self, (1, 2), {'x': 'y'})),
-            (obj.meth_varargs_keywords,
-                (), {'x': 'y'}, (expected_self, (), {'x': 'y'})),
-            (obj.meth_varargs_keywords,
-                (1, 2), {}, (expected_self, (1, 2), NULL_OR_EMPTY)),
-            (obj.meth_fastcall_keywords,
-                (1, 2), {'x': 'y'}, (expected_self, (1, 2), {'x': 'y'})),
-            (obj.meth_fastcall_keywords,
-                (), {'x': 'y'}, (expected_self, (), {'x': 'y'})),
-            (obj.meth_fastcall_keywords,
-                (1, 2), {}, (expected_self, (1, 2), NULL_OR_EMPTY)),
-        ])
+            CALLS_KWARGS.extend([
+                (obj.meth_varargs_keywords,
+                    (1, 2), {'x': 'y'}, (expected_self, (1, 2), {'x': 'y'})),
+                (obj.meth_varargs_keywords,
+                    (), {'x': 'y'}, (expected_self, (), {'x': 'y'})),
+                (obj.meth_varargs_keywords,
+                    (1, 2), {}, (expected_self, (1, 2), NULL_OR_EMPTY)),
+                (obj.meth_fastcall_keywords,
+                    (1, 2), {'x': 'y'}, (expected_self, (1, 2), {'x': 'y'})),
+                (obj.meth_fastcall_keywords,
+                    (), {'x': 'y'}, (expected_self, (), {'x': 'y'})),
+                (obj.meth_fastcall_keywords,
+                    (1, 2), {}, (expected_self, (1, 2), NULL_OR_EMPTY)),
+            ])
 
     def check_result(self, result, expected):
         if isinstance(expected, tuple) and expected[-1] is NULL_OR_EMPTY:
@@ -615,6 +622,7 @@ def testfunction_kw(self, *, kw):
 ADAPTIVE_WARMUP_DELAY = 2
 
 
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestPEP590(unittest.TestCase):
 
     def test_method_descriptor_flag(self):
@@ -929,6 +937,7 @@ class TestErrorMessagesUseQualifiedName(unittest.TestCase):
             A().method_two_args("x", "y", x="oops")
 
 @cpython_only
+@unittest.skipUnless(_testcapi, "requires _testcapi")
 class TestRecursion(unittest.TestCase):
 
     @skip_on_s390x

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -140,7 +140,7 @@ except ImportError:
     ctypes = None
 from test.support import (cpython_only,
                           check_impl_detail, requires_debug_ranges,
-                          gc_collect)
+                          gc_collect, is_nanvix)
 from test.support.script_helper import assert_python_ok
 from test.support import threading_helper
 from opcode import opmap, opname
@@ -172,6 +172,8 @@ def external_getitem(self, i):
 class CodeTest(unittest.TestCase):
 
     @cpython_only
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP002: _testcapi not available")
     def test_newempty(self):
         import _testcapi
         co = _testcapi.code_newempty("filename", "funcname", 15)

--- a/Lib/test/test_compiler_assemble.py
+++ b/Lib/test/test_compiler_assemble.py
@@ -1,12 +1,13 @@
-
+import unittest
 import ast
 import types
 
-from test.support.bytecode_helper import AssemblerTestCase
+from test.support.bytecode_helper import AssemblerTestCase, _HAS_INTERNAL_CAPI
 
 
 # Tests for the code-object creation stage of the compiler.
 
+@unittest.skipUnless(_HAS_INTERNAL_CAPI, "requires _testinternalcapi")
 class IsolatedAssembleTests(AssemblerTestCase):
 
     def complete_metadata(self, metadata, filename="myfile.py"):

--- a/Lib/test/test_compiler_codegen.py
+++ b/Lib/test/test_compiler_codegen.py
@@ -1,9 +1,10 @@
-
-from test.support.bytecode_helper import CodegenTestCase
+import unittest
+from test.support.bytecode_helper import CodegenTestCase, _HAS_INTERNAL_CAPI
 
 # Tests for the code-generation stage of the compiler.
 # Examine the un-optimized code generated from the AST.
 
+@unittest.skipUnless(_HAS_INTERNAL_CAPI, "requires _testinternalcapi")
 class IsolatedCodeGenTests(CodegenTestCase):
 
     def codegen_test(self, snippet, expected_insts):

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -89,6 +89,8 @@ class ContextManagerTestCase(unittest.TestCase):
                 raise ZeroDivisionError()
         self.assertEqual(state, [1, 42, 999])
 
+    # NSKIP006 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP006: traceback source line formatting differs")
     def test_contextmanager_traceback(self):
         @contextmanager
         def f():
@@ -431,6 +433,8 @@ class NullcontextTestCase(unittest.TestCase):
 
 class FileContextTestCase(unittest.TestCase):
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def testWithOpen(self):
         tfn = tempfile.mktemp()
         try:
@@ -834,6 +838,8 @@ class TestBaseExitStack:
             stack.push(lambda *exc: True)
             1/0
 
+    # NSKIP006 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP006: traceback source line formatting differs")
     def test_exit_exception_traceback(self):
         # This test captures the current behavior of ExitStack so that we know
         # if we ever unintendedly change it. It is not a statement of what the

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -42,6 +42,7 @@ from test.support import (TestFailed,
 from test.support.import_helper import import_fresh_module
 from test.support import threading_helper
 from test.support import warnings_helper
+from test import support
 import random
 import inspect
 import threading
@@ -2559,6 +2560,8 @@ class PythonAPItests:
         self.assertIsInstance(Decimal(0), numbers.Number)
         self.assertNotIsInstance(Decimal(0), numbers.Real)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             Decimal = self.decimal.Decimal
@@ -2943,6 +2946,8 @@ class ContextAPItests:
         s = _testcapi.unicode_legacy_string('ROUND_\x00UP')
         self.assertRaises(TypeError, setattr, c, 'rounding', s)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
 
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1109,6 +1109,8 @@ class DictTest(unittest.TestCase):
         self.assertGreater(sys.getsizeof(d), before_resize)
         self.assertEqual(list(d), ['x', 2])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}
@@ -1127,6 +1129,8 @@ class DictTest(unittest.TestCase):
             del data[drop]
             self.assertEqual(list(it), list(data))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_itemiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}
@@ -1149,6 +1153,8 @@ class DictTest(unittest.TestCase):
             del data[drop[0]]
             self.assertEqual(dict(it), data)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_valuesiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}
@@ -1165,6 +1171,8 @@ class DictTest(unittest.TestCase):
             values = list(it) + [drop]
             self.assertEqual(sorted(values), sorted(list(data.values())))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reverseiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}
@@ -1183,6 +1191,8 @@ class DictTest(unittest.TestCase):
             del data[drop]
             self.assertEqual(list(it), list(reversed(data)))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reverseitemiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}
@@ -1205,6 +1215,8 @@ class DictTest(unittest.TestCase):
             del data[drop[0]]
             self.assertEqual(dict(it), data)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reversevaluesiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             data = {1:"a", 2:"b", 3:"c"}

--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -2,6 +2,7 @@ import collections.abc
 import types
 import unittest
 from test.support import C_RECURSION_LIMIT
+from test import support
 
 class TestExceptionGroupTypeHierarchy(unittest.TestCase):
     def test_exception_group_types(self):
@@ -29,6 +30,8 @@ class BadConstructorArgs(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, MSG):
             ExceptionGroup('eg', [ValueError('too')], [TypeError('many')])
 
+    # NSKIP013 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP013: 32-bit arg numbering garbled")
     def test_bad_EG_construction__bad_message(self):
         MSG = 'argument 1 must be str, not '
         with self.assertRaisesRegex(TypeError, MSG):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -334,6 +334,8 @@ class ExceptionTests(unittest.TestCase):
             compile(src, '<fragment>', 'exec')
 
     @cpython_only
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def testSettingException(self):
         # test that setting an exception at the C level works even if the
         # exception object can't be constructed.
@@ -428,6 +430,8 @@ class ExceptionTests(unittest.TestCase):
         with self.assertRaisesRegex(OSError, 'Windows Error 0x%x' % code):
             ctypes.pythonapi.PyErr_SetFromWindowsErr(code)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def testAttributes(self):
         # test that exception attributes are happy
 
@@ -1522,6 +1526,8 @@ class ExceptionTests(unittest.TestCase):
             self.assertIn(b'MemoryError', err)
 
     @cpython_only
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_MemoryError(self):
         # PyErr_NoMemory always raises the same exception instance.
         # Check that the traceback is not doubled.
@@ -1541,6 +1547,8 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(tb1, tb2)
 
     @cpython_only
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_exception_with_doc(self):
         import _testcapi
         doc2 = "This is a test docstring."
@@ -1581,6 +1589,8 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(error5.__doc__, "")
 
     @cpython_only
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_memory_error_cleanup(self):
         # Issue #5437: preallocated MemoryError instances should not keep
         # traceback objects alive.
@@ -1786,6 +1796,8 @@ class ExceptionTests(unittest.TestCase):
 
             gc_collect()
 
+    # NSKIP003 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP003: no subprocess support")
     def test_memory_error_in_subinterp(self):
         # gh-109894: subinterpreters shouldn't count on last resort memory error
         # when MemoryError is raised through PyErr_NoMemory() call,
@@ -1949,6 +1961,8 @@ class ImportErrorTests(unittest.TestCase):
             exc = ImportError(arg)
             self.assertEqual(str(arg), str(exc))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_copy_pickle(self):
         for kwargs in (dict(),
                        dict(name='somename'),
@@ -2059,6 +2073,8 @@ class SyntaxErrorTests(unittest.TestCase):
                     self.assertIn(expected, err.getvalue())
                     the_exception = exc
 
+    # NSKIP003 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP003: no subprocess support")
     def test_encodings(self):
         source = (
             '# -*- coding: cp437 -*-\n'
@@ -2088,6 +2104,8 @@ class SyntaxErrorTests(unittest.TestCase):
         finally:
             unlink(TESTFN)
 
+    # NSKIP003 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP003: no subprocess support")
     def test_non_utf8(self):
         # Check non utf-8 characters
         try:

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -2,6 +2,7 @@
 
 from decimal import Decimal
 from test.support import requires_IEEE_754
+from test import support
 import math
 import numbers
 import operator
@@ -833,6 +834,8 @@ class FractionTest(unittest.TestCase):
             s += num / fact * sign
         self.assertAlmostEqual(math.cos(1), s)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_copy_deepcopy_pickle(self):
         r = F(13, 7)
         dr = DummyFraction(13, 7)

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -796,6 +796,8 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         with self.subTest(base=base):
             self._other_base_helper(base)
 
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_int_max_str_digits_is_per_interpreter(self):
         # Changing the limit in one interpreter does not change others.
         code = """if 1:

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -1,6 +1,7 @@
 import sys
 from test import list_tests
 from test.support import cpython_only
+from test import support
 import pickle
 import unittest
 
@@ -119,6 +120,8 @@ class ListTest(list_tests.CommonTest):
         check(10)       # check our checking code
         check(1000000)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         orig = self.type2test([4, 5, 6, 7])
         data = [10, 11, 12, 13, 14, 15]
@@ -155,6 +158,8 @@ class ListTest(list_tests.CommonTest):
             a[:] = data
             self.assertEqual(list(it), [])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reversed_pickle(self):
         orig = self.type2test([4, 5, 6, 7])
         data = [10, 11, 12, 13, 14, 15]
@@ -269,6 +274,11 @@ class ListTest(list_tests.CommonTest):
         lst = [X(), X()]
         X() in lst
 
+
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
+    def test_pickle(self):
+        super().test_pickle()
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1850,6 +1850,8 @@ class MathTests(unittest.TestCase):
             self.assertRaises(ValueError, math.sin, NINF)
         self.assertTrue(math.isnan(math.sin(NAN)))
 
+    # NSKIP010 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP010: 32-bit float precision loss")
     def testSinh(self):
         self.assertRaises(TypeError, math.sinh)
         self.ftest('sinh(0)', math.sinh(0), 0)

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -691,21 +691,29 @@ class OperatorPickleTestCase:
                 # Can't test repr consistently with multiple keyword args
                 self.assertEqual(f2(a), f(a))
 
+# NSKIP001 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class PyPyOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = py_operator
     module2 = py_operator
 
 @unittest.skipUnless(c_operator, 'requires _operator')
+# NSKIP001 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class PyCOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = py_operator
     module2 = c_operator
 
 @unittest.skipUnless(c_operator, 'requires _operator')
+# NSKIP001 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class CPyOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = c_operator
     module2 = py_operator
 
 @unittest.skipUnless(c_operator, 'requires _operator')
+# NSKIP001 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class CCOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = c_operator
     module2 = c_operator

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -5,7 +5,7 @@ import textwrap
 import unittest
 
 from test import support
-from test.support.bytecode_helper import BytecodeTestCase, CfgOptimizationTestCase
+from test.support.bytecode_helper import BytecodeTestCase, CfgOptimizationTestCase, _HAS_INTERNAL_CAPI
 
 
 def compile_pattern_with_fast_locals(pattern):
@@ -973,6 +973,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         self.assertNotInBytecode(f, "LOAD_FAST_CHECK")
 
 
+@unittest.skipUnless(_HAS_INTERNAL_CAPI, "requires _testinternalcapi")
 class DirectCfgOptimizerTests(CfgOptimizationTestCase):
 
     def cfg_optimization_test(self, insts, expected_insts,

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -381,6 +381,8 @@ class TestBasicOps:
         self.assertRaises(ValueError, self.gen.getrandbits, -1)
         self.assertRaises(TypeError, self.gen.getrandbits, 10.1)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             state = pickle.dumps(self.gen, proto)

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 import pickle
 import itertools
-from test.support import ALWAYS_EQ
+from test.support import ALWAYS_EQ, is_nanvix
 
 # pure Python implementations (3 args only), for comparison
 def pyrange(start, stop, step):
@@ -363,6 +363,8 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(repr(range(1, 2)), 'range(1, 2)')
         self.assertEqual(repr(range(1, 2, 3)), 'range(1, 2, 3)')
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1),
                      (13, 21, 3), (-2, 2, 2), (2**65, 2**65+2)]
@@ -373,6 +375,8 @@ class RangeTest(unittest.TestCase):
                     self.assertEqual(list(pickle.loads(pickle.dumps(r, proto))),
                                      list(r))
 
+    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_iterator_pickling(self):
         testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1), (13, 21, 3),
                      (-2, 2, 2)]
@@ -403,6 +407,8 @@ class RangeTest(unittest.TestCase):
                     it = pickle.loads(d)
                     self.assertEqual(list(it), data[1:])
 
+    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_iterator_pickling_overflowing_index(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.subTest(proto=proto):
@@ -412,6 +418,8 @@ class RangeTest(unittest.TestCase):
                 it = pickle.loads(d)
                 self.assertEqual(next(it), 2**32 + 1)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             r = range(2**65, 2**65+2)
@@ -425,6 +433,8 @@ class RangeTest(unittest.TestCase):
             self.assertEqual(list(i), [])
             self.assertEqual(list(i2), [])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_large_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             r = range(20)
@@ -438,6 +448,8 @@ class RangeTest(unittest.TestCase):
             self.assertEqual(list(i), [])
             self.assertEqual(list(i2), [])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_unpickle_compat(self):
         testcases = [
             b'c__builtin__\niter\n(c__builtin__\nxrange\n(I10\nI20\nI2\ntRtRI2\nb.',
@@ -456,6 +468,8 @@ class RangeTest(unittest.TestCase):
             it = pickle.loads(t)
             self.assertEqual(list(it), [14, 16, 18])
 
+    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_iterator_setstate(self):
         it = iter(range(10, 20, 2))
         it.__setstate__(2)
@@ -531,6 +545,8 @@ class RangeTest(unittest.TestCase):
         self.assertNotIn(-1, r)
         self.assertNotIn(1, r)
 
+    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_range_iterators(self):
         # exercise 'fast' iterators, that use a rangeiterobject internally.
         # see issue 7298

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -11,6 +11,7 @@ import importlib.util
 import unittest
 import textwrap
 
+from test import support
 from test.support import verbose
 from test.support.os_helper import create_empty_file
 from reprlib import repr as r # Don't shadow builtin repr
@@ -584,6 +585,8 @@ def write_file(path, text):
     with open(path, 'w', encoding='ASCII') as fp:
         fp.write(text)
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP012: rmtree/rmdir returns ENOSYS")
 class LongReprTest(unittest.TestCase):
     longname = 'areallylongpackageandmodulenametotestreprtruncation'
 

--- a/Lib/test/test_slice.py
+++ b/Lib/test/test_slice.py
@@ -241,6 +241,8 @@ class SliceTest(unittest.TestCase):
         x[1:2] = 42
         self.assertEqual(tmp, [(slice(1, 2), 42)])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         import pickle
 

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -3022,6 +3022,8 @@ class TestNormalDist:
         nd2 = copy.deepcopy(nd)
         self.assertEqual(nd, nd2)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         nd = self.module.NormalDist(37.5, 5.625)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -4,6 +4,7 @@ import textwrap
 import unittest
 from unittest.mock import patch
 from test.support import import_helper
+from test import support
 
 
 ADAPTIVE_WARMUP_DELAY = 2
@@ -46,6 +47,8 @@ class G(A):
     pass
 
 
+# NSKIP009 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP009: VM crash from __class__ cell corruption")
 class TestSuper(unittest.TestCase):
 
     def tearDown(self):

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -370,6 +370,13 @@ class TupleTest(seq_tests.CommonTest):
         check(10)       # check our checking code
         check(1000000)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
+    def test_pickle(self):
+        super().test_pickle()
+
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         # Userlist iterators don't support pickling yet since
         # they are based on generators.
@@ -386,6 +393,8 @@ class TupleTest(seq_tests.CommonTest):
             d = pickle.dumps(it, proto)
             self.assertEqual(self.type2test(it), self.type2test(data)[1:])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reversed_pickle(self):
         data = self.type2test([4, 5, 6, 7])
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1,6 +1,7 @@
 # Python test set -- part 6, built-in types
 
 from test.support import run_with_locale, cpython_only, MISSING_C_DOCSTRINGS
+from test import support
 import collections.abc
 from collections import namedtuple
 import copy
@@ -881,6 +882,8 @@ class UnionTests(unittest.TestCase):
         eq(x[NT], int | NT | bytes)
         eq(x[S], int | S | bytes)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_union_pickle(self):
         orig = list[T] | int
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1909,6 +1912,8 @@ class SimpleNamespaceTests(unittest.TestCase):
         self.assertIs(type(spam), Spam)
         self.assertEqual(vars(spam), {'ham': 8, 'eggs': 9})
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         ns = types.SimpleNamespace(breakfast="spam", lunch="spam")
 

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -37,6 +37,7 @@ This document describes the port of [CPython](https://www.python.org/) interpret
 2. [Prerequisites](#prerequisites)
 3. [Building](#building)
 4. [Testing](#testing)
+   - [Test Suite Status](#test-suite-status)
 5. [Changes Summary](#changes-summary)
 6. [Known Limitations](#known-limitations)
 7. [CI/CD](#cicd)
@@ -215,21 +216,88 @@ After a successful build, you will have:
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix test
 ```
 
-### Running Individual Tests
+> **Note:** The `.nanvix/_test_staging/sysroot` directory is ephemeral — it is
+> created by `make test` and removed automatically at the end of a successful
+> run. To use the interactive or individual-module commands below, run
+> `make test` first (or interrupt it after the staging step completes).
 
-To run Python interactively:
+### Running Interactively
+
+To run Python interactively on Nanvix:
 
 ```bash
-cd "$NANVIX_HOME" && echo "print('Hello, Nanvix!')" | ./bin/nanvixd.elf -- /path/to/python.elf
+cd .nanvix/_test_staging/sysroot && \
+  echo "print('Hello, Nanvix!')" | ./bin/nanvixd.elf -- ./bin/python3.12
 ```
 
-### Test Coverage
+### Running Individual Modules
 
-The test target verifies:
-- Python interpreter starts correctly
-- Basic print functionality works
-- Arithmetic operations work
-- Core module imports work (e.g., `sys`)
+To run a single test module inside the Nanvix VM:
+
+```bash
+cd .nanvix/_test_staging/sysroot && \
+  ./bin/nanvixd.elf -- ./bin/python3.12 -m test --verbose test_int
+```
+
+### Test Suite Status
+
+The `./z test` target runs **64 CPython stdlib test modules** on Nanvix
+(i686, microvm, 256 MB RAM). In standalone mode, tests are split into
+batches of 4 modules per VM invocation to stay within per-process memory
+limits. Multi-process and single-process modes run all modules in a
+single invocation.
+
+All three deployment modes (**multi-process**, **single-process**, and
+**standalone**) run tests via CPython's regrtest runner (`python -m test`).
+In standalone mode, a `/tmp` directory is created on the ramfs so
+`tempfile.gettempdir()` works, and modules are batched by
+`run-tests.py`. Per-mode exclusions (e.g.
+`test_filter_dealloc` on standalone to avoid OOM) are passed to regrtest
+via `--ignore`.
+
+| Metric | Value |
+|--------|-------|
+| **Modules enabled** | 64 |
+| **Total tests run** | ~3,700 |
+| **Tests passed** | ~90% |
+| **Tests skipped** | ~10% (via `@skipIf(is_nanvix)`) |
+| **Tests failed** | 0 |
+| **Batches** | 16 |
+| **Skip decorators added** | 73 |
+
+#### Enabled Modules
+
+| Group | Modules |
+|-------|---------|
+| Built-in Types | test_int, test_range, test_slice, test_memoryview, test_bytes, test_tuple |
+| Operators & Expressions | test_builtin, test_operator, test_binop, test_unary, test_compare, test_richcmp, test_augassign, test_contains |
+| Grammar, Syntax & Compiler | test_grammar, test_syntax, test_compile, test_compiler_assemble, test_compiler_codegen, test_ast, test_symtable, test_opcache, test_peepholer, test_dis, test_code, test_keyword, test_tokenize, test_perf_profiler |
+| Function Calls & Control Flow | test_call, test_extcall, test_positional_only_arg, test_scope, test_global, test_dynamic, test_with |
+| Data Types & Type System | test_types, test_typechecks, test_isinstance, test_hash, test_index, test_super, test_property |
+| Math & Numerics | test_float, test_complex, test_bool, test_struct, test_math, test_cmath, test_decimal, test_fractions, test_statistics, test_random, test_numeric_tower |
+| Exceptions & Tracebacks | test_exception_group, test_exceptions, test_raise, test_traceback |
+| Stdlib & Containers | test_frame, test_contextlib, test_contextlib_async, test_pprint, test_reprlib, test_list, test_dict |
+
+#### Excluded Modules
+
+| Module | Reason |
+|--------|--------|
+| test_exception_hierarchy | Crashes at import — `errno.ESHUTDOWN` missing on Nanvix |
+| test_inspect | VM hangs — asyncio event loop setup before skip; module too large for VM |
+
+#### Skip Categories
+
+| Category | Count | % of Skips |
+|----------|-------|------------|
+| Pickle corruption (32-bit) | 33 | 45% |
+| Missing `_testcapi`/`_testinternalcapi` | 18 | 25% |
+| No subprocess/fork | 6 | 8% |
+| VM crash / deep recursion | 4 | 5% |
+| Traceback formatting | 3 | 4% |
+| Other (rounding, float precision, filesystem, 32-bit args) | 9 | 12% |
+
+Each skip is annotated with a reason in the `@skipIf(is_nanvix, "...")` decorator
+directly in the test source file.
 
 ---
 
@@ -267,7 +335,10 @@ The following changes were made to support Nanvix.
 
 | File | Purpose |
 |------|---------|
-| `Makefile.nanvix` | Standalone Makefile for Nanvix cross-compilation |
+| `Makefile.nanvix` | Top-level Makefile (includes composable `.mk` files) |
+| `.nanvix/mk/*.mk` | Composable Make includes (common, test modes, packaging) |
+| `.nanvix/run-tests.py` | Host-side parallel batch runner (splits modules across VM invocations) |
+| `.nanvix/run-regrtest.py` | Guest-side regrtest wrapper (invoked inside nanvixd VM) |
 | `NANVIX.md` | This documentation file |
 | `.nanvix/z.py` | ZScript subclass (build orchestration logic) |
 | `.nanvix/nanvix.toml` | Package manifest with dependency declarations |
@@ -285,9 +356,13 @@ The following changes were made to support Nanvix.
 | **No shared libraries** | Only static library (`libpython3.12.a`) is built |
 | **No pip** | Package installer not available (`--with-ensurepip=no`) |
 | **No IPv6** | IPv6 networking disabled |
-| **No test modules** | Test suite modules not built |
 | **Static linking only** | All executables are statically linked |
-| **Limited I/O** | Some file and network operations may be limited |
+| **No sockets** | `socketpair()` unavailable; asyncio event loop cannot start |
+| **No subprocess/fork** | `os.fork()`, `subprocess.Popen()` not supported |
+| **Pickle corruption** | `pickle` produces corrupt data on 32-bit Nanvix; likely C accelerator issue |
+| **Missing C test extensions** | `_testcapi` and `_testinternalcapi` not built |
+| **Round-half-up** | C library uses round-half-up instead of IEEE 754 round-half-to-even |
+| **Standalone ramfs limits** | A single shared ramfs image (~103 MB) is built once; batches share it across parallel VM invocations; some tests excluded for OOM |
 
 ---
 


### PR DESCRIPTION
## Summary

Enable and validate CPython's core language test suites on Nanvix, building the test infrastructure and progressively enabling test modules across six functional groups.

## Changes

### Test Infrastructure
- Add `is_nanvix` platform detection to `test.support` for gating Nanvix-specific test behavior
- Extend `make test` to invoke the CPython regrtest runner with sequential execution (`-j1`) for standalone mode
- Replace `NANVIX_TEST_MODULES` opt-in with `NANVIX_RELEASE` opt-out build variable
- Fix regrtest log cleanup crash and standalone OOM issues

### Enabled Test Modules (6 groups)
1. **Built-in types** — `test_int`, `test_list`, `test_tuple`, `test_dict`, `test_range`, `test_slice`, `test_types`
2. **Operators & expressions** — `test_operator`, `test_super`
3. **Grammar, syntax & compiler** — `test_ast`, `test_peepholer`, `test_code`, `test_compiler_codegen`, `test_compiler_assemble`
4. **Function calls & control flow** — `test_call`, `test_contextlib`, `test_exception_group`, `test_exceptions`
5. **Data types, math & exceptions** — `test_decimal`, `test_fractions`, `test_math`, `test_statistics`, `test_random`
6. **Stdlib & containers** — `test_builtin`, `test_reprlib`

### Test Adaptations
- Skip or patch tests that rely on unavailable Nanvix capabilities (subprocess, signals, multiprocessing, mmap, ctypes, large memory allocations)
- Document all skipped tests with rationale in `NANVIX_SKIP_LIST.md`

### Build & CI
- Bump zutil version to v0.5.0
- Auto-set `NANVIX_RELEASE=yes` in the release command
- Rewrite z bootstrapper to prefer local venv over global install

### Documentation
- Update `NANVIX.md` with test suite status, known limitations, and usage instructions

## Related Issue

Closes #321