### PR TITLE
[ci] E: Add 256MB image builds to CI matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -27,6 +27,7 @@ jobs:
     with:
       zutil-version: "v0.5.1"
       platforms: '["microvm"]'
+      memory-sizes: '["128mb","256mb"]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
     secrets:


### PR DESCRIPTION
## Summary

Add 256MB memory size to the `nanvix-ci.yml` CI workflow matrix.

### Changes

- Set `memory-sizes: '["128mb","256mb"]'` in the reusable workflow call, overriding the default `["128mb"]`.
- This enables CI to build and test against both 128MB and 256MB Nanvix images across all platform × process-mode combinations.