### PR TITLE
[ci] B: Update nanvix workflow refs to v1.3.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.1
     with:
       zutil-version: "v0.6.0"
       platforms: '["microvm"]'


### PR DESCRIPTION
Updates `nanvix/workflows` ref from `v1.3.0` → `v1.3.1`.

v1.3.0 caused `startup_failure` across all consumer repos because the `update-nanvix-version` job declared `pull-requests: write` at the job level without matching workflow-level permissions. v1.3.1 fixes this.

See: https://github.com/nanvix/workflows/pull/20