### PR TITLE
[ci] B: Update nanvix workflow refs to v1.3.2

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.1
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.2
     with:
       zutil-version: "v0.6.0"
       platforms: '["microvm"]'


### PR DESCRIPTION
Updates nanvix/workflows ref v1.3.1 → v1.3.2. Removes unsupported top-level concurrency that caused startup_failure. See: https://github.com/nanvix/workflows/pull/21