### PR TITLE
[ci] B: Update nanvix workflow refs to v1.3.3

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.2
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.3.3
     with:
       zutil-version: "v0.6.0"
       platforms: '["microvm"]'


### PR DESCRIPTION
Updates v1.3.2 → v1.3.3. Removes pull-requests permission that exceeds caller grants. See: https://github.com/nanvix/workflows/pull/22