### PR TITLE
Windows cross-build support via Docker host-side re-invocation

### DIFF
--- a/.nanvix/mk/common.mk
+++ b/.nanvix/mk/common.mk
@@ -3,33 +3,7 @@
 # Copyright(c) The Maintainers of Nanvix.
 # Licensed under the MIT License.
 
-# Nanvix Docker image for cross-compilation (used as fallback if native toolchain not found)
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
-
-# Platform and deployment configuration (passed by nanvix-zutil / z.py)
-PLATFORM ?= microvm
-PROCESS_MODE ?= standalone
-MEMORY_SIZE ?= 256mb
-
-# Set to 'yes' for release packaging: disables C test extension modules and
-# skips regrtest.  Dev builds (the default) compile test extensions and run
-# regrtest so that every `./z test` invocation exercises the test suite.
-# NOTE: changing this between builds requires 'make -f Makefile.nanvix distclean'
-# followed by a full rebuild so the new configure flags are picked up.
-NANVIX_RELEASE ?= no
-
-# Space-separated list of stdlib test modules to run via 'python3 -m test'.
-# Keep this list to pure-Python, non-networking tests known to pass on Nanvix.
-# Expand it as more tests are enabled (see issues linked from #320).
-#
-# Trimmed to validated-green modules only. The remaining modules fail due to
-# missing platform capabilities (fork/exec, tempdir, asyncio event loop) or
-# memory limits (test_json MemoryError). Those belong to #321 and #322 where
-# each module gets individual skip/xfail annotations before being re-added.
-#   Deferred: test_builtin test_dict test_list test_str test_tuple test_set
-#             test_bytes test_int test_json test_datetime test_os test_pathlib
-#             test_io
-NANVIX_TEST_LIST ?= test_float test_complex test_bool test_struct
+include $(dir $(lastword $(MAKEFILE_LIST)))defaults.mk
 
 # Nanvix cross-compilation configuration
 ifdef CONFIG_NANVIX
@@ -117,11 +91,6 @@ ifdef CONFIG_NANVIX
   # archive paths portably (e.g. $(NANVIX_SYSROOT)/lib/numpy/*.a).
   NANVIX_SYSROOT := $(SYSROOT_PATH)
   export NANVIX_SYSROOT
-
-  # INSTALL_PREFIX: the prefix baked into the python binary (sys.prefix, sys.path).
-  # Defaults to /sysroot which matches the runtime layout on Nanvix and keeps
-  # DESTDIR installs predictable (files land under DESTDIR/sysroot/...).
-  INSTALL_PREFIX ?= /sysroot
 else
   # Allow clean target without CONFIG_NANVIX
   ifneq ($(MAKECMDGOALS),clean)

--- a/.nanvix/mk/defaults.mk
+++ b/.nanvix/mk/defaults.mk
@@ -1,0 +1,28 @@
+# defaults.mk - Shared variable defaults for all Makefile paths
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Included by common.mk (native / Linux-Docker builds) and docker-host.mk
+# (Windows host-side re-invocation) so that platform defaults are defined
+# in exactly one place.
+
+# Nanvix Docker image for cross-compilation
+NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+
+# Platform and deployment configuration (passed by nanvix-zutil / z.py)
+PLATFORM ?= microvm
+PROCESS_MODE ?= standalone
+MEMORY_SIZE ?= 256mb
+
+# Install prefix baked into the python binary (sys.prefix, sys.path)
+INSTALL_PREFIX ?= /sysroot
+
+# Set to 'yes' for release packaging
+NANVIX_RELEASE ?= no
+
+# Space-separated list of stdlib test modules to run via regrtest.
+NANVIX_TEST_LIST ?= test_float test_complex test_bool test_struct
+
+# Nanvix sysroot directory (set by z.py / environment)
+NANVIX_HOME ?= $(HOME)/nanvix

--- a/.nanvix/mk/docker-host.mk
+++ b/.nanvix/mk/docker-host.mk
@@ -1,0 +1,180 @@
+# docker-host.mk - Windows Docker host-side re-invocation
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# When DOCKER_HOST_MODE=windows is passed, all build targets are re-invoked
+# inside a Docker container with tar-based source copying to avoid the
+# Docker Desktop bind mount I/O penalty.
+#
+# The inner make invocation runs without DOCKER_HOST_MODE, so it uses the
+# native toolchain inside the container (no Docker wrapping).
+
+ifdef DOCKER_HOST_MODE
+
+include $(dir $(lastword $(MAKEFILE_LIST)))defaults.mk
+
+# Docker paths for the inner build
+_DHM_BUILD_DIR  := /tmp/build
+_DHM_WS_MOUNT   := /mnt/workspace
+_DHM_SYS_MOUNT  := /mnt/sysroot
+
+# Files that need CRLF -> LF normalization for autotools
+_DHM_CRLF_FILES := configure config.guess config.sub install-sh \
+    Modules/makesetup Modules/Setup \
+    Modules/Setup.bootstrap.in Modules/Setup.stdlib.in \
+    Modules/config.c.in Modules/ld_so_aix.in \
+    Makefile.pre.in pyconfig.h.in aclocal.m4 configure.ac \
+    Misc/python.pc.in Misc/python-embed.pc.in \
+    Misc/python-config.sh.in Misc/python-config.in
+
+# Tar excludes (saves ~200MB of transfer)
+_DHM_TAR_EXCLUDES := --exclude=.git --exclude=.nanvix/venv \
+    --exclude=.nanvix/cache --exclude=.nanvix/sysroot \
+    --exclude=.nanvix/buildroot --exclude=Doc \
+    --exclude=Lib/idlelib --exclude=Lib/tkinter \
+    --exclude=Lib/turtledemo --exclude=Lib/ensurepip \
+    --exclude=PC --exclude=PCbuild
+
+# Inner make arguments (no DOCKER_HOST_MODE => runs natively inside container)
+_DHM_INNER_ARGS := make -f Makefile.nanvix \
+    CONFIG_NANVIX=y \
+    NANVIX_HOME=$(_DHM_SYS_MOUNT) \
+    NANVIX_TOOLCHAIN=/opt/nanvix \
+    PLATFORM=$(PLATFORM) \
+    PROCESS_MODE=$(PROCESS_MODE) \
+    MEMORY_SIZE=$(MEMORY_SIZE) \
+    INSTALL_PREFIX=$(INSTALL_PREFIX) \
+    NANVIX_RELEASE=$(NANVIX_RELEASE)
+
+# Build output files to copy back to the host workspace
+_DHM_OUTPUT_FILES := python python.exe python.elf python.wasm libpython3.12.a
+
+# docker-host-run: sync sources into container, fix CRLF, run inner make,
+# copy outputs back.
+#   $(1) = inner make targets
+define docker-host-run
+docker run --rm \
+    -v $(CURDIR):$(_DHM_WS_MOUNT) \
+    -v $(abspath $(NANVIX_HOME)):$(_DHM_SYS_MOUNT):ro \
+    -w $(_DHM_BUILD_DIR) \
+    -e HOME=/tmp \
+    $(NANVIX_DOCKER_IMAGE) \
+    sh -c '\
+        mkdir -p $(_DHM_BUILD_DIR) && \
+        tar -cf - -C $(_DHM_WS_MOUNT) $(_DHM_TAR_EXCLUDES) . \
+            | tar -xf - -C $(_DHM_BUILD_DIR) && \
+        for f in $(_DHM_CRLF_FILES); do \
+            if [ -f "$$f" ]; then sed "s/\r$$//" "$$f" > /tmp/_crlf.tmp && \
+            cat /tmp/_crlf.tmp > "$$f"; fi; done && \
+        rm -f .nanvix-configured conftest* config.cache && \
+        $(_DHM_INNER_ARGS) $(1); rc=$$?; \
+        for f in $(_DHM_OUTPUT_FILES); do \
+            [ -f $(_DHM_BUILD_DIR)/$$f ] && \
+            cp -f $(_DHM_BUILD_DIR)/$$f $(_DHM_WS_MOUNT)/$$f; \
+        done; exit $$rc'
+endef
+
+# docker-host-test-prepare: like docker-host-run but also copies the test
+# staging directory back to the host so that nanvixd can run natively.
+#   $(1) = inner make prepare target(s)
+define docker-host-test-prepare
+docker run --rm \
+    -v $(CURDIR):$(_DHM_WS_MOUNT) \
+    -v $(abspath $(NANVIX_HOME)):$(_DHM_SYS_MOUNT):ro \
+    -w $(_DHM_BUILD_DIR) \
+    -e HOME=/tmp \
+    $(NANVIX_DOCKER_IMAGE) \
+    sh -c '\
+        mkdir -p $(_DHM_BUILD_DIR) && \
+        tar -cf - -C $(_DHM_WS_MOUNT) $(_DHM_TAR_EXCLUDES) . \
+            | tar -xf - -C $(_DHM_BUILD_DIR) && \
+        for f in $(_DHM_CRLF_FILES); do \
+            if [ -f "$$f" ]; then sed "s/\r$$//" "$$f" > /tmp/_crlf.tmp && \
+            cat /tmp/_crlf.tmp > "$$f"; fi; done && \
+        rm -f .nanvix-configured conftest* config.cache && \
+        $(_DHM_INNER_ARGS) $(1); rc=$$?; \
+        for f in $(_DHM_OUTPUT_FILES); do \
+            [ -f $(_DHM_BUILD_DIR)/$$f ] && \
+            cp -f $(_DHM_BUILD_DIR)/$$f $(_DHM_WS_MOUNT)/$$f; \
+        done; \
+        rm -rf $(_DHM_WS_MOUNT)/.nanvix/_test_staging; \
+        if [ -d $(_DHM_BUILD_DIR)/.nanvix/_test_staging ]; then \
+            cp -a $(_DHM_BUILD_DIR)/.nanvix/_test_staging \
+                   $(_DHM_WS_MOUNT)/.nanvix/_test_staging; \
+            chmod -R a+rwX $(_DHM_WS_MOUNT)/.nanvix/_test_staging; \
+        fi; \
+        if [ -f /tmp/cpython-rootfs.img ]; then \
+            cp -f /tmp/cpython-rootfs.img \
+                   $(_DHM_WS_MOUNT)/.nanvix/_test_staging/cpython-rootfs.img; \
+        fi; \
+        exit $$rc'
+endef
+
+# Test staging directory on the host (populated by docker-host-test-prepare)
+_DHM_TEST_STAGING := $(CURDIR)/.nanvix/_test_staging
+
+# Determine the prepare target name and test script content based on
+# deployment mode.  The test script runs via WSL on the host.
+ifeq ($(PROCESS_MODE),standalone)
+  _DHM_TEST_PREPARE := test-hello-standalone-prepare test-regrtest-standalone
+  _DHM_RAMFS_IMG := $(_DHM_TEST_STAGING)/cpython-rootfs.img
+else ifeq ($(PROCESS_MODE),single-process)
+  _DHM_TEST_PREPARE := test-hello-single-process-prepare test-regrtest-single-process-prepare
+else
+  _DHM_TEST_PREPARE := test-hello-multi-process-prepare test-regrtest-multi-process-prepare
+endif
+
+# Convert a Windows path to a WSL /mnt/ path via wslpath at Make parse time.
+_dhm_to_wsl = $(shell wsl wslpath -a '$(subst \,/,$(1))')
+
+# Path to the host-side test runner script (runs natively on Windows and Linux)
+_DHM_TEST_RUNNER := $(dir $(lastword $(MAKEFILE_LIST)))test-run-host.py
+
+# Regrtest arguments: pass test list for non-release, non-standalone builds
+ifeq ($(PROCESS_MODE),standalone)
+  _DHM_REGRTEST_ARGS :=
+else ifeq ($(NANVIX_RELEASE),yes)
+  _DHM_REGRTEST_ARGS :=
+else
+  _DHM_REGRTEST_ARGS := $(NANVIX_TEST_LIST)
+endif
+
+# Override main targets when running from Windows host
+all: build
+
+build:
+	$(call docker-host-run,build)
+
+# Test: cross-compile and stage inside Docker, then run nanvixd on the host.
+# Phase 1 (Docker): build, install, ramfs, strip — everything needing the
+#   cross-toolchain or Linux tools.
+# Phase 2 (host): execute nanvixd.elf natively on Windows.
+#   nanvixd.elf is a Linux ELF binary that runs via Windows WSL interop.
+#   The Python test runner invokes it directly (no explicit WSL call).
+test:
+	@echo "=== Phase 1: Preparing test artifacts inside Docker ==="
+	$(call docker-host-test-prepare,$(_DHM_TEST_PREPARE))
+	@echo "=== Phase 2: Running tests on host ==="
+	python $(_DHM_TEST_RUNNER) $(subst /,\,$(_DHM_TEST_STAGING)) $(PROCESS_MODE) $(_DHM_REGRTEST_ARGS)
+	-rmdir /s /q $(subst /,\,$(_DHM_TEST_STAGING)) 2>nul
+	@echo "		*** CPython tests PASSED ***"
+
+install:
+	$(call docker-host-run,install)
+
+package:
+	$(call docker-host-run,package)
+
+# Clean does not need Docker; just remove local artifacts
+clean:
+	-del /f .nanvix-configured python.elf python.exe 2>nul
+	-rmdir /s /q .nanvix\_test_staging 2>nul
+	-rmdir /s /q _test_staging 2>nul
+	-rmdir /s /q staging 2>nul
+
+distclean: clean
+
+.PHONY: all build test install package clean distclean
+
+endif # DOCKER_HOST_MODE

--- a/.nanvix/mk/test-multi-process.mk
+++ b/.nanvix/mk/test-multi-process.mk
@@ -8,8 +8,12 @@
 
 include .nanvix/mk/test-common.mk
 
-# test-hello-multi-process: run hello test via nanvixd with direct file access
-test-hello-multi-process: test-stage
+# test-hello-multi-process-prepare: build and install into staging.
+test-hello-multi-process-prepare: test-stage
+
+# test-hello-multi-process-run: execute hello test via nanvixd.
+# Runs on the host — no cross-toolchain needed.
+test-hello-multi-process-run:
 	@echo "Test: Hello world..."
 	cd $(TEST_STAGING)/sysroot && \
 		{ \
@@ -26,8 +30,14 @@ test-hello-multi-process: test-stage
 		}
 	$(call validate-hello,/tmp/cpython_test.log)
 
-# test-regrtest-multi-process: run stdlib regression tests
-test-regrtest-multi-process: test-stage
+# test-hello-multi-process: combined prepare + run (for native Linux builds)
+test-hello-multi-process: test-hello-multi-process-prepare test-hello-multi-process-run
+
+# test-regrtest-multi-process-prepare: build and install into staging.
+test-regrtest-multi-process-prepare: test-stage
+
+# test-regrtest-multi-process-run: execute stdlib regression tests via nanvixd.
+test-regrtest-multi-process-run:
 ifneq ($(NANVIX_RELEASE),yes)
 	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
 	cd $(TEST_STAGING)/sysroot && \
@@ -46,7 +56,10 @@ else
 	@echo "Test: regrtest skipped (NANVIX_RELEASE=yes)"
 endif
 
+# test-regrtest-multi-process: combined prepare + run (for native Linux builds)
+test-regrtest-multi-process: test-regrtest-multi-process-prepare test-regrtest-multi-process-run
+
 # Aggregate test target for multi-process mode
 test: test-hello-multi-process test-regrtest-multi-process test-cleanup
 
-.PHONY: test-hello-multi-process test-regrtest-multi-process test
+.PHONY: test-hello-multi-process-prepare test-hello-multi-process-run test-hello-multi-process test-regrtest-multi-process-prepare test-regrtest-multi-process-run test-regrtest-multi-process test

--- a/.nanvix/mk/test-run-host.py
+++ b/.nanvix/mk/test-run-host.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# test-run-host.py - Run nanvixd tests on the host (outside Docker/container).
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Usage: test-run-host.py <staging-dir> <process-mode> [test-list...]
+#
+# Unified test runner for both Windows and Linux hosts.
+# On Windows, nanvixd.elf is invoked via WSL with paths translated by wslpath.
+# On Linux, staging is copied to /tmp for writable access and run directly.
+
+import argparse
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+IS_WINDOWS = platform.system() == "Windows"
+
+
+def die(msg):
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def validate_test_names(test_list):
+    """Validate that test module names contain only alphanumeric and underscores."""
+    for t in test_list:
+        if not re.fullmatch(r"[A-Za-z0-9_]+", t):
+            die(f"Invalid test module name: '{t}'")
+
+
+def to_wsl_path(win_path):
+    """Convert a Windows path to a WSL /mnt/ path via wslpath."""
+    unix = win_path.replace("\\", "/")
+    result = subprocess.run(
+        ["wsl", "wslpath", "-a", unix],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def run_command(cmd, timeout, log_path):
+    """Run a command, capture output to log_path, return (exit_code, output, elapsed_ms)."""
+    start = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        output = (result.stdout + "\n" + result.stderr).strip()
+        with open(log_path, "w", encoding="utf-8") as f:
+            f.write(output)
+        return result.returncode, output, elapsed_ms
+    except subprocess.TimeoutExpired:
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        die(f"Command timed out after {timeout}s")
+
+
+def prepare_workdir_linux(staging):
+    """Copy staging to a writable /tmp location (Linux only)."""
+    workdir = "/tmp/cpython-test-staging"
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    shutil.copytree(staging, workdir)
+    # Make writable
+    for root, dirs, files in os.walk(workdir):
+        for d in dirs:
+            os.chmod(os.path.join(root, d), 0o755)
+        for f in files:
+            os.chmod(os.path.join(root, f), 0o644)
+    return workdir
+
+
+def build_hello_cmd(mode, staging_dir):
+    """Build the command list for the hello-world test."""
+    if IS_WINDOWS:
+        wsl_staging = to_wsl_path(os.path.abspath(staging_dir))
+        nanvixd = f"{wsl_staging}/sysroot/bin/nanvixd.elf"
+        python_bin = f"{wsl_staging}/sysroot/bin/python3.12"
+        if mode == "standalone":
+            ramfs = f"{wsl_staging}/cpython-rootfs.img"
+            bin_dir = f"{wsl_staging}/sysroot/bin"
+            return [
+                "wsl", "--", nanvixd,
+                "-bin-dir", bin_dir, "-ramfs", ramfs,
+                "--", python_bin,
+                "-B /test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1",
+            ]
+        else:
+            inner = f"cd '{wsl_staging}/sysroot' && '{nanvixd}' -- '{python_bin}' ./test_hello.py 2>&1"
+            return ["wsl", "--", "bash", "-c", inner]
+    else:
+        # Linux: use the /tmp workdir
+        sysroot = os.path.join(staging_dir, "sysroot")
+        nanvixd = "./bin/nanvixd.elf"
+        python_bin = "./bin/python3.12"
+        if mode == "standalone":
+            ramfs = os.path.join(staging_dir, "cpython-rootfs.img")
+            return [
+                nanvixd,
+                "-bin-dir", "./bin", "-ramfs", ramfs,
+                "--", python_bin,
+                "-B /test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1",
+            ]
+        else:
+            return [nanvixd, "--", python_bin, "./test_hello.py"]
+
+
+def build_regrtest_cmd(staging_dir, test_list):
+    """Build the command list for regrtest."""
+    if IS_WINDOWS:
+        wsl_staging = to_wsl_path(os.path.abspath(staging_dir))
+        nanvixd = f"{wsl_staging}/sysroot/bin/nanvixd.elf"
+        python_bin = f"{wsl_staging}/sysroot/bin/python3.12"
+        test_args = " ".join(test_list)
+        inner = (
+            f"cd '{wsl_staging}/sysroot' && "
+            f"'{nanvixd}' -- '{python_bin}' -m test --timeout=120 {test_args} 2>&1"
+        )
+        return ["wsl", "--", "bash", "-c", inner]
+    else:
+        nanvixd = "./bin/nanvixd.elf"
+        python_bin = "./bin/python3.12"
+        return [nanvixd, "--", python_bin, "-m", "test", "--timeout=120"] + test_list
+
+
+def run_hello_test(mode, staging_dir, log_dir):
+    """Run the hello-world test and validate output."""
+    print(f"Test: Hello world ({mode})...")
+    log_path = os.path.join(log_dir, "cpython_test.log")
+    cmd = build_hello_cmd(mode, staging_dir)
+
+    # On Linux, cd into sysroot before running
+    cwd = None
+    if not IS_WINDOWS:
+        cwd = os.path.join(staging_dir, "sysroot")
+
+    start = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired:
+        die("Hello test timed out after 120s")
+
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    output = (result.stdout + "\n" + result.stderr).strip()
+    with open(log_path, "w", encoding="utf-8") as f:
+        f.write(output)
+
+    print(f"  Execution time: {elapsed_ms} ms")
+
+    if result.returncode != 0:
+        print(f"  FAIL: Hello test exited with status {result.returncode}")
+        print(output)
+        sys.exit(1)
+
+    # Validate expected output marker
+    for line in output.splitlines():
+        if line.startswith("CPYTHON_TEST_HELLO:"):
+            print(f"  PASS: {line.strip()}")
+            return
+
+    print("  FAIL: Hello test did not produce expected output")
+    print(output)
+    sys.exit(1)
+
+
+def run_regrtest(staging_dir, test_list, log_dir):
+    """Run stdlib regression tests."""
+    print(f"Test: regrtest ({len(test_list)} modules)...")
+    log_path = os.path.join(log_dir, "cpython_regrtest.log")
+    cmd = build_regrtest_cmd(staging_dir, test_list)
+
+    cwd = None
+    if not IS_WINDOWS:
+        cwd = os.path.join(staging_dir, "sysroot")
+
+    start = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired:
+        die("regrtest timed out after 600s")
+
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    output = (result.stdout + "\n" + result.stderr).strip()
+    with open(log_path, "w", encoding="utf-8") as f:
+        f.write(output)
+
+    print(f"  Execution time: {elapsed_ms} ms")
+
+    if result.returncode != 0:
+        print(f"  FAIL: regrtest exited with status {result.returncode}")
+        print(output)
+        sys.exit(1)
+
+    print("  PASS: regrtest completed")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run nanvixd tests on the host (Windows or Linux).",
+    )
+    parser.add_argument("staging_dir", help="Path to the test staging directory")
+    parser.add_argument(
+        "process_mode",
+        choices=["standalone", "multi-process", "single-process"],
+        help="Deployment process mode",
+    )
+    parser.add_argument(
+        "test_list", nargs="*", default=[],
+        help="Stdlib test modules for regrtest",
+    )
+    args = parser.parse_args()
+
+    staging_dir = args.staging_dir
+    mode = args.process_mode
+    test_list = args.test_list
+
+    # Validate test names
+    validate_test_names(test_list)
+
+    # Verify WSL on Windows
+    if IS_WINDOWS and shutil.which("wsl") is None:
+        die("WSL is required but was not found. "
+            "Install WSL: https://learn.microsoft.com/windows/wsl/install")
+
+    # Verify staging directory
+    if IS_WINDOWS:
+        nanvixd_path = os.path.join(staging_dir, "sysroot", "bin", "nanvixd.elf")
+    else:
+        nanvixd_path = os.path.join(staging_dir, "sysroot", "bin", "nanvixd.elf")
+
+    if not os.path.exists(nanvixd_path):
+        die(f"nanvixd.elf not found in staging: {nanvixd_path}")
+
+    # On Linux, copy staging to a writable /tmp location
+    if not IS_WINDOWS:
+        staging_dir = prepare_workdir_linux(staging_dir)
+
+    # Log directory
+    if IS_WINDOWS:
+        log_dir = staging_dir
+    else:
+        log_dir = "/tmp"
+
+    # Run hello-world test
+    run_hello_test(mode, staging_dir, log_dir)
+
+    # Run regrtest if applicable
+    if mode != "standalone" and test_list:
+        run_regrtest(staging_dir, test_list, log_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/.nanvix/mk/test-single-process.mk
+++ b/.nanvix/mk/test-single-process.mk
@@ -8,8 +8,12 @@
 
 include .nanvix/mk/test-common.mk
 
-# test-hello-single-process: run hello test via nanvixd with direct file access
-test-hello-single-process: test-stage
+# test-hello-single-process-prepare: build and install into staging.
+test-hello-single-process-prepare: test-stage
+
+# test-hello-single-process-run: execute hello test via nanvixd.
+# Runs on the host — no cross-toolchain needed.
+test-hello-single-process-run:
 	@echo "Test: Hello world (single-process)..."
 	cd $(TEST_STAGING)/sysroot && \
 		{ \
@@ -26,8 +30,14 @@ test-hello-single-process: test-stage
 		}
 	$(call validate-hello,/tmp/cpython_test.log)
 
-# test-regrtest-single-process: run stdlib regression tests
-test-regrtest-single-process: test-stage
+# test-hello-single-process: combined prepare + run (for native Linux builds)
+test-hello-single-process: test-hello-single-process-prepare test-hello-single-process-run
+
+# test-regrtest-single-process-prepare: build and install into staging.
+test-regrtest-single-process-prepare: test-stage
+
+# test-regrtest-single-process-run: execute stdlib regression tests via nanvixd.
+test-regrtest-single-process-run:
 ifneq ($(NANVIX_RELEASE),yes)
 	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
 	cd $(TEST_STAGING)/sysroot && \
@@ -46,7 +56,10 @@ else
 	@echo "Test: regrtest skipped (NANVIX_RELEASE=yes)"
 endif
 
+# test-regrtest-single-process: combined prepare + run (for native Linux builds)
+test-regrtest-single-process: test-regrtest-single-process-prepare test-regrtest-single-process-run
+
 # Aggregate test target for single-process mode
 test: test-hello-single-process test-regrtest-single-process test-cleanup
 
-.PHONY: test-hello-single-process test-regrtest-single-process test
+.PHONY: test-hello-single-process-prepare test-hello-single-process-run test-hello-single-process test-regrtest-single-process-prepare test-regrtest-single-process-run test-regrtest-single-process test

--- a/.nanvix/mk/test-standalone.mk
+++ b/.nanvix/mk/test-standalone.mk
@@ -19,8 +19,9 @@ RAMFS_IMG = /tmp/cpython-rootfs.img
 
 include .nanvix/mk/ramfs.mk
 
-# test-hello-standalone: build ramfs from a trimmed copy, run hello test via nanvixd
-test-hello-standalone: test-stage
+# test-hello-standalone-prepare: build, install, create ramfs, strip binary.
+# Everything that requires the cross-toolchain or Linux tools.
+test-hello-standalone-prepare: test-stage
 	@# Prepare ramfs content: copy sysroot into a separate tree, then trim it.
 	@# This keeps the original staging tree with binaries intact for invocation.
 	@rm -rf $(TEST_RAMFS_CONTENT)
@@ -43,6 +44,10 @@ else
 	$(if $(wildcard $(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip),\
 		$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip --strip-debug $(TEST_STAGING)/sysroot/bin/python3.12 2>/dev/null || true)
 endif
+
+# test-hello-standalone-run: execute hello test via nanvixd.
+# Runs on the host — no cross-toolchain needed.
+test-hello-standalone-run:
 	@echo "Test: Hello world (standalone)..."
 	cd $(TEST_STAGING)/sysroot && \
 		{ \
@@ -65,6 +70,9 @@ endif
 	@rm -f $(RAMFS_IMG)
 	@rm -rf $(TEST_RAMFS_CONTENT)
 
+# test-hello-standalone: combined prepare + run (for native Linux builds)
+test-hello-standalone: test-hello-standalone-prepare test-hello-standalone-run
+
 # test-regrtest-standalone: regrtest is skipped in standalone mode (ramfs memory limit)
 test-regrtest-standalone:
 	@echo "Test: regrtest ($(words $(NANVIX_TEST_LIST)) modules)..."
@@ -73,4 +81,4 @@ test-regrtest-standalone:
 # Aggregate test target for standalone mode
 test: test-hello-standalone test-regrtest-standalone test-cleanup
 
-.PHONY: test-hello-standalone test-regrtest-standalone test
+.PHONY: test-hello-standalone-prepare test-hello-standalone-run test-hello-standalone test-regrtest-standalone test

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -11,11 +11,23 @@ Usage:
     ./z clean     # Remove build artifacts
 """
 
+import json
 import os
 import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
 from pathlib import Path
 
-from nanvix_zutil import CFG_SYSROOT, CFG_TOOLCHAIN, EXIT_MISSING_DEP, ZScript, log
+from nanvix_zutil import (
+    CFG_SYSROOT,
+    CFG_TOOLCHAIN,
+    EXIT_MISSING_DEP,
+    ZScript,
+    log,
+    suffix_dep,
+)
 
 # Makefile variable names (build-system-specific).
 _MAKE_VAR_CONFIG = "CONFIG_NANVIX"
@@ -32,8 +44,43 @@ _MAKE_VAR_RELEASE = "NANVIX_RELEASE"
 _DEFAULT_INSTALL_PREFIX = "/sysroot"
 
 
+# Map dependency names to the library files they install into buildroot/lib.
+_DEP_EXPECTED_LIBS: dict[str, list[str]] = {
+    "bzip2": ["libbz2.a"],
+    "libffi": ["libffi.a"],
+    "zlib": ["libz.a"],
+    "sqlite": ["libsqlite3.a"],
+    "openssl": ["libssl.a", "libcrypto.a"],
+}
+
+
 class CPythonBuild(ZScript):
     """Build script for nanvix/cpython."""
+
+    # ---- Make invocation -------------------------------------------------
+
+    def _run_make(self, make_args: list[str]) -> None:
+        """Execute a make command, delegating Docker wrapping to the Makefile.
+
+        On Windows, passes ``DOCKER_HOST_MODE=windows`` so that
+        ``.nanvix/mk/docker-host.mk`` handles tar-based source copying,
+        CRLF normalization, and output copy-back inside Docker.
+        """
+        if sys.platform == "win32":
+            if not shutil.which("docker"):
+                log.fatal(
+                    "Docker is required for cross-compilation on Windows "
+                    "but was not found on PATH.",
+                    code=EXIT_MISSING_DEP,
+                    hint="Install Docker Desktop: "
+                    "https://docs.docker.com/desktop/install/windows/",
+                )
+            # Insert DOCKER_HOST_MODE right after CONFIG_NANVIX=y so the
+            # Makefile activates the host-side Docker wrapper.
+            make_args.insert(4, "DOCKER_HOST_MODE=windows")
+        self.run(*make_args, cwd=self.repo_root, docker=False)
+
+    # ---- Make argument builder -------------------------------------------
 
     def _make_args(self, *targets: str, with_install_prefix: bool = True) -> list[str]:
         """Build the common make argument list."""
@@ -75,11 +122,31 @@ class CPythonBuild(ZScript):
     def setup(self) -> None:
         """Download the Nanvix sysroot and dependencies.
 
-        After the base setup installs dependencies into the buildroot,
-        merge buildroot libraries and headers into the sysroot so the
-        existing Makefile.nanvix can find them at its expected paths.
+        Overrides the base ``setup()`` to handle dependency resolution
+        with fallback: when a dependency hasn't been built for the exact
+        sysroot version, the newest compatible release is used instead.
+
+        The base class is not called for dependency installation because
+        its retry loop wastes ~30 seconds on expected 404s before raising.
         """
-        super().setup()
+        # ---- Step 1: download and verify the sysroot (from base class) ----
+        from nanvix_zutil import Sysroot, CFG_GH_TOKEN
+
+        self.sysroot = Sysroot.download(
+            machine=self.config.machine,
+            deployment_mode=self.config.deployment_mode,
+            memory_size=self.config.memory_size,
+            tag=self.manifest.sysroot_ref.value,
+            gh_token=self.config.get(CFG_GH_TOKEN),
+            dest=self.nanvix_dir / "sysroot",
+            config=self.config,
+        )
+        self.sysroot.verify(self.sysroot_required_files())
+        self.config.set(CFG_SYSROOT, str(self.sysroot.path))
+
+        # ---- Step 2: install dependencies with fallback resolution ----
+        self._install_missing_deps()
+        self.config.save()
 
         buildroot = self.nanvix_dir / "buildroot"
         sysroot = self.config.get(CFG_SYSROOT, "")
@@ -104,37 +171,187 @@ class CPythonBuild(ZScript):
 
     def build(self) -> None:
         """Cross-compile python.elf and libpython3.12.a for Nanvix."""
-        self.run(*self._make_args("all"), cwd=self.repo_root)
+        self._run_make(self._make_args("all"))
 
     def test(self) -> None:
-        """Run the CPython test suite.
-
-        Without targets, runs the full suite (hello-world on nanvixd.elf).
-        With targets (e.g. ``./z test -- test-smoke test-integration``), passes
-        them directly to the Makefile.
-        """
+        """Run the CPython test suite."""
         targets = self.targets if self.targets else ["test"]
-        self.run(*self._make_args(*targets), cwd=self.repo_root)
+        self._run_make(self._make_args(*targets))
 
     def release(self) -> None:
-        """Package the CPython release tarballs and verify them.
-
-        Release builds always set NANVIX_RELEASE=yes to strip C test extension
-        modules and skip regrtest, producing a trimmed production artifact.
-        """
+        """Package the CPython release tarballs and verify them."""
         os.environ[_MAKE_VAR_RELEASE] = "yes"
-        self.run(*self._make_args("package"), cwd=self.repo_root)
-        self.run(*self._make_args("verify-package"), cwd=self.repo_root)
+        self._run_make(self._make_args("package"))
+        self._run_make(self._make_args("verify-package"))
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        self.run(
-            "make",
-            "-f",
-            "Makefile.nanvix",
-            "clean",
-            cwd=self.repo_root,
-        )
+        if sys.platform == "win32":
+            # On Windows, clean does not need Docker — just remove local files.
+            for name in (".nanvix-configured", "python.elf", "python.exe"):
+                p = self.repo_root / name
+                if p.is_file():
+                    p.unlink()
+                    log.info(f"Removed {name}")
+            for name in ("_test_staging", "staging"):
+                p = self.repo_root / name
+                if p.is_dir():
+                    shutil.rmtree(p)
+                    log.info(f"Removed {name}/")
+            test_staging = self.repo_root / ".nanvix" / "_test_staging"
+            if test_staging.is_dir():
+                shutil.rmtree(test_staging)
+                log.info("Removed .nanvix/_test_staging/")
+        else:
+            self.run(
+                "make", "-f", "Makefile.nanvix", "clean",
+                cwd=self.repo_root,
+            )
+
+    # ---- Fallback dependency download ------------------------------------
+
+    def _install_missing_deps(self) -> None:
+        """Download missing dependency libraries using fallback assets."""
+        buildroot = self.nanvix_dir / "buildroot"
+        buildroot.mkdir(parents=True, exist_ok=True)
+        lib_dir = buildroot / "lib"
+
+        sysroot_tag = self.manifest.sysroot_ref.value
+        nanvix_version = sysroot_tag.removeprefix("v") if sysroot_tag else ""
+
+        for dep in self.manifest.dependencies:
+            expected = _DEP_EXPECTED_LIBS.get(dep.name, [])
+            if not expected:
+                continue
+            if all((lib_dir / lib).exists() for lib in expected):
+                continue
+            resolved = suffix_dep(dep, nanvix_version) if nanvix_version else dep
+            self._download_dep_fallback(
+                resolved.name, resolved.repo, resolved.ref.value, buildroot
+            )
+
+    def _download_dep_fallback(
+        self, dep_name: str, repo: str, ref: str, buildroot: Path,
+    ) -> None:
+        """Download *dep_name* using a fallback asset variant.
+
+        First tries the exact release tag. If that fails (e.g. not yet
+        built for the current sysroot version), scans all releases for
+        the newest matching tag.
+        """
+        platform = self.config.machine
+        memory = self.config.memory_size
+        release = None
+
+        # 1. Try exact tag.
+        api_url = f"https://api.github.com/repos/{repo}/releases/tags/{ref}"
+        try:
+            req = urllib.request.Request(api_url)
+            req.add_header("Accept", "application/vnd.github+json")
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                release = json.loads(resp.read())
+        except (OSError, ValueError, urllib.error.URLError):
+            pass
+
+        # 2. Fallback: find the newest release whose tag shares the same
+        #    upstream version prefix (e.g. "1.3.1-nanvix-*").
+        if release is None:
+            prefix = ref.split("-nanvix-")[0] if "-nanvix-" in ref else ref
+            releases_url = f"https://api.github.com/repos/{repo}/releases?per_page=100"
+            try:
+                req = urllib.request.Request(releases_url)
+                req.add_header("Accept", "application/vnd.github+json")
+                with urllib.request.urlopen(req, timeout=30) as resp:
+                    all_releases = json.loads(resp.read())
+            except (OSError, ValueError, urllib.error.URLError) as exc:
+                log.warning(f"Cannot query GitHub releases for {dep_name}: {exc}")
+                return
+            for rel in all_releases:
+                tag = rel.get("tag_name", "")
+                if tag.startswith(f"{prefix}-nanvix-"):
+                    release = rel
+                    log.info(f"Using {tag} (fallback for {ref})")
+                    break
+            if release is None:
+                log.warning(f"No compatible release for {dep_name} ({ref})")
+                return
+
+        assets = {
+            a["name"]: a["browser_download_url"]
+            for a in release.get("assets", [])
+            if a["name"].endswith(".tar.bz2")
+        }
+
+        deployment = self.config.deployment_mode
+        candidates = [
+            f"{dep_name}-{platform}-{deployment}-{memory}.tar.bz2",
+            f"{dep_name}-{platform}-standalone-{memory}.tar.bz2",
+            f"{dep_name}-{platform}-single-process-{memory}.tar.bz2",
+            f"{dep_name}-{platform}-multi-process-{memory}.tar.bz2",
+        ]
+
+        download_url: str | None = None
+        chosen: str | None = None
+        for name in candidates:
+            if name in assets:
+                download_url = assets[name]
+                chosen = name
+                break
+
+        if not download_url:
+            # Prefer assets matching the platform.
+            for name, url in assets.items():
+                if platform in name and name.endswith(f"-{memory}.tar.bz2"):
+                    download_url = url
+                    chosen = name
+                    break
+        if not download_url:
+            for name, url in assets.items():
+                if name.endswith(f"-{memory}.tar.bz2"):
+                    download_url = url
+                    chosen = name
+                    break
+
+        if not download_url or not chosen:
+            log.warning(f"No compatible fallback asset for {dep_name}")
+            return
+
+        log.info(f"Downloading {chosen} (fallback for {dep_name})...")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarball_path = Path(tmpdir) / chosen
+            urllib.request.urlretrieve(download_url, str(tarball_path))
+
+            extract_dir = Path(tmpdir) / "extracted"
+            extract_dir.mkdir()
+            with tarfile.open(str(tarball_path), "r:bz2") as tf:
+                # Use filter="data" to prevent path traversal attacks.
+                # The filter parameter requires Python 3.12+; fall back
+                # gracefully on older interpreters.
+                try:
+                    tf.extractall(str(extract_dir), filter="data")
+                except TypeError:
+                    tf.extractall(str(extract_dir))
+
+            lib_dst = buildroot / "lib"
+            lib_dst.mkdir(parents=True, exist_ok=True)
+            for lib_file in extract_dir.rglob("*.a"):
+                shutil.copy2(lib_file, lib_dst / lib_file.name)
+                log.info(f"Installed {lib_file.name}")
+
+            inc_dst = buildroot / "include"
+            for inc_src in extract_dir.rglob("include"):
+                if not inc_src.is_dir():
+                    continue
+                inc_dst.mkdir(parents=True, exist_ok=True)
+                for item in inc_src.iterdir():
+                    target = inc_dst / item.name
+                    if item.is_dir():
+                        shutil.copytree(item, target, dirs_exist_ok=True)
+                    else:
+                        shutil.copy2(item, target)
+                log.info(f"Installed headers for {dep_name}")
+                break
 
 
 if __name__ == "__main__":

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -26,8 +26,18 @@
 #   .nanvix/mk/test-single-process.mk - single-process deployment mode tests
 #   .nanvix/mk/test-hyperlight.mk    - hyperlight machine type overrides
 #   .nanvix/mk/test-microvm.mk       - microvm machine type overrides
+#   .nanvix/mk/docker-host.mk        - Windows Docker host-side re-invocation
 #   .nanvix/mk/package-common.mk     - release packaging
 #   .nanvix/mk/verify-package.mk     - tarball verification
+
+# ---- Windows Docker host-side re-invocation ----
+# When DOCKER_HOST_MODE=windows is set, this overrides build/test/install/package
+# targets to re-invoke make inside a Docker container with tar-based source
+# copying (avoids Docker Desktop bind mount I/O penalty). All subsequent
+# includes are skipped because docker-host.mk provides its own target recipes.
+include .nanvix/mk/docker-host.mk
+
+ifndef DOCKER_HOST_MODE
 
 # ---- Common: variables, toolchain, configure, build, install, clean ----
 include .nanvix/mk/common.mk
@@ -57,3 +67,5 @@ include .nanvix/mk/package-common.mk
 include .nanvix/mk/verify-package.mk
 
 .PHONY: all
+
+endif # DOCKER_HOST_MODE

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -165,6 +165,23 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
 - Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`)
 
+### Building on Windows
+
+On Windows, cross-compilation is performed entirely inside Docker:
+
+```powershell
+# Prerequisites: Python 3, Make, and Docker Desktop must be installed and running.
+# Avoid GnuWin32 Make 3.81; prefer ezwinports Make 4.4.1 (winget install ezwinports.make).
+docker pull nanvix/toolchain:latest-minimal
+
+.\z.ps1 setup
+.\z.ps1 build
+.\z.ps1 test
+.\z.ps1 release
+```
+
+Set `NANVIX_DOCKER_IMAGE` to override the default Docker image.
+
 ### Using Native Toolchain
 
 ```bash


### PR DESCRIPTION
## Summary

Add support for cross-compiling CPython for Nanvix from a Windows host. All cross-compilation runs inside Docker with tar-based source copying (avoids Docker Desktop bind-mount I/O penalty), while test execution happens natively on the host via WSL interop.

## Changes

1. **Extract `defaults.mk`** - shared variable defaults moved from `common.mk` into a dedicated file, usable by multiple Makefile entry points.
2. **Split test targets into prepare/run phases** - decompose monolithic test targets into `*-prepare` (needs toolchain, runs in Docker) and `*-run` (host-only, runs nanvixd). Original combined targets preserved as aliases.
3. **Docker host-side re-invocation (`docker-host.mk`)** - when `DOCKER_HOST_MODE=windows` is set, all build/test/install/package targets re-invoke make inside Docker with tar-based source copying and CRLF normalization.
4. **Host-side test runner (`test-run-host.py`)** - Python script that executes nanvixd natively on Windows after Docker prepares the staging directory. Supports standalone, single-process, and multi-process modes.
5. **Windows support in `z.py`** - `_run_make()` injects `DOCKER_HOST_MODE=windows` on Windows, `clean()` removes local artifacts directly, and `setup()` uses GitHub API fallback for dependency resolution.
6. **Documentation** - `NANVIX.md` updated with Windows build instructions.

## Usage

```powershell
docker pull nanvix/toolchain:latest-minimal
.\z.ps1 setup
.\z.ps1 build
.\z.ps1 test
.\z.ps1 release
```
