### PR TITLE
[build] Update Default Platform Config

### DIFF
--- a/.nanvix/mk/common.mk
+++ b/.nanvix/mk/common.mk
@@ -7,9 +7,9 @@
 NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
 
 # Platform and deployment configuration (passed by nanvix-zutil / z.py)
-PLATFORM ?= hyperlight
-PROCESS_MODE ?= multi-process
-MEMORY_SIZE ?= 128mb
+PLATFORM ?= microvm
+PROCESS_MODE ?= standalone
+MEMORY_SIZE ?= 256mb
 
 # Set to 'yes' for release packaging: disables C test extension modules and
 # skips regrtest.  Dev builds (the default) compile test extensions and run


### PR DESCRIPTION
This pull request updates the default platform and deployment configuration settings in the `.nanvix/mk/common.mk` file. The changes primarily adjust the build and runtime environment defaults to better suit the current project requirements.

Configuration updates:

* Changed the default `PLATFORM` from `hyperlight` to `microvm`.
* Updated the default `PROCESS_MODE` from `multi-process` to `standalone`.
* Increased the default `MEMORY_SIZE` from `128mb` to `256mb`.