### PR TITLE
[ci] Sync zutils v0.7.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
-      zutil-version: "v0.7.0"
+      zutil-version: "v0.7.1"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       skip-full-test-modes: '[]'

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -3,6 +3,12 @@ name = "cpython"
 version = "3.12.3"
 nanvix-version = "latest"
 
+[builds]
+[builds.matrix]
+platforms = ["microvm"]
+modes = ["multi-process", "single-process", "standalone"]
+memory = ["256mb"]
+
 [dependencies]
 zlib = "1.3.1"
 sqlite = "3.49.0"

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.5.1"
+    "0.7.1"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly
@@ -40,7 +40,9 @@ function Bootstrap {
 
     # Discover a Python 3 interpreter.
     $venvArgs = @("-m", "venv")
-    if (Test-Path $venvDir) { $venvArgs += "--clear" }
+    if (Test-Path $venvDir) {
+        $venvArgs += "--clear" 
+    }
     $venvArgs += $venvDir
 
     if (Get-Command py -ErrorAction SilentlyContinue) {
@@ -74,7 +76,12 @@ if ((-not (Test-Path $venvDir)) -and (-not $zutilGlobalVersion)) {
     $bin = $venvZutil
 }
 elseif (Test-Path $venvZutil) {
-    $venvVersion = try { & $venvZutil --version 2>$null } catch { $null }
+    $venvVersion = try {
+        & $venvZutil --version 2>$null 
+    }
+    catch {
+        $null 
+    }
     if ($venvVersion -ne "nanvix-zutil ${zutilVersion}") {
         Write-Warning "Venv nanvix-zutil version mismatch. Expected ${zutilVersion}, found ${venvVersion}. Re-bootstrapping..."
         Bootstrap

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,8 @@
 
 set -euo pipefail
 
-ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-0.5.1}"
+PINNED_VERSION="0.7.1"
+ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 VENV_BIN="$VENV/bin/nanvix-zutil"


### PR DESCRIPTION
Automated sync with [`v0.7.1`](https://github.com/nanvix/zutils/releases/tag/v0.7.1):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.