### PR TITLE
[ci] Sync zutils v0.7.3

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ jobs:
   ci:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
-      zutil-version: "v0.7.2"
+      zutil-version: "v0.7.3"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       skip-full-test-modes: '[]'

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.2"
+    "0.7.3"
 }
 
 # z.ps1 lives at the repository root, so use its directory directly
@@ -27,8 +27,9 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
-# FIXME: https://github.com/nanvix/zutils/issues/56
-$ShimCode = 'import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())'
+$ShimCode = @'
+import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+'@
 
 $zutilGlobalVersion = try {
     & nanvix-zutil --version 2>$null
@@ -47,7 +48,7 @@ function Bootstrap {
     # Discover a Python 3 interpreter.
     $venvArgs = @("-m", "venv")
     if (Test-Path $venvDir) {
-        $venvArgs += "--clear" 
+        $venvArgs += "--clear"
     }
     $venvArgs += $venvDir
 

--- a/z.sh
+++ b/z.sh
@@ -7,13 +7,14 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.2"
+PINNED_VERSION="0.7.3"
 ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 VENV="$REPO_ROOT/.nanvix/venv"
 
 # Resolve venv layout (bin/ vs Scripts/) based on what exists on disk.
-# Must be called after venv creation to pick up the correct paths.
+# Can be called before venv creation to initialize default paths; call it
+# again after venv creation to pick up the actual layout.
 function _resolve_venv_paths() {
     if [ -d "$VENV/Scripts" ]; then
         VENV_BIN="$VENV/Scripts/nanvix-zutil.exe"


### PR DESCRIPTION
Automated sync with [`v0.7.3`](https://github.com/nanvix/zutils/releases/tag/v0.7.3):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.