### PR TITLE
[ci] Add pull-requests write permission for scheduled runs

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,6 +23,24 @@ concurrency:
 
 jobs:
   ci:
+    if: github.event_name != 'schedule'
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
+    with:
+      zutil-version: "v0.7.3"
+      platforms: '["microvm"]'
+      memory-sizes: '["256mb"]'
+      skip-full-test-modes: '[]'
+      caller-event-name: ${{ github.event_name }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
+  ci-scheduled:
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: write
+      actions: write
+      issues: write
+      pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
     with:
       zutil-version: "v0.7.3"
@@ -41,11 +59,14 @@ jobs:
   # uploads it to the same release.
   # -------------------------------------------------------------------
   windows-zip:
-    needs: ci
-    if: ${{ !cancelled() && needs.ci.result == 'success' && github.event_name != 'pull_request' }}
+    needs: [ci, ci-scheduled]
+    if: >-
+      !cancelled() &&
+      (needs.ci.result == 'success' || needs.ci-scheduled.result == 'success') &&
+      github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ needs.ci.outputs.package_version }}-nanvix-${{ needs.ci.outputs.nanvix_version }}
+      RELEASE_TAG: ${{ (needs.ci.outputs.package_version || needs.ci-scheduled.outputs.package_version) }}-nanvix-${{ (needs.ci.outputs.nanvix_version || needs.ci-scheduled.outputs.nanvix_version) }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary

Add `pull-requests: write` to the caller workflow permissions block to fix the nightly scheduled CI failure.

## Problem

Since April 5, all scheduled runs fail on the `Update Nanvix Version` job with:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

The `update-nanvix-version` job (introduced in `nanvix/workflows` v1.3.x) needs `pull-requests: write` to create version-bump PRs. The caller only grants `contents`, `actions`, and `issues` — so the reusable workflow cannot exceed that scope.

## Fix

Add `pull-requests: write` to the `permissions` block in the caller workflow.