### PR TITLE
[ci] E: Bump reusable workflow to v1.5.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.5.0
     with:
       zutil-version: "v0.7.3"
       platforms: '["microvm"]'
@@ -41,7 +41,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.4.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.5.0
     with:
       zutil-version: "v0.7.3"
       platforms: '["microvm"]'


### PR DESCRIPTION
Updates nanvix/workflows from v1.4.0 to v1.5.0. The v1.5.0 release includes `pull-requests: write` in the reusable workflow permissions block, which is needed for the caller-callee permission intersection to grant PR creation access.