### PR TITLE
[build] Fix Docker incremental builds re-triggering on every invocation

### DIFF
--- a/.nanvix/mk/common.mk
+++ b/.nanvix/mk/common.mk
@@ -166,8 +166,10 @@ build: $(CONFIGURED_MARKER)
 ifdef CONFIG_NANVIX_DOCKER
 	@echo "Building inside Docker..."
 	$(DOCKER_RUN) make -j$$(nproc) all
-	@# Rename python to python.elf for consistency (always use the latest build)
-	@if [ -f python ]; then mv -f python python$(EXE); fi
+	@# Copy python to python.elf for consistency (always use the latest build).
+	@# Use cp instead of mv so that the original 'python' remains on disk;
+	@# otherwise Make would see the missing target and re-link on every run.
+	@if [ -f python ]; then cp -f python python$(EXE); fi
 	@# Strip debug symbols from the final binary for size reduction
 	$(DOCKER_RUN) sh -c '\
 		if [ ! -x "$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" ]; then \
@@ -180,8 +182,10 @@ ifdef CONFIG_NANVIX_DOCKER
 		fi'
 else
 	make -j$$(nproc) all
-	@# Rename python to python.elf for consistency (always use the latest build)
-	@if [ -f python ]; then mv -f python python$(EXE); fi
+	@# Copy python to python.elf for consistency (always use the latest build).
+	@# Use cp instead of mv so that the original 'python' remains on disk;
+	@# otherwise Make would see the missing target and re-link on every run.
+	@if [ -f python ]; then cp -f python python$(EXE); fi
 	@# Strip debug symbols from the final binary for size reduction
 	@if [ -x "$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip" ]; then \
 		if [ -f "python$(EXE)" ]; then \

--- a/.nanvix/mk/docker-host.mk
+++ b/.nanvix/mk/docker-host.mk
@@ -19,6 +19,14 @@ _DHM_BUILD_DIR  := /tmp/build
 _DHM_WS_MOUNT   := /mnt/workspace
 _DHM_SYS_MOUNT  := /mnt/sysroot
 
+# Named Docker volume that persists the build tree across container runs,
+# so that Make's timestamp-based dependency tracking can skip up-to-date
+# targets on subsequent builds instead of rebuilding from scratch.
+# The volume name includes a hash of the workspace path to avoid
+# cross-contamination between different clones/branches on the same host.
+_DHM_WORKSPACE_ID := $(shell printf '%s' '$(abspath $(CURDIR))' | cksum | awk '{print $$1}')
+_DHM_BUILD_VOLUME ?= cpython-nanvix-build-$(_DHM_WORKSPACE_ID)
+
 # Files that need CRLF -> LF normalization for autotools
 _DHM_CRLF_FILES := configure config.guess config.sub install-sh \
     Modules/makesetup Modules/Setup \
@@ -50,24 +58,38 @@ _DHM_INNER_ARGS := make -f Makefile.nanvix \
 # Build output files to copy back to the host workspace
 _DHM_OUTPUT_FILES := python python.exe python.elf python.wasm libpython3.12.a
 
-# docker-host-run: sync sources into container, fix CRLF, run inner make,
-# copy outputs back.
-#   $(1) = inner make targets
-define docker-host-run
+# Path to the source-sync helper (resolved inside the container via the
+# workspace bind mount).  The script is piped through sed to strip any
+# Windows CRLF line endings before execution.
+_DHM_SYNC_SCRIPT := $(_DHM_WS_MOUNT)/.nanvix/mk/sync-sources.sh
+
+# Common docker-run prefix shared by all container invocations.
+define _dhm_docker_run
 docker run --rm \
+    -v $(_DHM_BUILD_VOLUME):$(_DHM_BUILD_DIR) \
     -v $(CURDIR):$(_DHM_WS_MOUNT) \
     -v $(abspath $(NANVIX_HOME)):$(_DHM_SYS_MOUNT):ro \
     -w $(_DHM_BUILD_DIR) \
     -e HOME=/tmp \
-    $(NANVIX_DOCKER_IMAGE) \
+    $(NANVIX_DOCKER_IMAGE)
+endef
+
+# Common shell preamble: CRLF-strip the sync script, run it, then cd into
+# the build directory.
+define _dhm_sync_preamble
+        sed "s/\r$$//" $(_DHM_SYNC_SCRIPT) > /tmp/_sync.sh && \
+        TAR_EXCLUDES="$(_DHM_TAR_EXCLUDES)" \
+            sh /tmp/_sync.sh $(_DHM_WS_MOUNT) $(_DHM_BUILD_DIR) $(_DHM_CRLF_FILES) && \
+        cd $(_DHM_BUILD_DIR)
+endef
+
+# docker-host-run: sync sources into container via a persistent Docker volume,
+# run inner make, copy outputs back.
+#   $(1) = inner make targets
+define docker-host-run
+$(call _dhm_docker_run) \
     sh -c '\
-        mkdir -p $(_DHM_BUILD_DIR) && \
-        tar -cf - -C $(_DHM_WS_MOUNT) $(_DHM_TAR_EXCLUDES) . \
-            | tar -xf - -C $(_DHM_BUILD_DIR) && \
-        for f in $(_DHM_CRLF_FILES); do \
-            if [ -f "$$f" ]; then sed "s/\r$$//" "$$f" > /tmp/_crlf.tmp && \
-            cat /tmp/_crlf.tmp > "$$f"; fi; done && \
-        rm -f .nanvix-configured conftest* config.cache && \
+        $(_dhm_sync_preamble) && \
         $(_DHM_INNER_ARGS) $(1); rc=$$?; \
         for f in $(_DHM_OUTPUT_FILES); do \
             [ -f $(_DHM_BUILD_DIR)/$$f ] && \
@@ -79,20 +101,9 @@ endef
 # staging directory back to the host so that nanvixd can run natively.
 #   $(1) = inner make prepare target(s)
 define docker-host-test-prepare
-docker run --rm \
-    -v $(CURDIR):$(_DHM_WS_MOUNT) \
-    -v $(abspath $(NANVIX_HOME)):$(_DHM_SYS_MOUNT):ro \
-    -w $(_DHM_BUILD_DIR) \
-    -e HOME=/tmp \
-    $(NANVIX_DOCKER_IMAGE) \
+$(call _dhm_docker_run) \
     sh -c '\
-        mkdir -p $(_DHM_BUILD_DIR) && \
-        tar -cf - -C $(_DHM_WS_MOUNT) $(_DHM_TAR_EXCLUDES) . \
-            | tar -xf - -C $(_DHM_BUILD_DIR) && \
-        for f in $(_DHM_CRLF_FILES); do \
-            if [ -f "$$f" ]; then sed "s/\r$$//" "$$f" > /tmp/_crlf.tmp && \
-            cat /tmp/_crlf.tmp > "$$f"; fi; done && \
-        rm -f .nanvix-configured conftest* config.cache && \
+        $(_dhm_sync_preamble) && \
         $(_DHM_INNER_ARGS) $(1); rc=$$?; \
         for f in $(_DHM_OUTPUT_FILES); do \
             [ -f $(_DHM_BUILD_DIR)/$$f ] && \
@@ -172,6 +183,7 @@ clean:
 	-rmdir /s /q .nanvix\_test_staging 2>nul
 	-rmdir /s /q _test_staging 2>nul
 	-rmdir /s /q staging 2>nul
+	-docker volume rm $(_DHM_BUILD_VOLUME) 2>nul
 
 distclean: clean
 

--- a/.nanvix/mk/sync-sources.sh
+++ b/.nanvix/mk/sync-sources.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# sync-sources.sh - Content-aware source sync for incremental Docker builds.
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Extracts host workspace sources into a staging area, normalises CRLF line
+# endings on autotools files, then copies only genuinely changed files into
+# the persistent build directory.  Unchanged files keep their original
+# timestamps so Make's dependency tracking works correctly.
+#
+# Usage:  sync-sources.sh <ws_mount> <build_dir> [crlf_files...]
+#
+# Environment:
+#   TAR_EXCLUDES  - tar --exclude flags (word-split intentionally)
+
+set -e
+
+WS_MOUNT="$1"; shift
+BUILD_DIR="$1"; shift
+# Remaining positional args are files requiring CRLF -> LF normalization.
+
+_stg=$(mktemp -d /tmp/sync-staging.XXXXXX)
+_sync_list=$(mktemp /tmp/sync-list.XXXXXX)
+_build_list=$(mktemp /tmp/build-list.XXXXXX)
+# Clean up temp files on exit (normal or early error via set -e).
+trap 'rm -rf "$_stg" "$_sync_list" "$_build_list"' EXIT
+
+# Word splitting on TAR_EXCLUDES is intentional (multiple --exclude flags).
+# shellcheck disable=SC2086
+tar -cf - -C "$WS_MOUNT" ${TAR_EXCLUDES} . | tar -xf - -C "$_stg"
+
+for f in "$@"; do
+    [ -f "$_stg/$f" ] && sed -i 's/\r$//' "$_stg/$f"
+done
+
+# --- Copy new/changed files into the build directory ---
+cd "$_stg"
+find . -type f > "$_sync_list"
+while IFS= read -r _f; do
+    _t="$BUILD_DIR/$_f"
+    if [ ! -f "$_t" ] || ! cmp -s "$_f" "$_t"; then
+        mkdir -p "$(dirname "$_t")"
+        cp -f "$_f" "$_t"
+    fi
+done < "$_sync_list"
+
+# --- Remove stale files from the build directory ---
+# Files that exist in the persistent build tree but no longer appear in the
+# source workspace must be pruned so they don't affect subsequent builds.
+cd "$BUILD_DIR"
+find . -type f > "$_build_list"
+while IFS= read -r _f; do
+    [ ! -f "$_stg/$_f" ] && rm -f "$BUILD_DIR/$_f"
+done < "$_build_list"


### PR DESCRIPTION
## Problem

Two sequential invocations of `./z build` would trigger a full rebuild (configure + compile + link) even when no source files changed. This made the edit-build-test cycle unnecessarily slow on Windows Docker hosts.

## Root Causes

1. **`common.mk`: `mv` removed the Make target** — The build step used `mv -f python python.elf`, deleting the `python` binary that the CPython Makefile depends on. Make would detect the missing target and re-link from scratch.

2. **`docker-host.mk`: ephemeral container with no build persistence** — Each Docker invocation used a throwaway `/tmp/build` directory and explicitly ran `rm -f .nanvix-configured`, forcing `./configure` to re-run every time.

3. **`docker-host.mk`: CRLF normalization touched timestamps** — Autotools files were normalized in-place on every run, updating timestamps and triggering Make rebuilds.

## Solution

### Commit 1: Use `cp` instead of `mv` for `python.elf`
Keeps the original `python` binary so Make's dependency tracking is satisfied.

### Commit 2: Add content-aware source sync script
New `sync-sources.sh` extracts sources into a staging area, normalizes CRLF, then uses `cmp` to copy only genuinely changed files into the build directory — preserving timestamps of unmodified files.

### Commit 3: Persistent Docker volume + shared helpers
- Named Docker volume (`cpython-nanvix-build`) persists build artifacts across container runs
- Shared `_dhm_docker_run` and `_dhm_sync_preamble` helpers deduplicate the `docker-host-run` and `docker-host-test-prepare` defines
- Removed the unconditional `rm -f .nanvix-configured`
- `clean` target removes the Docker volume

## Verification

After the fix, a second `./z build` with no source changes produces:
\\\
make -j\ all
Checked 110 modules (72 built-in, 0 shared, 38 n/a on nanvix-i686, ...)
\\\
No configure, no compilation, no linking.