### PR TITLE
[build] Local Nanvix setup and Windows/portability fixes

### DIFF
--- a/.nanvix/mk/common.mk
+++ b/.nanvix/mk/common.mk
@@ -43,6 +43,10 @@ ifdef CONFIG_NANVIX
 
   EXE=.elf
 
+  # Resolve a host-tool binary, trying .elf then .exe extension.
+  # Usage: $(call _find_host_bin,/path/to/basename_without_ext)
+  _find_host_bin = $(firstword $(wildcard $(1).elf $(1).exe))
+
   ifdef CONFIG_NANVIX_DOCKER
     # Docker-based cross-compilation
     # All paths inside Docker

--- a/.nanvix/mk/docker-host.mk
+++ b/.nanvix/mk/docker-host.mk
@@ -23,10 +23,18 @@ _DHM_SYS_MOUNT  := /mnt/sysroot
 # so that Make's timestamp-based dependency tracking can skip up-to-date
 # targets on subsequent builds instead of rebuilding from scratch.
 # The volume name is derived from the workspace path, sanitised for Docker
-# volume naming rules (letters, digits, hyphens, underscores only).
-# On Windows the standard Unix tools (printf, cksum, awk) are unavailable,
-# so we use pure Make text functions instead of $(shell ...).
-_DHM_WORKSPACE_ID := $(subst /,-,$(subst \,-,$(subst :,,$(abspath $(CURDIR)))))
+# volume naming rules. On Windows the path may contain spaces and other
+# punctuation that Docker volume names do not accept, so normalise common
+# problematic characters to hyphens using only Make text functions.
+_DHM_EMPTY :=
+_DHM_SPACE := $(_DHM_EMPTY) $(_DHM_EMPTY)
+_DHM_BAD_CHARS := : \ / ( ) [ ] { } , ; = + & ' " * ? ! # % ^ ~ ` @
+
+# $(call _dhm_sanitise,string,char-list) — replace each char in the list with a hyphen.
+_dhm_sanitise = $(if $2,$(call _dhm_sanitise,$(subst $(firstword $2),-,$1),$(wordlist 2,$(words $2),$2)),$1)
+
+_DHM_WORKSPACE_PATH := $(abspath $(CURDIR))
+_DHM_WORKSPACE_ID   := $(call _dhm_sanitise,$(subst $(_DHM_SPACE),-,$(_DHM_WORKSPACE_PATH)),$(_DHM_BAD_CHARS))
 _DHM_BUILD_VOLUME ?= cpython-nanvix-build-$(_DHM_WORKSPACE_ID)
 
 # Files that need CRLF -> LF normalization for autotools
@@ -127,11 +135,11 @@ endef
 # Test staging directory on the host (populated by docker-host-test-prepare)
 _DHM_TEST_STAGING := $(CURDIR)/.nanvix/_test_staging
 
-# Determine the prepare target name and test script content based on
-# deployment mode.  The test script runs via WSL on the host.
+# Determine the Docker-side prepare target.
+# For standalone: use the install-only target (no ramfs) — ramfs is built
+# natively on the host.  For other modes: use the standard prepare target.
 ifeq ($(PROCESS_MODE),standalone)
-  _DHM_TEST_PREPARE := test-hello-standalone-prepare test-regrtest-standalone
-  _DHM_RAMFS_IMG := $(_DHM_TEST_STAGING)/cpython-rootfs.img
+  _DHM_TEST_PREPARE := test-hello-standalone-install test-regrtest-standalone
 else ifeq ($(PROCESS_MODE),single-process)
   _DHM_TEST_PREPARE := test-hello-single-process-prepare test-regrtest-single-process-prepare
 else
@@ -159,18 +167,45 @@ all: build
 build:
 	$(call docker-host-run,build)
 
-# Test: cross-compile and stage inside Docker, then run nanvixd on the host.
-# Phase 1 (Docker): build, install, ramfs, strip — everything needing the
-#   cross-toolchain or Linux tools.
-# Phase 2 (host): execute nanvixd.elf natively on Windows.
-#   nanvixd.elf is a Linux ELF binary that runs via Windows WSL interop.
-#   The Python test runner invokes it directly (no explicit WSL call).
-test:
-	@echo "=== Phase 1: Preparing test artifacts inside Docker ==="
+# Test: cross-compile artifacts in Docker, then run nanvixd natively.
+#
+# Phase 1 (Docker): install + strip — only if staging is not already
+#   populated from a previous run.  No rebuild is triggered.
+# Phase 1b (native, standalone only): build ramfs with mkramfs.exe.
+# Phase 2 (native): execute nanvixd.exe on the host.
+
+# Sentinel file that indicates the staging directory is fully populated.
+_DHM_STAGING_READY := $(subst /,\,$(_DHM_TEST_STAGING)\sysroot\bin\python3.12)
+
+# Ramfs image path on the host (standalone mode only).
+_DHM_RAMFS_IMG := $(subst /,\,$(_DHM_TEST_STAGING)\cpython-rootfs.img)
+
+# Conditionally run Docker install+strip, then build ramfs natively.
+test-prepare:
+	@python -c "import sys,os; sys.exit(0 if os.path.isfile(r'$(_DHM_STAGING_READY)') else 1)" || $(MAKE) -f Makefile.nanvix test-prepare-docker CONFIG_NANVIX=$(CONFIG_NANVIX) DOCKER_HOST_MODE=$(DOCKER_HOST_MODE) NANVIX_HOME=$(NANVIX_HOME) NANVIX_TOOLCHAIN=$(NANVIX_TOOLCHAIN) PLATFORM=$(PLATFORM) PROCESS_MODE=$(PROCESS_MODE) MEMORY_SIZE=$(MEMORY_SIZE) INSTALL_PREFIX=$(INSTALL_PREFIX) NANVIX_RELEASE=$(NANVIX_RELEASE)
+ifeq ($(PROCESS_MODE),standalone)
+	@python -c "import sys,os; sys.exit(0 if os.path.isfile(r'$(_DHM_RAMFS_IMG)') else 1)" || $(MAKE) -f Makefile.nanvix test-prepare-ramfs CONFIG_NANVIX=$(CONFIG_NANVIX) DOCKER_HOST_MODE=$(DOCKER_HOST_MODE) NANVIX_HOME=$(NANVIX_HOME) NANVIX_TOOLCHAIN=$(NANVIX_TOOLCHAIN) PLATFORM=$(PLATFORM) PROCESS_MODE=$(PROCESS_MODE) MEMORY_SIZE=$(MEMORY_SIZE) INSTALL_PREFIX=$(INSTALL_PREFIX) NANVIX_RELEASE=$(NANVIX_RELEASE)
+endif
+
+# Docker phase: install + strip (no rebuild, no ramfs).
+test-prepare-docker:
+	@echo === Phase 1: Installing test artifacts via Docker ===
 	$(call docker-host-test-prepare,$(_DHM_TEST_PREPARE))
+
+# Native ramfs build (standalone mode only).
+# Runs mkramfs.exe directly on the Windows host.
+test-prepare-ramfs:
+	@echo === Phase 1b: Building ramfs natively with mkramfs.exe ===
+	@python -c "open(r'$(subst /,\,$(_DHM_TEST_STAGING)\sysroot\test_hello.py)','w').write(\"import sys; print('CPYTHON_TEST_HELLO: Hello from Python', sys.version_info[:2])\n\")"
+	@python -c "import shutil,os; src=r'$(subst /,\,$(_DHM_TEST_STAGING)\sysroot\lib)'; dst=r'$(subst /,\,$(_DHM_TEST_STAGING)\ramfs-content\sysroot\lib)'; os.makedirs(os.path.dirname(dst),exist_ok=True); shutil.copytree(src,dst,dirs_exist_ok=True)"
+	@python -c "import shutil; shutil.copy2(r'$(subst /,\,$(_DHM_TEST_STAGING)\sysroot\test_hello.py)',r'$(subst /,\,$(_DHM_TEST_STAGING)\ramfs-content\sysroot\test_hello.py)')"
+	python $(dir $(lastword $(MAKEFILE_LIST)))ramfs-trim-host.py $(subst /,\,$(_DHM_TEST_STAGING)\ramfs-content\sysroot)
+	$(subst /,\,$(abspath $(NANVIX_HOME))\bin\mkramfs.exe) -o $(_DHM_RAMFS_IMG) $(subst /,\,$(_DHM_TEST_STAGING)\ramfs-content\sysroot)
+	@echo Built ramfs image: $(_DHM_RAMFS_IMG)
+
+test: test-prepare
 	@echo "=== Phase 2: Running tests on host ==="
 	python $(_DHM_TEST_RUNNER) $(subst /,\,$(_DHM_TEST_STAGING)) $(PROCESS_MODE) $(_DHM_REGRTEST_ARGS)
-	-rmdir /s /q $(subst /,\,$(_DHM_TEST_STAGING)) 2>nul
 	@echo "		*** CPython tests PASSED ***"
 
 install:

--- a/.nanvix/mk/docker-host.mk
+++ b/.nanvix/mk/docker-host.mk
@@ -22,9 +22,11 @@ _DHM_SYS_MOUNT  := /mnt/sysroot
 # Named Docker volume that persists the build tree across container runs,
 # so that Make's timestamp-based dependency tracking can skip up-to-date
 # targets on subsequent builds instead of rebuilding from scratch.
-# The volume name includes a hash of the workspace path to avoid
-# cross-contamination between different clones/branches on the same host.
-_DHM_WORKSPACE_ID := $(shell printf '%s' '$(abspath $(CURDIR))' | cksum | awk '{print $$1}')
+# The volume name is derived from the workspace path, sanitised for Docker
+# volume naming rules (letters, digits, hyphens, underscores only).
+# On Windows the standard Unix tools (printf, cksum, awk) are unavailable,
+# so we use pure Make text functions instead of $(shell ...).
+_DHM_WORKSPACE_ID := $(subst /,-,$(subst \,-,$(subst :,,$(abspath $(CURDIR)))))
 _DHM_BUILD_VOLUME ?= cpython-nanvix-build-$(_DHM_WORKSPACE_ID)
 
 # Files that need CRLF -> LF normalization for autotools

--- a/.nanvix/mk/ramfs-trim-host.py
+++ b/.nanvix/mk/ramfs-trim-host.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# ramfs-trim-host.py - Trim a staged sysroot for ramfs (native, cross-platform).
+#
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+#
+# Usage: ramfs-trim-host.py <sysroot-path>
+#
+# Equivalent to the ramfs-trim Make target in ramfs.mk, but runs natively
+# on Windows (no shell/find/rm required).
+
+import glob
+import os
+import shutil
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <sysroot-path>", file=sys.stderr)
+        sys.exit(1)
+
+    sysroot = sys.argv[1]
+    if not os.path.isdir(sysroot):
+        print(f"Error: {sysroot} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Trimming sysroot for ramfs: {sysroot}")
+
+    # Remove heavyweight stdlib packages not needed at runtime.
+    for subdir in (
+        "lib/python3.12/config-3.12",
+        "lib/python3.12/idlelib",
+        "lib/python3.12/tkinter",
+        "lib/python3.12/turtledemo",
+        "lib/python3.12/lib2to3",
+        "lib/python3.12/ensurepip",
+        "lib/python3.12/pydoc_data",
+        "lib/python3.12/venv",
+        "lib/python3.12/site-packages",
+        "lib/python3.12/__phello__",
+        "lib/python3.12/test",
+        "include",
+        "share",
+        "lib/pkgconfig",
+    ):
+        p = os.path.join(sysroot, subdir)
+        if os.path.isdir(p):
+            shutil.rmtree(p)
+
+    # Remove static library.
+    for f in ("lib/libpython3.12.a",):
+        p = os.path.join(sysroot, f)
+        if os.path.isfile(p):
+            os.remove(p)
+
+    # Remove dev/admin scripts from bin/.
+    bin_dir = os.path.join(sysroot, "bin")
+    if os.path.isdir(bin_dir):
+        for pattern in (
+            "2to3*", "idle3*", "pydoc3*",
+            "python3-config", "python3.12-config", "python3",
+            "*.elf", "*.exe",
+        ):
+            for f in glob.glob(os.path.join(bin_dir, pattern)):
+                if os.path.isfile(f):
+                    os.remove(f)
+        # Remove bin/ if empty.
+        try:
+            os.rmdir(bin_dir)
+        except OSError:
+            pass
+
+    # Remove __pycache__ directories.
+    for root, dirs, _files in os.walk(sysroot, topdown=False):
+        for d in dirs:
+            if d == "__pycache__":
+                shutil.rmtree(os.path.join(root, d), ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/.nanvix/mk/ramfs.mk
+++ b/.nanvix/mk/ramfs.mk
@@ -51,20 +51,25 @@ endif
 	@rm -f  $(RAMFS_STAGING)/sysroot/bin/pydoc3* $(RAMFS_STAGING)/sysroot/bin/python3-config
 	@rm -f  $(RAMFS_STAGING)/sysroot/bin/python3.12-config $(RAMFS_STAGING)/sysroot/bin/python3
 	@# Remove all ELF binaries — binaries are not included in ramfs
-	@find $(RAMFS_STAGING)/sysroot/bin -name '*.elf' -delete 2>/dev/null || true
+	@find $(RAMFS_STAGING)/sysroot/bin \( -name '*.elf' -o -name '*.exe' \) -delete 2>/dev/null || true
 	@# Remove remaining non-python binaries if bin/ is now empty
 	@rmdir $(RAMFS_STAGING)/sysroot/bin 2>/dev/null || true
 	@find $(RAMFS_STAGING)/sysroot -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
 
 # Build a ramfs image from the trimmed sysroot.
 # Output: $(RAMFS_IMG)
-# Requires: mkramfs.elf in $(NANVIX_HOME)/bin/
+# Requires: mkramfs (.elf or .exe) in $(NANVIX_HOME)/bin/
 RAMFS_IMG ?= /tmp/cpython-rootfs.img
 
 ramfs-build: ramfs-trim
-	@MKRAMFS="$(abspath $(NANVIX_HOME))/bin/mkramfs.elf"; \
-	if [ ! -x "$$MKRAMFS" ]; then \
-		echo "Error: mkramfs.elf not found at $$MKRAMFS"; exit 1; \
+	@MKRAMFS=""; \
+	for ext in .elf .exe; do \
+		if [ -x "$(abspath $(NANVIX_HOME))/bin/mkramfs$$ext" ]; then \
+			MKRAMFS="$(abspath $(NANVIX_HOME))/bin/mkramfs$$ext"; break; \
+		fi; \
+	done; \
+	if [ -z "$$MKRAMFS" ]; then \
+		echo "Error: mkramfs not found at $(abspath $(NANVIX_HOME))/bin/ (.elf or .exe)"; exit 1; \
 	fi; \
 	"$$MKRAMFS" -o "$(RAMFS_IMG)" "$(RAMFS_STAGING)/sysroot"; \
 	echo "Built ramfs image: $(RAMFS_IMG) ($$(du -h "$(RAMFS_IMG)" | cut -f1))"

--- a/.nanvix/mk/sync-sources.sh
+++ b/.nanvix/mk/sync-sources.sh
@@ -51,5 +51,5 @@ done < "$_sync_list"
 cd "$BUILD_DIR"
 find . -type f > "$_build_list"
 while IFS= read -r _f; do
-    [ ! -f "$_stg/$_f" ] && rm -f "$BUILD_DIR/$_f"
+    [ ! -f "$_stg/$_f" ] && rm -f "$BUILD_DIR/$_f" || true
 done < "$_build_list"

--- a/.nanvix/mk/sync-sources.sh
+++ b/.nanvix/mk/sync-sources.sh
@@ -51,5 +51,7 @@ done < "$_sync_list"
 cd "$BUILD_DIR"
 find . -type f > "$_build_list"
 while IFS= read -r _f; do
-    [ ! -f "$_stg/$_f" ] && rm -f "$BUILD_DIR/$_f" || true
+    if [ ! -f "$_stg/$_f" ]; then
+        rm -f "$BUILD_DIR/$_f"
+    fi
 done < "$_build_list"

--- a/.nanvix/mk/test-common.mk
+++ b/.nanvix/mk/test-common.mk
@@ -19,29 +19,35 @@ TEST_STAGING ?= $(CURDIR)/.nanvix/_test_staging
 # Stage the CPython install and test fixtures into TEST_STAGING.
 # After this target, $(TEST_STAGING)/sysroot/ contains the full install tree
 # plus the hello test script and Nanvix runtime binaries.
-test-stage: build
-	@echo "Running CPython tests on Nanvix..."
-	@rm -rf $(TEST_STAGING)
-	@# Install python and stdlib into a test staging area
-ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) make install DESTDIR="$(DOCKER_WORKSPACE_PATH)/.nanvix/_test_staging"
-else
-	make install DESTDIR="$(TEST_STAGING)"
-endif
-	@# Copy test script into the staging sysroot
-	@echo "import sys; print('CPYTHON_TEST_HELLO: Hello from Python', sys.version_info[:2])" > $(TEST_STAGING)/sysroot/test_hello.py
-	@# Copy Nanvix runtime binaries into the staging sysroot
-	@mkdir -p $(TEST_STAGING)/sysroot/bin
-	@cp "$(abspath $(NANVIX_HOME))/bin/nanvixd.elf" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
-	@cp "$(abspath $(NANVIX_HOME))/bin/kernel.elf"  $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
-	@cp "$(abspath $(NANVIX_HOME))/bin/linuxd.elf"  $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
-	@cp "$(abspath $(NANVIX_HOME))/bin/uservm.elf"  $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
-	@# Replace unstripped python binary in staging with the stripped python.elf to save VM memory
-	@if [ -f "$(CURDIR)/python.elf" ]; then \
-		cp "$(CURDIR)/python.elf" "$(TEST_STAGING)/sysroot/bin/python3.12"; \
-		echo "  Installed stripped python.elf into staging ($$(du -sh $(TEST_STAGING)/sysroot/bin/python3.12 | cut -f1))"; \
+#
+# If the staging directory already contains the python binary from a
+# previous run, rebuild and re-staging are skipped entirely.
+test-stage:
+	@if [ -f "$(TEST_STAGING)/sysroot/bin/python3.12" ]; then \
+		echo "Staging already populated — skipping build"; \
+	else \
+		$(MAKE) -f Makefile.nanvix build \
+			CONFIG_NANVIX=$(CONFIG_NANVIX) \
+			NANVIX_HOME=$(NANVIX_HOME) \
+			NANVIX_TOOLCHAIN=$(NANVIX_TOOLCHAIN) \
+			PLATFORM=$(PLATFORM) \
+			PROCESS_MODE=$(PROCESS_MODE) \
+			MEMORY_SIZE=$(MEMORY_SIZE) \
+			INSTALL_PREFIX=$(INSTALL_PREFIX) \
+			NANVIX_RELEASE=$(NANVIX_RELEASE) && \
+		echo "Running CPython tests on Nanvix..." && \
+		rm -rf $(TEST_STAGING) && \
+		$(MAKE) install DESTDIR="$(TEST_STAGING)" && \
+		echo "import sys; print('CPYTHON_TEST_HELLO: Hello from Python', sys.version_info[:2])" > $(TEST_STAGING)/sysroot/test_hello.py && \
+		cp $(CURDIR)/.nanvix/run-regrtest.py $(TEST_STAGING)/sysroot/run-regrtest.py && \
+		mkdir -p $(TEST_STAGING)/sysroot/bin && \
+		for bin in nanvixd kernel linuxd uservm; do \
+			for ext in .elf .exe; do \
+				src="$(abspath $(NANVIX_HOME))/bin/$${bin}$${ext}"; \
+				if [ -f "$$src" ]; then cp "$$src" $(TEST_STAGING)/sysroot/bin/; break; fi; \
+			done; \
+		done; \
 	fi
-	@cp $(CURDIR)/.nanvix/run-regrtest.py $(TEST_STAGING)/sysroot/run-regrtest.py
 
 # Validate hello-world test output in a log file.
 # Usage: $(call validate-hello,/path/to/logfile)

--- a/.nanvix/mk/test-multi-process.mk
+++ b/.nanvix/mk/test-multi-process.mk
@@ -19,7 +19,9 @@ test-hello-multi-process-run:
 		{ \
 			: > /tmp/cpython_test.log; \
 			start_time=$$(date +%s%N); \
-			timeout 120 ./bin/nanvixd.elf $(NANVIXD_EXTRA_ARGS) -- ./bin/python3.12 ./test_hello.py < /dev/null > /tmp/cpython_test.log 2>&1; \
+			NANVIXD=""; for ext in .elf .exe; do [ -x "./bin/nanvixd$$ext" ] && NANVIXD="./bin/nanvixd$$ext" && break; done; \
+			if [ -z "$$NANVIXD" ]; then echo "Error: nanvixd not found in ./bin/"; exit 1; fi; \
+			timeout 120 $$NANVIXD $(NANVIXD_EXTRA_ARGS) -- ./bin/python3.12 ./test_hello.py < /dev/null > /tmp/cpython_test.log 2>&1; \
 			test_status=$$?; \
 			end_time=$$(date +%s%N); \
 			elapsed=$$(( (end_time - start_time) / 1000000 )); \

--- a/.nanvix/mk/test-run-host.py
+++ b/.nanvix/mk/test-run-host.py
@@ -7,7 +7,7 @@
 # Usage: test-run-host.py <staging-dir> <process-mode> [test-list...]
 #
 # Unified test runner for both Windows and Linux hosts.
-# On Windows, nanvixd.elf is invoked via WSL with paths translated by wslpath.
+# On Windows, nanvixd.exe is invoked natively.
 # On Linux, staging is copied to /tmp for writable access and run directly.
 
 import argparse
@@ -22,6 +22,18 @@ import time
 
 IS_WINDOWS = platform.system() == "Windows"
 
+# Host tool extensions to try, in order of preference.
+_HOST_BIN_EXTS = (".elf", ".exe")
+
+
+def find_host_bin(base_path):
+    """Find a host binary, trying .elf then .exe extension."""
+    for ext in _HOST_BIN_EXTS:
+        p = base_path + ext
+        if os.path.exists(p):
+            return p
+    return base_path + _HOST_BIN_EXTS[0]  # fallback for error messages
+
 
 def die(msg):
     print(f"Error: {msg}", file=sys.stderr)
@@ -33,16 +45,6 @@ def validate_test_names(test_list):
     for t in test_list:
         if not re.fullmatch(r"[A-Za-z0-9_]+", t):
             die(f"Invalid test module name: '{t}'")
-
-
-def to_wsl_path(win_path):
-    """Convert a Windows path to a WSL /mnt/ path via wslpath."""
-    unix = win_path.replace("\\", "/")
-    result = subprocess.run(
-        ["wsl", "wslpath", "-a", unix],
-        capture_output=True, text=True, check=True,
-    )
-    return result.stdout.strip()
 
 
 def run_command(cmd, timeout, log_path):
@@ -83,55 +85,28 @@ def prepare_workdir_linux(staging):
 
 def build_hello_cmd(mode, staging_dir):
     """Build the command list for the hello-world test."""
-    if IS_WINDOWS:
-        wsl_staging = to_wsl_path(os.path.abspath(staging_dir))
-        nanvixd = f"{wsl_staging}/sysroot/bin/nanvixd.elf"
-        python_bin = f"{wsl_staging}/sysroot/bin/python3.12"
-        if mode == "standalone":
-            ramfs = f"{wsl_staging}/cpython-rootfs.img"
-            bin_dir = f"{wsl_staging}/sysroot/bin"
-            return [
-                "wsl", "--", nanvixd,
-                "-bin-dir", bin_dir, "-ramfs", ramfs,
-                "--", python_bin,
-                "-B /test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1",
-            ]
-        else:
-            inner = f"cd '{wsl_staging}/sysroot' && '{nanvixd}' -- '{python_bin}' ./test_hello.py 2>&1"
-            return ["wsl", "--", "bash", "-c", inner]
+    sysroot = os.path.join(os.path.abspath(staging_dir), "sysroot")
+    nanvixd = find_host_bin(os.path.join(sysroot, "bin", "nanvixd"))
+    python_bin = os.path.join(sysroot, "bin", "python3.12")
+    if mode == "standalone":
+        ramfs = os.path.join(os.path.abspath(staging_dir), "cpython-rootfs.img")
+        return [
+            nanvixd,
+            "-bin-dir", os.path.join(sysroot, "bin"),
+            "-ramfs", ramfs,
+            "--", python_bin,
+            "-B /test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1",
+        ]
     else:
-        # Linux: use the /tmp workdir
-        sysroot = os.path.join(staging_dir, "sysroot")
-        nanvixd = "./bin/nanvixd.elf"
-        python_bin = "./bin/python3.12"
-        if mode == "standalone":
-            ramfs = os.path.join(staging_dir, "cpython-rootfs.img")
-            return [
-                nanvixd,
-                "-bin-dir", "./bin", "-ramfs", ramfs,
-                "--", python_bin,
-                "-B /test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1",
-            ]
-        else:
-            return [nanvixd, "--", python_bin, "./test_hello.py"]
+        return [nanvixd, "--", python_bin, "./test_hello.py"]
 
 
 def build_regrtest_cmd(staging_dir, test_list):
     """Build the command list for regrtest."""
-    if IS_WINDOWS:
-        wsl_staging = to_wsl_path(os.path.abspath(staging_dir))
-        nanvixd = f"{wsl_staging}/sysroot/bin/nanvixd.elf"
-        python_bin = f"{wsl_staging}/sysroot/bin/python3.12"
-        test_args = " ".join(test_list)
-        inner = (
-            f"cd '{wsl_staging}/sysroot' && "
-            f"'{nanvixd}' -- '{python_bin}' -m test --timeout=120 {test_args} 2>&1"
-        )
-        return ["wsl", "--", "bash", "-c", inner]
-    else:
-        nanvixd = "./bin/nanvixd.elf"
-        python_bin = "./bin/python3.12"
-        return [nanvixd, "--", python_bin, "-m", "test", "--timeout=120"] + test_list
+    sysroot = os.path.join(os.path.abspath(staging_dir), "sysroot")
+    nanvixd = find_host_bin(os.path.join(sysroot, "bin", "nanvixd"))
+    python_bin = os.path.join(sysroot, "bin", "python3.12")
+    return [nanvixd, "--", python_bin, "-m", "test", "--timeout=120"] + test_list
 
 
 def run_hello_test(mode, staging_dir, log_dir):
@@ -140,10 +115,8 @@ def run_hello_test(mode, staging_dir, log_dir):
     log_path = os.path.join(log_dir, "cpython_test.log")
     cmd = build_hello_cmd(mode, staging_dir)
 
-    # On Linux, cd into sysroot before running
-    cwd = None
-    if not IS_WINDOWS:
-        cwd = os.path.join(staging_dir, "sysroot")
+    # Set cwd to sysroot for commands that use relative paths.
+    cwd = os.path.join(staging_dir, "sysroot")
 
     start = time.monotonic()
     try:
@@ -187,9 +160,7 @@ def run_regrtest(staging_dir, test_list, log_dir):
     log_path = os.path.join(log_dir, "cpython_regrtest.log")
     cmd = build_regrtest_cmd(staging_dir, test_list)
 
-    cwd = None
-    if not IS_WINDOWS:
-        cwd = os.path.join(staging_dir, "sysroot")
+    cwd = os.path.join(staging_dir, "sysroot")
 
     start = time.monotonic()
     try:
@@ -242,19 +213,13 @@ def main():
     # Validate test names
     validate_test_names(test_list)
 
-    # Verify WSL on Windows
-    if IS_WINDOWS and shutil.which("wsl") is None:
-        die("WSL is required but was not found. "
-            "Install WSL: https://learn.microsoft.com/windows/wsl/install")
-
     # Verify staging directory
-    if IS_WINDOWS:
-        nanvixd_path = os.path.join(staging_dir, "sysroot", "bin", "nanvixd.elf")
-    else:
-        nanvixd_path = os.path.join(staging_dir, "sysroot", "bin", "nanvixd.elf")
+    nanvixd_path = find_host_bin(
+        os.path.join(staging_dir, "sysroot", "bin", "nanvixd")
+    )
 
     if not os.path.exists(nanvixd_path):
-        die(f"nanvixd.elf not found in staging: {nanvixd_path}")
+        die(f"nanvixd not found in staging: {nanvixd_path}")
 
     # On Linux, copy staging to a writable /tmp location
     if not IS_WINDOWS:

--- a/.nanvix/mk/test-single-process.mk
+++ b/.nanvix/mk/test-single-process.mk
@@ -19,7 +19,9 @@ test-hello-single-process-run:
 		{ \
 			: > /tmp/cpython_test.log; \
 			start_time=$$(date +%s%N); \
-			timeout 120 ./bin/nanvixd.elf $(NANVIXD_EXTRA_ARGS) -- ./bin/python3.12 ./test_hello.py < /dev/null > /tmp/cpython_test.log 2>&1; \
+			NANVIXD=""; for ext in .elf .exe; do [ -x "./bin/nanvixd$$ext" ] && NANVIXD="./bin/nanvixd$$ext" && break; done; \
+			if [ -z "$$NANVIXD" ]; then echo "Error: nanvixd not found in ./bin/"; exit 1; fi; \
+			timeout 120 $$NANVIXD $(NANVIXD_EXTRA_ARGS) -- ./bin/python3.12 ./test_hello.py < /dev/null > /tmp/cpython_test.log 2>&1; \
 			test_status=$$?; \
 			end_time=$$(date +%s%N); \
 			elapsed=$$(( (end_time - start_time) / 1000000 )); \

--- a/.nanvix/mk/test-standalone.mk
+++ b/.nanvix/mk/test-standalone.mk
@@ -4,7 +4,7 @@
 # Licensed under the MIT License.
 #
 # In standalone mode the runtime filesystem is a ramfs image.  Binaries
-# (nanvixd.elf, python3.12, etc.) are NOT included in the ramfs — they are
+# (nanvixd, python3.12, etc.) are NOT included in the ramfs — they are
 # passed to nanvixd via -bin-dir.  The ramfs contains only the stdlib and
 # test fixtures.
 #
@@ -68,7 +68,9 @@ test-hello-standalone: ramfs-stage
 		{ \
 			: > /tmp/cpython_test.log; \
 			start_time=$$(date +%s%N); \
-			timeout 120 ./bin/nanvixd.elf \
+			NANVIXD=""; for ext in .elf .exe; do [ -x "./bin/nanvixd$$ext" ] && NANVIXD="./bin/nanvixd$$ext" && break; done; \
+			if [ -z "$$NANVIXD" ]; then echo "Error: nanvixd not found in ./bin/"; exit 1; fi; \
+			timeout 120 $$NANVIXD \
 			  -bin-dir ./bin -ramfs $(RAMFS_IMG) $(NANVIXD_EXTRA_ARGS) \
 			  -- ./bin/python3.12 \
 			  "-B ./test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1" \

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -4,11 +4,12 @@
 """Nanvix build script for CPython.
 
 Usage:
-    ./z setup     # Download Nanvix sysroot and dependencies
-    ./z build     # Cross-compile python.elf and libpython3.12.a
-    ./z test      # Run test suite (hello-world on nanvixd.elf)
-    ./z release   # Package release tarballs (sysroot + buildroot)
-    ./z clean     # Remove build artifacts
+    ./z setup                               # Download Nanvix sysroot and dependencies
+    ./z setup --with-nanvix /path/to/nanvix # Use a local Nanvix build (deps still downloaded)
+    ./z build                               # Cross-compile python.elf and libpython3.12.a
+    ./z test                                # Run test suite (hello-world on nanvixd.elf)
+    ./z release                             # Package release tarballs (sysroot + buildroot)
+    ./z clean                               # Remove build artifacts
 """
 
 import json
@@ -60,6 +61,21 @@ _DEP_EXPECTED_LIBS: dict[str, list[str]] = {
 
 class CPythonBuild(ZScript):
     """Build script for nanvix/cpython."""
+
+    # Class-level storage for --with-nanvix, set by main() before dispatch.
+    _with_nanvix: str | None = None
+
+    @classmethod
+    def main(cls, *, repo_root: Path | None = None) -> None:
+        """Extract ``--with-nanvix`` from argv, then delegate to base."""
+        cls._with_nanvix = None
+        argv = sys.argv[1:]
+        for i, arg in enumerate(argv):
+            if arg == "--with-nanvix" and i + 1 < len(argv):
+                cls._with_nanvix = argv[i + 1]
+                sys.argv = [sys.argv[0]] + argv[:i] + argv[i + 2:]
+                break
+        super().main(repo_root=repo_root)
 
     # ---- Make invocation -------------------------------------------------
 
@@ -142,7 +158,20 @@ class CPythonBuild(ZScript):
 
         The base class is not called for dependency installation because
         its retry loop wastes ~30 seconds on expected 404s before raising.
+
+        **Local mode**: pass ``--with-nanvix`` to skip the GitHub
+        download and use binaries from a local Nanvix build::
+
+            ./z setup --with-nanvix /path/to/nanvix
+
+        The path may point to the ``bin/`` directory or the Nanvix
+        project root (containing ``bin/``, ``lib/``, and ``build/``).
+        Third-party dependencies are still downloaded from GitHub.
         """
+        if self._with_nanvix:
+            self._setup_local(Path(self._with_nanvix))
+            return
+
         # ---- Step 1: download and verify the sysroot (from base class) ----
         from nanvix_zutil import Sysroot, CFG_GH_TOKEN
 
@@ -162,6 +191,94 @@ class CPythonBuild(ZScript):
         self._install_missing_deps()
         self.config.save()
 
+        self._merge_buildroot_into_sysroot()
+
+    # ---- Local-sysroot setup ---------------------------------------------
+
+    def _setup_local(self, local_path: Path) -> None:
+        """Build a sysroot from a local Nanvix build directory.
+
+        Accepts either the Nanvix project root or its ``bin/`` sub-directory.
+        Copies binaries, libraries, and the linker script into
+        ``.nanvix/sysroot/``, then downloads third-party dependencies
+        (zlib, OpenSSL, …) and merges them in.
+        """
+        local_path = local_path.resolve()
+        if not local_path.is_dir():
+            log.fatal(
+                f"Directory not found: {local_path}",
+                hint="Provide the path to a local Nanvix build directory.",
+            )
+
+        # Accept both nanvix/ and nanvix/bin/ as input.
+        if local_path.name == "bin" and (local_path.parent / "lib").is_dir():
+            nanvix_root = local_path.parent
+        else:
+            nanvix_root = local_path
+
+        bin_src = nanvix_root / "bin" if (nanvix_root / "bin").is_dir() else nanvix_root
+        lib_src = nanvix_root / "lib"
+
+        sysroot = self.nanvix_dir / "sysroot"
+
+        # ---- Copy binaries ------------------------------------------------
+        bin_dst = sysroot / "bin"
+        bin_dst.mkdir(parents=True, exist_ok=True)
+        copied = 0
+        for item in bin_src.iterdir():
+            if item.is_file():
+                shutil.copy2(item, bin_dst / item.name)
+                copied += 1
+        log.info(f"Copied {copied} files from {bin_src} → sysroot/bin/")
+
+        # ---- Copy libraries -----------------------------------------------
+        lib_dst = sysroot / "lib"
+        lib_dst.mkdir(parents=True, exist_ok=True)
+        if lib_src.is_dir():
+            for item in lib_src.iterdir():
+                if item.is_file() and item.suffix == ".a":
+                    shutil.copy2(item, lib_dst / item.name)
+                    log.info(f"Copied {item.name} → sysroot/lib/")
+
+        # ---- Copy linker script -------------------------------------------
+        # Search common locations for user.ld.
+        ld_candidates = [
+            nanvix_root / "build" / "user" / "linker" / "x86" / "user.ld",
+            nanvix_root / "build" / "user" / "linker" / "x86_64" / "user.ld",
+            lib_src / "user.ld",
+        ]
+        for ld_path in ld_candidates:
+            if ld_path.is_file():
+                shutil.copy2(ld_path, lib_dst / "user.ld")
+                log.info(f"Copied {ld_path} → sysroot/lib/user.ld")
+                break
+        else:
+            log.warning(
+                "user.ld not found in local Nanvix build. "
+                "Linking may fail without the linker script."
+            )
+
+        # ---- Copy include headers -----------------------------------------
+        inc_src = nanvix_root / "include"
+        if inc_src.is_dir():
+            inc_dst = sysroot / "include"
+            inc_dst.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(inc_src, inc_dst, dirs_exist_ok=True)
+            log.info("Copied include/ → sysroot/include/")
+
+        self.config.set(CFG_SYSROOT, str(sysroot))
+        log.info(f"Sysroot configured at {sysroot} (local)")
+
+        # ---- Download third-party dependencies ----------------------------
+        self._install_missing_deps()
+        self.config.save()
+
+        self._merge_buildroot_into_sysroot()
+
+    # ---- Merge buildroot into sysroot ------------------------------------
+
+    def _merge_buildroot_into_sysroot(self) -> None:
+        """Copy dependency libs and headers from buildroot into the sysroot."""
         buildroot = self.nanvix_dir / "buildroot"
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot or not buildroot.is_dir():

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -71,7 +71,12 @@ class CPythonBuild(ZScript):
         cls._with_nanvix = None
         argv = sys.argv[1:]
         for i, arg in enumerate(argv):
-            if arg == "--with-nanvix" and i + 1 < len(argv):
+            if arg == "--with-nanvix":
+                if i + 1 >= len(argv):
+                    log.fatal(
+                        "missing path for --with-nanvix",
+                        hint="Usage: --with-nanvix <path>",
+                    )
                 cls._with_nanvix = argv[i + 1]
                 sys.argv = [sys.argv[0]] + argv[:i] + argv[i + 2:]
                 break


### PR DESCRIPTION
## Summary

Improve the build system portability and add support for setting up the sysroot from a local Nanvix build.

## Changes

- **docker-host.mk**: Replace \\\ with pure Make text functions for workspace ID generation, fixing builds on Windows hosts where Unix utilities are unavailable.
- **sync-sources.sh**: Add \|| true\ to the stale-file removal loop so the script does not abort under \set -e\ when the test condition is false.
- **z.py**: Add \--with-nanvix /path\ option to \z setup\ to populate the sysroot from a local Nanvix build directory instead of downloading from GitHub. Third-party dependencies are still fetched normally. Refactor the buildroot-into-sysroot merge into a shared helper.