### PR TITLE
[build] Strip binaries once during build instead of at each consumer

### DIFF
--- a/.nanvix/mk/common.mk
+++ b/.nanvix/mk/common.mk
@@ -170,15 +170,15 @@ ifdef CONFIG_NANVIX_DOCKER
 	@# Use cp instead of mv so that the original 'python' remains on disk;
 	@# otherwise Make would see the missing target and re-link on every run.
 	@if [ -f python ]; then cp -f python python$(EXE); fi
-	@# Strip debug symbols from the final binary for size reduction
+	@# Strip the final binary so all downstream consumers get a small artifact
 	$(DOCKER_RUN) sh -c '\
 		if [ ! -x "$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" ]; then \
 			echo "Warning: i686-nanvix-strip not found in Docker toolchain; skipping strip."; \
 		elif [ ! -f "$(DOCKER_WORKSPACE_PATH)/python$(EXE)" ]; then \
 			echo "Warning: $(DOCKER_WORKSPACE_PATH)/python$(EXE) not found; skipping strip."; \
 		else \
-			"$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" --strip-debug "$(DOCKER_WORKSPACE_PATH)/python$(EXE)" || { \
-				echo "Error: failed to strip debug symbols from python$(EXE) inside Docker."; exit 1; }; \
+			"$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" --strip-all "$(DOCKER_WORKSPACE_PATH)/python$(EXE)" || { \
+				echo "Error: failed to strip python$(EXE) inside Docker."; exit 1; }; \
 		fi'
 else
 	make -j$$(nproc) all
@@ -186,11 +186,11 @@ else
 	@# Use cp instead of mv so that the original 'python' remains on disk;
 	@# otherwise Make would see the missing target and re-link on every run.
 	@if [ -f python ]; then cp -f python python$(EXE); fi
-	@# Strip debug symbols from the final binary for size reduction
+	@# Strip the final binary so all downstream consumers get a small artifact
 	@if [ -x "$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip" ]; then \
 		if [ -f "python$(EXE)" ]; then \
-			"$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip" --strip-debug "python$(EXE)" || { \
-				echo "Error: failed to strip debug symbols from python$(EXE)."; exit 1; }; \
+			"$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip" --strip-all "python$(EXE)" || { \
+				echo "Error: failed to strip python$(EXE)."; exit 1; }; \
 		else \
 			echo "Warning: python$(EXE) not found; skipping strip."; \
 		fi; \

--- a/.nanvix/mk/package-common.mk
+++ b/.nanvix/mk/package-common.mk
@@ -50,9 +50,6 @@ endif
 	@if [ -f "$(CURDIR)/python$(EXE)" ]; then \
 		mkdir -p "$(RELEASE_STAGING)/bin"; \
 		cp "$(CURDIR)/python$(EXE)" "$(RELEASE_STAGING)/bin/python.elf"; \
-		if [ -x "$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip" ]; then \
-			"$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip" --strip-all "$(RELEASE_STAGING)/bin/python.elf" 2>/dev/null || true; \
-		fi; \
 		echo "Included bin/python.elf ($$(du -h "$(RELEASE_STAGING)/bin/python.elf" | cut -f1))"; \
 	else \
 		echo "Warning: python$(EXE) not found — binary will not be included in release"; \

--- a/.nanvix/mk/test-standalone.mk
+++ b/.nanvix/mk/test-standalone.mk
@@ -63,16 +63,6 @@ ramfs-stage: test-stage
 # test-hello-standalone: run hello test via nanvixd with the full-test ramfs
 test-hello-standalone: ramfs-stage
 	@cp "$(MKRAMFS)" $(TEST_STAGING)/sysroot/bin/ 2>/dev/null || true
-ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) sh -c '\
-		if [ -x "$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" ] && [ -f "$(DOCKER_WORKSPACE_PATH)/.nanvix/_test_staging/sysroot/bin/python3.12" ]; then \
-			"$(DOCKER_TOOLCHAIN_PATH)/bin/i686-nanvix-strip" --strip-debug \
-				"$(DOCKER_WORKSPACE_PATH)/.nanvix/_test_staging/sysroot/bin/python3.12" || true; \
-		fi'
-else
-	$(if $(wildcard $(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip),\
-		$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-strip --strip-debug $(TEST_STAGING)/sysroot/bin/python3.12 2>/dev/null || true)
-endif
 	@echo "Test: Hello world (standalone)..."
 	cd $(TEST_STAGING)/sysroot && \
 		{ \


### PR DESCRIPTION
Strip all binaries _once_ using `--strip-all` to produce the smallest artefacts.