### PR TITLE
[build] B: Fix distclean not removing _test_staging on Windows

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -14,6 +14,7 @@ Usage:
 import json
 import os
 import shutil
+import stat
 import sys
 import tarfile
 import tempfile
@@ -210,12 +211,10 @@ class CPythonBuild(ZScript):
             for name in ("_test_staging", "staging"):
                 p = self.repo_root / name
                 if p.is_dir():
-                    shutil.rmtree(p)
-                    log.info(f"Removed {name}/")
+                    self._rmtree_robust(p, name)
             test_staging = self.repo_root / ".nanvix" / "_test_staging"
             if test_staging.is_dir():
-                shutil.rmtree(test_staging)
-                log.info("Removed .nanvix/_test_staging/")
+                self._rmtree_robust(test_staging, ".nanvix/_test_staging")
         else:
             self.run(
                 "make",
@@ -224,6 +223,50 @@ class CPythonBuild(ZScript):
                 "clean",
                 cwd=self.repo_root,
             )
+
+    @staticmethod
+    def _rmtree_robust(path: Path, label: str) -> None:
+        """Remove a directory tree, retrying on permission errors.
+
+        On Windows, files copied from Docker volumes may have read-only
+        attributes that cause ``shutil.rmtree`` to fail.  The onerror
+        handler clears the write attribute and retries.  On other
+        platforms the original error is re-raised so failures are not
+        silently swallowed.
+        """
+        def _on_error(func, fpath, exc_info):
+            if os.name == "nt":
+                try:
+                    os.chmod(fpath, stat.S_IWRITE)
+                    func(fpath)
+                except OSError as retry_exc:
+                    log.warning(
+                        f"Failed to remove {fpath} after retry: {retry_exc} "
+                        f"(original error: {exc_info[1]})"
+                    )
+            else:
+                raise exc_info[1]
+
+        try:
+            shutil.rmtree(path, onerror=_on_error)
+            if path.exists():
+                log.warning(f"Could not fully remove {label}/ — some files may be locked")
+            else:
+                log.info(f"Removed {label}/")
+        except OSError as e:
+            log.warning(f"Could not remove {label}/: {e}")
+
+    def distclean(self) -> None:
+        """Remove all transient artifacts including test staging.
+
+        Extends the base distclean to also remove CPython-specific artifacts
+        (test staging, build outputs) that the base class does not know about.
+        """
+        try:
+            self.clean()
+        except Exception as e:
+            log.warning(f"clean() failed during distclean: {e}")
+        super().distclean()
 
     # ---- Fallback dependency download ------------------------------------
 


### PR DESCRIPTION
## Problem

`distclean` does not remove the `.nanvix/_test_staging/` directory on Windows. This causes `z test` to reuse stale binaries (e.g., nanvixd) from a previous build, producing incorrect benchmark results.

### Root cause

Two issues combine:

1. **`distclean` never calls `clean()`.**  The base class `distclean()` in `nanvix-zutil` only removes its own artifacts (`sysroot`, `buildroot`, `venv`, etc.).  The CPython-specific `_test_staging` directory is only handled by the `clean()` method, which `distclean` does not invoke.

2. **`shutil.rmtree()` silently fails on Windows.**  Files copied from Docker volumes often have read-only attributes.  `shutil.rmtree()` raises `PermissionError` on these files, and since there was no error handler, the deletion would fail silently — leaving the stale staging directory intact.

Because `_test_staging` survives, the `test-stage` target in `test-common.mk` sees that `python3.12` already exists in staging and skips re-populating it (including copying the updated nanvixd).  This means `z test` runs with an outdated nanvixd binary even after a full `distclean` → `setup` → `build` cycle.

### Observed impact

After upgrading nanvix from v0.12.415 to v0.12.418 (which includes the `fast_memcpy`/`fast_memset` optimizations), `z test` continued reporting ~5.2s execution time instead of the expected ~3.4s, because the staging directory still contained the old v0.12.415 nanvixd binary.

### Reproduction (on the default branch, before this fix)

```
# Create staging with a read-only file (simulates Docker volume copy)
mkdir -p .nanvix/_test_staging/sysroot/bin
echo "fake" > .nanvix/_test_staging/sysroot/bin/nanvixd.exe
attrib +R .nanvix\_test_staging\sysroot\bin\nanvixd.exe

# Run distclean
.\z distclean

# _test_staging is still there!
Test-Path .nanvix\_test_staging   # True  (BUG: should be False)
```

**Issue 1 — distclean skips _test_staging:**
```
=== Running distclean (default branch behavior) ===
  Would remove: venv
  (Note: _test_staging is NOT in the base class artifact list)

=== After distclean ===
  _test_staging exists: True
  Stale nanvixd.exe still present: True
```

**Issue 2 — even clean() fails on read-only files:**
```
=== Attempting shutil.rmtree (what clean() does) ===
  rmtree FAILED: [WinError 5] Access is denied: '.nanvix\_test_staging\sysroot\bin\nanvixd.exe'
  _test_staging still exists: True
```

**After this fix — _rmtree_robust handles read-only + distclean calls clean():**
```
=== Attempting _rmtree_robust (the fix) ===
  SUCCESS: Removed .nanvix/_test_staging/

=== After fix ===
  _test_staging exists: False
```

## Changes

- **Override `distclean()`**: calls `clean()` first (which removes `_test_staging` and other build artifacts), wrapped in `try/except` so base class cleanup always runs even if `clean()` fails. Then delegates to the base class for sysroot/buildroot/venv cleanup.
- **Add `_rmtree_robust()`**: uses `shutil.rmtree(onerror=...)` to clear the write attribute via `stat.S_IWRITE` on Windows and logs retry failures. On non-Windows, the original error is re-raised so failures are not silently swallowed.
- **Replace bare `shutil.rmtree()`** calls in `clean()` with `_rmtree_robust()`.