### PR TITLE
[ci] Sync zutils v0.7.21

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.12.432"
+nanvix-version = "0.12.435"
 
 [builds]
 [builds.matrix]

--- a/z.ps1
+++ b/z.ps1
@@ -29,7 +29,7 @@ $venvZutil = Join-Path $venvDir "Scripts\nanvix-zutil.exe"
 # Windows compatibility shim: nanvix-zutil references os.getuid/os.getgid
 # which are unavailable on Windows.  Stub them before importing the package.
 $ShimCode = @'
-import os,sys;os.getuid=getattr(os,'getuid',lambda:0);os.getgid=getattr(os,'getgid',lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
+import os,sys;os.getuid=getattr(os,"getuid",lambda:0);os.getgid=getattr(os,"getgid",lambda:0);from nanvix_zutil.__main__ import main;sys.exit(main())
 '@
 
 $zutilGlobalVersion = try {
@@ -116,31 +116,10 @@ else {
     }
 }
 
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-$filteredArgs = @()
-$i = 0
-while ($i -lt $ZArgs.Count) {
-    if ($ZArgs[$i] -eq '--with-nanvix') {
-        if ($i + 1 -ge $ZArgs.Count) {
-            throw "ERROR: --with-nanvix requires a path argument"
-        }
-        $localPath = (Resolve-Path $ZArgs[$i + 1] -ErrorAction Stop).Path
-        if (-not (Test-Path $localPath -PathType Container)) {
-            throw "ERROR: --with-nanvix path does not exist: $($ZArgs[$i + 1])"
-        }
-        $env:NANVIX_LOCAL_PATH = $localPath
-        $i += 2
-    }
-    else {
-        $filteredArgs += $ZArgs[$i]
-        $i++
-    }
-}
-
 if ($bin -eq $venvZutil) {
-    & $venvPython -c $ShimCode @filteredArgs
+    & $venvPython -c $ShimCode @ZArgs
 }
 else {
-    & $bin @filteredArgs
+    & $bin @ZArgs
 }
 exit $LASTEXITCODE

--- a/z.sh
+++ b/z.sh
@@ -72,31 +72,4 @@ else
     fi
 fi
 
-# Extract --with-nanvix PATH before forwarding to nanvix-zutil.
-# The nanvix-zutil CLI inspects positional args to find the subcommand;
-# --with-nanvix's PATH argument would be mistaken for a subcommand.
-# Pass the value via env var so z.py can pick it up.
-ARGS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --with-nanvix)
-            if [[ $# -lt 2 ]]; then
-                echo "ERROR: --with-nanvix requires a path argument" >&2
-                exit 1
-            fi
-            NANVIX_LOCAL_PATH="$(cd "$2" 2>/dev/null && pwd || readlink -f "$2")"
-            if [[ ! -d "$NANVIX_LOCAL_PATH" ]]; then
-                echo "ERROR: --with-nanvix path does not exist: $2" >&2
-                exit 1
-            fi
-            export NANVIX_LOCAL_PATH
-            shift 2
-            ;;
-        *)
-            ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
-
-exec "$BIN" "${ARGS[@]}"
+exec "$BIN" "$@"


### PR DESCRIPTION
Automated sync with [`v0.7.21`](https://github.com/nanvix/zutils/releases/tag/v0.7.21):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.12.435` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.