### PR TITLE
test: enable data structures and algorithms test modules (#371)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -193,9 +193,9 @@ DEFAULT_TEST_BATCH_SIZE = 4
 
 # Per-mode test exclusions (passed to regrtest --ignore).
 STANDALONE_EXCLUDE: list[str] = [
-    "test_queue",      # NSKIP015: OOM (thread stacks exhaust 32MB standalone heap)
-    "test_itertools",  # NSKIP015: OOM (large test data exhaust 32MB standalone heap)
-    "test_functools",  # NSKIP015: OOM (large test data exhaust 32MB standalone heap)
+    "test_queue",      # NSKIP019: standalone 32 MB heap too small for module
+    "test_itertools",  # NSKIP019: standalone 32 MB heap too small for module
+    "test_functools",  # NSKIP019: standalone 32 MB heap too small for module
 ]
 
 # Platform-specific nanvixd extra arguments.

--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -177,13 +177,26 @@ NANVIX_TEST_LIST: list[str] = [
     "test_frame", "test_contextlib", "test_contextlib_async",
     "test_pprint", "test_reprlib",
     "test_list", "test_dict",
+    "test_listcomps", "test_dictcomps", "test_setcomps", "test_genexps",
+    "test_set",
+    "test_heapq", "test_bisect", "test_queue", "test_sort",
+    "test_iter", "test_itertools", "test_iterlen",
+    "test_generators", "test_generator_stop", "test_yield_from", "test_coroutines",
+    "test_functools", "test_funcattrs", "test_decorators",
+    "test_copy", "test_copyreg",
+    "test_collections", "test_defaultdict", "test_ordered_dict", "test_deque", "test_array",
+    "test_weakref", "test_weakset", "test_buffer",
 ]
 
 # Default batch size for regrtest VM invocations.
 DEFAULT_TEST_BATCH_SIZE = 4
 
 # Per-mode test exclusions (passed to regrtest --ignore).
-STANDALONE_EXCLUDE: list[str] = ["test_filter_dealloc", "test_tokenize"]
+STANDALONE_EXCLUDE: list[str] = [
+    "test_queue",      # NSKIP015: OOM (thread stacks exhaust 32MB standalone heap)
+    "test_itertools",  # NSKIP015: OOM (large test data exhaust 32MB standalone heap)
+    "test_functools",  # NSKIP015: OOM (large test data exhaust 32MB standalone heap)
+]
 
 # Platform-specific nanvixd extra arguments.
 PLATFORM_NANVIXD_ARGS: dict[str, list[str]] = {

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -271,7 +271,7 @@ class BaseTest:
         for protocol in range(3, pickle.HIGHEST_PROTOCOL + 1):
             self.assertIs(a.__reduce_ex__(protocol)[0], array_reconstructor)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -288,7 +288,7 @@ class BaseTest:
             self.assertEqual(a.x, b.x)
             self.assertEqual(type(a), type(b))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_for_empty_array(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -305,7 +305,7 @@ class BaseTest:
             self.assertEqual(a.x, b.x)
             self.assertEqual(type(a), type(b))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         orig = array.array(self.typecode, self.example)
@@ -361,7 +361,7 @@ class BaseTest:
         self.assertEqual(list(a), list(self.example))
         self.assertEqual(list(reversed(a)), list(iter(a))[::-1])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reverse_iterator_picking(self):
         orig = array.array(self.typecode, self.example)
@@ -452,7 +452,7 @@ class BaseTest:
             array.array(self.typecode, self.example + self.example[:1])
         )
 
-    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
     @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def test_tofromfile(self):
         a = array.array(self.typecode, 2*self.example)
@@ -476,7 +476,7 @@ class BaseTest:
                 f.close()
             os_helper.unlink(os_helper.TESTFN)
 
-    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
     @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def test_fromfile_ioerror(self):
         # Issue #5395: Check if fromfile raises a proper OSError
@@ -489,7 +489,7 @@ class BaseTest:
             f.close()
             os_helper.unlink(os_helper.TESTFN)
 
-    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
     @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def test_filewrite(self):
         a = array.array(self.typecode, 2*self.example)

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -271,6 +271,8 @@ class BaseTest:
         for protocol in range(3, pickle.HIGHEST_PROTOCOL + 1):
             self.assertIs(a.__reduce_ex__(protocol)[0], array_reconstructor)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             a = array.array(self.typecode, self.example)
@@ -286,6 +288,8 @@ class BaseTest:
             self.assertEqual(a.x, b.x)
             self.assertEqual(type(a), type(b))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_for_empty_array(self):
         for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             a = array.array(self.typecode)
@@ -301,6 +305,8 @@ class BaseTest:
             self.assertEqual(a.x, b.x)
             self.assertEqual(type(a), type(b))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         orig = array.array(self.typecode, self.example)
         data = list(orig)
@@ -355,6 +361,8 @@ class BaseTest:
         self.assertEqual(list(a), list(self.example))
         self.assertEqual(list(reversed(a)), list(iter(a))[::-1])
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reverse_iterator_picking(self):
         orig = array.array(self.typecode, self.example)
         data = list(orig)
@@ -444,6 +452,8 @@ class BaseTest:
             array.array(self.typecode, self.example + self.example[:1])
         )
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def test_tofromfile(self):
         a = array.array(self.typecode, 2*self.example)
         self.assertRaises(TypeError, a.tofile)
@@ -466,6 +476,8 @@ class BaseTest:
                 f.close()
             os_helper.unlink(os_helper.TESTFN)
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def test_fromfile_ioerror(self):
         # Issue #5395: Check if fromfile raises a proper OSError
         # instead of EOFError.
@@ -477,6 +489,8 @@ class BaseTest:
             f.close()
             os_helper.unlink(os_helper.TESTFN)
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def test_filewrite(self):
         a = array.array(self.typecode, 2*self.example)
         f = open(os_helper.TESTFN, 'wb')

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -123,13 +123,15 @@ class TestChainMap(unittest.TestCase):
                 self.assertIs(m1, m2)
 
         # check deep copies
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            e = pickle.loads(pickle.dumps(d, proto))
-            self.assertEqual(d, e)
-            self.assertEqual(d.maps, e.maps)
-            self.assertIsNot(d, e)
-            for m1, m2 in zip(d.maps, e.maps):
-                self.assertIsNot(m1, m2, e)
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                e = pickle.loads(pickle.dumps(d, proto))
+                self.assertEqual(d, e)
+                self.assertEqual(d.maps, e.maps)
+                self.assertIsNot(d, e)
+                for m1, m2 in zip(d.maps, e.maps):
+                    self.assertIsNot(m1, m2, e)
         for e in [copy.deepcopy(d),
                   eval(repr(d))
                 ]:
@@ -566,6 +568,8 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(b2, tuple(b2_expected))
         self.assertEqual(b._fields, tuple(names))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         p = TestNT(x=10, y=20, z=30)
         for module in (pickle,):
@@ -685,13 +689,15 @@ class TestNamedTuple(unittest.TestCase):
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)
 
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            with self.subTest(proto=proto):
-                class NewPoint(tuple):
-                    x = pickle.loads(pickle.dumps(Point.x, proto))
-                    y = pickle.loads(pickle.dumps(Point.y, proto))
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(proto=proto):
+                    class NewPoint(tuple):
+                        x = pickle.loads(pickle.dumps(Point.x, proto))
+                        y = pickle.loads(pickle.dumps(Point.y, proto))
 
-                np = NewPoint([1, 2])
+                    np = NewPoint([1, 2])
 
                 self.assertEqual(np.x, 1)
                 self.assertEqual(np.y, 2)
@@ -2215,9 +2221,11 @@ class TestCounter(unittest.TestCase):
         check(words.copy())
         check(copy.copy(words))
         check(copy.deepcopy(words))
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            with self.subTest(proto=proto):
-                check(pickle.loads(pickle.dumps(words, proto)))
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(proto=proto):
+                    check(pickle.loads(pickle.dumps(words, proto)))
         check(eval(repr(words)))
         update_test = Counter()
         update_test.update(words)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -123,7 +123,7 @@ class TestChainMap(unittest.TestCase):
                 self.assertIs(m1, m2)
 
         # check deep copies
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 e = pickle.loads(pickle.dumps(d, proto))
@@ -568,7 +568,7 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(b2, tuple(b2_expected))
         self.assertEqual(b._fields, tuple(names))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         p = TestNT(x=10, y=20, z=30)
@@ -689,7 +689,7 @@ class TestNamedTuple(unittest.TestCase):
         self.assertRaises(AttributeError, Point.x.__set__, p, 33)
         self.assertRaises(AttributeError, Point.x.__delete__, p)
 
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 with self.subTest(proto=proto):
@@ -2221,7 +2221,7 @@ class TestCounter(unittest.TestCase):
         check(words.copy())
         check(copy.copy(words))
         check(copy.deepcopy(words))
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 with self.subTest(proto=proto):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2120,8 +2120,8 @@ class CoroutineTest(unittest.TestCase):
         finally:
             aw.close()
 
-    # NSKIP013 https://github.com/nanvix/cpython/issues/371
-    @unittest.skipIf(support.is_nanvix, "NSKIP013: event loop interferes with coro warning in standalone")
+    # NSKIP017 https://github.com/nanvix/cpython/issues/485
+    @unittest.skipIf(support.is_nanvix, "NSKIP017: event loop interferes with coro warning in standalone")
     def test_fatal_coro_warning(self):
         # Issue 27811
         async def func(): pass
@@ -2255,7 +2255,7 @@ class CoroutineTest(unittest.TestCase):
     support.is_emscripten or support.is_wasi,
     "asyncio does not work under Emscripten/WASI yet."
 )
-# NSKIP014 https://github.com/nanvix/cpython/issues/371
+# NSKIP014 https://github.com/nanvix/cpython/issues/482
 @unittest.skipIf(support.is_nanvix, "NSKIP014: asyncio needs poll/selectors, unavailable in standalone")
 class CoroAsyncIOCompatTest(unittest.TestCase):
 
@@ -2448,7 +2448,7 @@ class UnawaitedWarningDuringShutdownTest(unittest.TestCase):
         assert_python_ok("-c", code)
 
 
-# NSKIP002 https://github.com/nanvix/cpython/issues/371
+# NSKIP002 https://github.com/nanvix/cpython/issues/470
 @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
 @support.cpython_only
 class CAPITest(unittest.TestCase):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2120,6 +2120,8 @@ class CoroutineTest(unittest.TestCase):
         finally:
             aw.close()
 
+    # NSKIP013 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP013: event loop interferes with coro warning in standalone")
     def test_fatal_coro_warning(self):
         # Issue 27811
         async def func(): pass
@@ -2253,6 +2255,8 @@ class CoroutineTest(unittest.TestCase):
     support.is_emscripten or support.is_wasi,
     "asyncio does not work under Emscripten/WASI yet."
 )
+# NSKIP014 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP014: asyncio needs poll/selectors, unavailable in standalone")
 class CoroAsyncIOCompatTest(unittest.TestCase):
 
     def test_asyncio_1(self):
@@ -2444,6 +2448,8 @@ class UnawaitedWarningDuringShutdownTest(unittest.TestCase):
         assert_python_ok("-c", code)
 
 
+# NSKIP002 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
 @support.cpython_only
 class CAPITest(unittest.TestCase):
 

--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -3,6 +3,7 @@
 import copy
 import pickle
 import unittest
+from test import support
 
 from collections import defaultdict
 
@@ -140,6 +141,8 @@ class TestDefaultDict(unittest.TestCase):
     def test_callable_arg(self):
         self.assertRaises(TypeError, defaultdict, {})
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         d = defaultdict(int)
         d[1]

--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -141,7 +141,7 @@ class TestDefaultDict(unittest.TestCase):
     def test_callable_arg(self):
         self.assertRaises(TypeError, defaultdict, {})
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         d = defaultdict(int)

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -613,6 +613,8 @@ class TestBasic(unittest.TestCase):
         self.assertNotEqual(id(d), id(e))
         self.assertEqual(list(d), list(e))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for d in deque(range(200)), deque(range(200), 100):
             for i in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -622,6 +624,8 @@ class TestBasic(unittest.TestCase):
                 self.assertEqual(list(e), list(d))
                 self.assertEqual(e.maxlen, d.maxlen)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_recursive(self):
         for d in deque('abc'), deque('abc', 3):
             d.append(d)
@@ -631,6 +635,8 @@ class TestBasic(unittest.TestCase):
                 self.assertEqual(id(e[-1]), id(e))
                 self.assertEqual(e.maxlen, d.maxlen)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         orig = deque(range(200))
         data = [i*1.01 for i in orig]
@@ -830,16 +836,20 @@ class TestSubclass(unittest.TestCase):
                 self.assertEqual(type(d), type(e))
                 self.assertEqual(list(d), list(e))
 
-                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                    s = pickle.dumps(d, proto)
-                    e = pickle.loads(s)
-                    self.assertNotEqual(id(d), id(e))
-                    self.assertEqual(type(d), type(e))
-                    self.assertEqual(list(d), list(e))
-                    self.assertEqual(e.x, d.x)
-                    self.assertEqual(e.z, d.z)
-                    self.assertFalse(hasattr(e, 'y'))
+                # NSKIP001 https://github.com/nanvix/cpython/issues/371
+                if not support.is_nanvix:
+                    for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                        s = pickle.dumps(d, proto)
+                        e = pickle.loads(s)
+                        self.assertNotEqual(id(d), id(e))
+                        self.assertEqual(type(d), type(e))
+                        self.assertEqual(list(d), list(e))
+                        self.assertEqual(e.x, d.x)
+                        self.assertEqual(e.z, d.z)
+                        self.assertFalse(hasattr(e, 'y'))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_recursive(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             for d in Deque('abc'), Deque('abc', 3):
@@ -905,6 +915,11 @@ class TestSubclassWithKwargs(unittest.TestCase):
 
 class TestSequence(seq_tests.CommonTest):
     type2test = deque
+
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
+    def test_pickle(self):
+        super().test_pickle()
 
     def test_getitem(self):
         # For now, bypass tests that require slicing

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -613,7 +613,7 @@ class TestBasic(unittest.TestCase):
         self.assertNotEqual(id(d), id(e))
         self.assertEqual(list(d), list(e))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for d in deque(range(200)), deque(range(200), 100):
@@ -624,7 +624,7 @@ class TestBasic(unittest.TestCase):
                 self.assertEqual(list(e), list(d))
                 self.assertEqual(e.maxlen, d.maxlen)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_recursive(self):
         for d in deque('abc'), deque('abc', 3):
@@ -635,7 +635,7 @@ class TestBasic(unittest.TestCase):
                 self.assertEqual(id(e[-1]), id(e))
                 self.assertEqual(e.maxlen, d.maxlen)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         orig = deque(range(200))
@@ -836,7 +836,7 @@ class TestSubclass(unittest.TestCase):
                 self.assertEqual(type(d), type(e))
                 self.assertEqual(list(d), list(e))
 
-                # NSKIP001 https://github.com/nanvix/cpython/issues/371
+                # NSKIP001 https://github.com/nanvix/cpython/issues/469
                 if not support.is_nanvix:
                     for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                         s = pickle.dumps(d, proto)
@@ -848,7 +848,7 @@ class TestSubclass(unittest.TestCase):
                         self.assertEqual(e.z, d.z)
                         self.assertFalse(hasattr(e, 'y'))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_recursive(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -916,7 +916,7 @@ class TestSubclassWithKwargs(unittest.TestCase):
 class TestSequence(seq_tests.CommonTest):
     type2test = deque
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         super().test_pickle()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1,3 +1,11 @@
+# NSKIP015 https://github.com/nanvix/cpython/issues/371
+# This module is excluded from standalone mode via STANDALONE_EXCLUDE in
+# .nanvix/config.py.  The nanvixd standalone VM has a 32MB heap
+# (sysalloc capacity=0x2000000).  test_functools exhausts it.
+#
+# In non-standalone modes (multi-process, single-process) the only failures
+# are pickle-related (NSKIP001), annotated below.
+
 import abc
 import builtins
 import collections
@@ -255,6 +263,8 @@ class TestPartial:
         finally:
             f.__setstate__((capture, (), {}, {}))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         with replaced_module('functools', self.module):
             f = self.partial(signature, ['asdf'], bar=[True])
@@ -338,6 +348,8 @@ class TestPartial:
         self.assertEqual(r, ((1, 2), {}))
         self.assertIs(type(r[0]), tuple)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_recursive_pickle(self):
         with replaced_module('functools', self.module):
             f = self.partial(capture)
@@ -1225,6 +1237,8 @@ class TestTotalOrdering(unittest.TestCase):
             with self.assertRaises(TypeError):
                 a <= b
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             for name in '__lt__', '__gt__', '__le__', '__ge__':
@@ -1640,6 +1654,8 @@ class TestLRU:
             self.assertEqual(getattr(g, attr), getattr(f, attr))
 
     @threading_helper.requires_working_threading()
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_lru_cache_threaded(self):
         n, m = 5, 11
         def orig(x, y):
@@ -1689,6 +1705,8 @@ class TestLRU:
             sys.setswitchinterval(orig_si)
 
     @threading_helper.requires_working_threading()
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_lru_cache_threaded2(self):
         # Simultaneous call with the same arguments
         n, m = 5, 7
@@ -1717,6 +1735,8 @@ class TestLRU:
                 self.assertEqual(f.cache_info(), (0, (i+1)*n, m*n, i+1))
 
     @threading_helper.requires_working_threading()
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_lru_cache_threaded3(self):
         @self.module.lru_cache(maxsize=2)
         def f(x):
@@ -1785,6 +1805,8 @@ class TestLRU:
         self.assertEqual(b.f.cache_info(), X.f.cache_info())
         self.assertEqual(c.f.cache_info(), X.f.cache_info())
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         cls = self.__class__
         for f in cls.cached_func[0], cls.cached_meth, cls.cached_staticmeth:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1,10 +1,6 @@
-# NSKIP015 https://github.com/nanvix/cpython/issues/371
-# This module is excluded from standalone mode via STANDALONE_EXCLUDE in
-# .nanvix/config.py.  The nanvixd standalone VM has a 32MB heap
-# (sysalloc capacity=0x2000000).  test_functools exhausts it.
-#
-# In non-standalone modes (multi-process, single-process) the only failures
-# are pickle-related (NSKIP001), annotated below.
+# NSKIP019 https://github.com/nanvix/cpython/issues/487
+# Module is excluded from standalone mode (32 MB heap too small).  Remaining
+# skips in non-standalone modes are NSKIP001 (pickle).
 
 import abc
 import builtins
@@ -263,7 +259,7 @@ class TestPartial:
         finally:
             f.__setstate__((capture, (), {}, {}))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         with replaced_module('functools', self.module):
@@ -348,7 +344,7 @@ class TestPartial:
         self.assertEqual(r, ((1, 2), {}))
         self.assertIs(type(r[0]), tuple)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_recursive_pickle(self):
         with replaced_module('functools', self.module):
@@ -1237,7 +1233,7 @@ class TestTotalOrdering(unittest.TestCase):
             with self.assertRaises(TypeError):
                 a <= b
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1654,7 +1650,7 @@ class TestLRU:
             self.assertEqual(getattr(g, attr), getattr(f, attr))
 
     @threading_helper.requires_working_threading()
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_lru_cache_threaded(self):
         n, m = 5, 11
@@ -1705,7 +1701,7 @@ class TestLRU:
             sys.setswitchinterval(orig_si)
 
     @threading_helper.requires_working_threading()
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_lru_cache_threaded2(self):
         # Simultaneous call with the same arguments
@@ -1735,7 +1731,7 @@ class TestLRU:
                 self.assertEqual(f.cache_info(), (0, (i+1)*n, m*n, i+1))
 
     @threading_helper.requires_working_threading()
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_lru_cache_threaded3(self):
         @self.module.lru_cache(maxsize=2)
@@ -1805,7 +1801,7 @@ class TestLRU:
         self.assertEqual(b.f.cache_info(), X.f.cache_info())
         self.assertEqual(c.f.cache_info(), X.f.cache_info())
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         cls = self.__class__

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -5,11 +5,13 @@ import unittest
 from test.support import cpython_only
 from test.support.os_helper import TESTFN, unlink
 from test.support import check_free_after_iterating, ALWAYS_EQ, NEVER_EQ
+from test import support
 import pickle
 import collections.abc
 import functools
 import contextlib
 import builtins
+
 
 # Test result of triple loop (too big to inline)
 TRIPLETS = [(0, 0, 0), (0, 0, 1), (0, 0, 2),
@@ -127,7 +129,14 @@ class TestCase(unittest.TestCase):
         self.assertEqual(res, seq)
 
     # Helper to check picklability
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    _nanvix_pickle_warned = False
     def check_pickle(self, itorg, seq):
+        if support.is_nanvix:
+            if not self._nanvix_pickle_warned:
+                support.print_warning("NSKIP001: skipping pickle check on Nanvix (32-bit corrupt)")
+                type(self)._nanvix_pickle_warned = True
+            return
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             d = pickle.dumps(itorg, proto)
             it = pickle.loads(d)
@@ -200,6 +209,8 @@ class TestCase(unittest.TestCase):
     def test_seq_class_iter(self):
         self.check_iterator(iter(SequenceClass(10)), list(range(10)))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_mutating_seq_class_iter_pickle(self):
         orig = SequenceClass(5)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -129,7 +129,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(res, seq)
 
     # Helper to check picklability
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     _nanvix_pickle_warned = False
     def check_pickle(self, itorg, seq):
         if support.is_nanvix:
@@ -209,7 +209,7 @@ class TestCase(unittest.TestCase):
     def test_seq_class_iter(self):
         self.check_iterator(iter(SequenceClass(10)), list(range(10)))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_mutating_seq_class_iter_pickle(self):
         orig = SequenceClass(5)

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1,3 +1,12 @@
+# NSKIP015 https://github.com/nanvix/cpython/issues/371
+# This module is excluded from standalone mode via STANDALONE_EXCLUDE in
+# .nanvix/config.py (32MB heap too small for itertools' large allocations).
+#
+# In non-standalone modes (256MB), two categories of failure remain:
+#   NSKIP001: pickle corrupt on 32-bit — picklecopiers emptied, and
+#             pickle_deprecated decorator patched to skip assertWarns phase.
+#   NSKIP015: test_tee_del_backward OOMs (20M-element tee exhausts memory).
+
 import doctest
 import unittest
 from test import support
@@ -24,15 +33,22 @@ def pickle_deprecated(testfunc):
     Third, run with warnings promoted to errors.
     """
     def inner(self):
-        with self.assertWarns(DeprecationWarning):
-            testfunc(self)
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # On Nanvix picklecopiers is empty (32-bit pickle corrupt), so
+        # no pickle call happens and the DeprecationWarning is never
+        # emitted.  Skip the assertWarns and assertRaises phases; still
+        # run with warnings suppressed to exercise the non-pickle logic.
+        if not support.is_nanvix:
+            with self.assertWarns(DeprecationWarning):
+                testfunc(self)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=DeprecationWarning)
             testfunc(self)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", category=DeprecationWarning)
-            with self.assertRaises((DeprecationWarning, AssertionError, SystemError)):
-                testfunc(self)
+        if not support.is_nanvix:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=DeprecationWarning)
+                with self.assertRaises((DeprecationWarning, AssertionError, SystemError)):
+                    testfunc(self)
 
     return inner
 
@@ -100,11 +116,23 @@ def underten(x):
 
 picklecopiers = [lambda s, proto=proto: pickle.loads(pickle.dumps(s, proto))
                  for proto in range(pickle.HIGHEST_PROTOCOL + 1)]
+# NSKIP001 https://github.com/nanvix/cpython/issues/371
+_nanvix_pickle_warned = False
+if support.is_nanvix:
+    support.print_warning("NSKIP001: disabling picklecopiers on Nanvix (32-bit corrupt)")
+    picklecopiers = []
 
 class TestBasicOps(unittest.TestCase):
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
     def pickletest(self, protocol, it, stop=4, take=1, compare=None):
         """Test that an iterator is the same after pickling, also when part-consumed"""
+        if support.is_nanvix:
+            global _nanvix_pickle_warned
+            if not _nanvix_pickle_warned:
+                support.print_warning("NSKIP001: skipping pickle check on Nanvix (32-bit corrupt)")
+                _nanvix_pickle_warned = True
+            return
         def expand(it, i=0):
             # Recursively expand iterables, within sensible bounds
             if i > 10:
@@ -703,6 +731,8 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(islice(cycle(gen3()),10)), [0,1,2,0,1,2,0,1,2,0])
 
     @pickle_deprecated
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_cycle_copy_pickle(self):
         # check copy, deepcopy, pickle
         c = cycle('abc')
@@ -740,6 +770,8 @@ class TestBasicOps(unittest.TestCase):
             self.assertEqual(take(20, d), list('cdeabcdeabcdeabcdeab'))
 
     @pickle_deprecated
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_cycle_unpickle_compat(self):
         testcases = [
             b'citertools\ncycle\n(c__builtin__\niter\n((lI1\naI2\naI3\natRI1\nbtR((lI1\naI0\ntb.',
@@ -828,13 +860,15 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(s, dup)
 
         # Check normal pickled
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            dup = []
-            for k, g in pickle.loads(pickle.dumps(groupby(s, testR), proto)):
-                for elem in g:
-                    self.assertEqual(k, elem[0])
-                    dup.append(elem)
-            self.assertEqual(s, dup)
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                dup = []
+                for k, g in pickle.loads(pickle.dumps(groupby(s, testR), proto)):
+                    for elem in g:
+                        self.assertEqual(k, elem[0])
+                        dup.append(elem)
+                self.assertEqual(s, dup)
 
         # Check nested case
         dup = []
@@ -847,15 +881,17 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(s, dup)
 
         # Check nested and pickled
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            dup = []
-            for k, g in pickle.loads(pickle.dumps(groupby(s, testR), proto)):
-                for ik, ig in pickle.loads(pickle.dumps(groupby(g, testR2), proto)):
-                    for elem in ig:
-                        self.assertEqual(k, elem[0])
-                        self.assertEqual(ik, elem[2])
-                        dup.append(elem)
-            self.assertEqual(s, dup)
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                dup = []
+                for k, g in pickle.loads(pickle.dumps(groupby(s, testR), proto)):
+                    for ik, ig in pickle.loads(pickle.dumps(groupby(g, testR2), proto)):
+                        for elem in ig:
+                            self.assertEqual(k, elem[0])
+                            self.assertEqual(ik, elem[2])
+                            dup.append(elem)
+                self.assertEqual(s, dup)
 
 
         # Check case where inner iterator is not used
@@ -877,12 +913,14 @@ class TestBasicOps(unittest.TestCase):
         list(it)  # exhaust the groupby iterator
         self.assertEqual(list(g3), [])
 
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            it = groupby(s, testR)
-            _, g = next(it)
-            next(it)
-            next(it)
-            self.assertEqual(list(pickle.loads(pickle.dumps(g, proto))), [])
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                it = groupby(s, testR)
+                _, g = next(it)
+                next(it)
+                next(it)
+                self.assertEqual(list(pickle.loads(pickle.dumps(g, proto))), [])
 
         # Exercise pipes and filters style
         s = 'abracadabra'
@@ -957,11 +995,13 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(copy.copy(c)), ans)
         c = filter(isEven, range(6))
         self.assertEqual(list(copy.deepcopy(c)), ans)
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            c = filter(isEven, range(6))
-            self.assertEqual(list(pickle.loads(pickle.dumps(c, proto))), ans)
-            next(c)
-            self.assertEqual(list(pickle.loads(pickle.dumps(c, proto))), ans[1:])
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                c = filter(isEven, range(6))
+                self.assertEqual(list(pickle.loads(pickle.dumps(c, proto))), ans)
+                next(c)
+                self.assertEqual(list(pickle.loads(pickle.dumps(c, proto))), ans[1:])
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             c = filter(isEven, range(6))
             self.pickletest(proto, c)
@@ -1011,15 +1051,17 @@ class TestBasicOps(unittest.TestCase):
         ans = [(x,y) for x, y in copy.deepcopy(zip('abc',count()))]
         self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
 
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            ans = [(x,y) for x, y in pickle.loads(pickle.dumps(zip('abc',count()), proto))]
-            self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                ans = [(x,y) for x, y in pickle.loads(pickle.dumps(zip('abc',count()), proto))]
+                self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
 
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            testIntermediate = zip('abc',count())
-            next(testIntermediate)
-            ans = [(x,y) for x, y in pickle.loads(pickle.dumps(testIntermediate, proto))]
-            self.assertEqual(ans, [('b', 1), ('c', 2)])
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                testIntermediate = zip('abc',count())
+                next(testIntermediate)
+                ans = [(x,y) for x, y in pickle.loads(pickle.dumps(testIntermediate, proto))]
+                self.assertEqual(ans, [('b', 1), ('c', 2)])
 
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             self.pickletest(proto, zip('abc', count()))
@@ -1704,6 +1746,8 @@ class TestBasicOps(unittest.TestCase):
         script_helper.assert_python_ok("-c", script)
 
     # Issue 13454: Crash when deleting backward iterator from tee()
+    # NSKIP015 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP015: 20M-element tee exhausts Nanvix memory")
     def test_tee_del_backward(self):
         forward, backward = tee(repeat(None, 20000000))
         try:
@@ -1856,6 +1900,8 @@ class TestExamples(unittest.TestCase):
         self.assertEqual(list(accumulate([1,2,3,4,5])), [1, 3, 6, 10, 15])
 
     @pickle_deprecated
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_accumulate_reducible(self):
         # check copy, deepcopy, pickle
         data = [1, 2, 3, 4, 5]
@@ -1872,6 +1918,8 @@ class TestExamples(unittest.TestCase):
         self.assertEqual(list(copy.copy(it)), accumulated[1:])
 
     @pickle_deprecated
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_accumulate_reducible_none(self):
         # Issue #25718: total is None
         it = accumulate([None, None, None], operator.is_)

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1,11 +1,6 @@
-# NSKIP015 https://github.com/nanvix/cpython/issues/371
-# This module is excluded from standalone mode via STANDALONE_EXCLUDE in
-# .nanvix/config.py (32MB heap too small for itertools' large allocations).
-#
-# In non-standalone modes (256MB), two categories of failure remain:
-#   NSKIP001: pickle corrupt on 32-bit — picklecopiers emptied, and
-#             pickle_deprecated decorator patched to skip assertWarns phase.
-#   NSKIP015: test_tee_del_backward OOMs (20M-element tee exhausts memory).
+# NSKIP019 https://github.com/nanvix/cpython/issues/487
+# Module is excluded from standalone mode (32 MB heap too small).  Remaining
+# skips in non-standalone modes are NSKIP001 (pickle) and NSKIP015 (tee OOM).
 
 import doctest
 import unittest
@@ -33,7 +28,7 @@ def pickle_deprecated(testfunc):
     Third, run with warnings promoted to errors.
     """
     def inner(self):
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         # On Nanvix picklecopiers is empty (32-bit pickle corrupt), so
         # no pickle call happens and the DeprecationWarning is never
         # emitted.  Skip the assertWarns and assertRaises phases; still
@@ -116,7 +111,7 @@ def underten(x):
 
 picklecopiers = [lambda s, proto=proto: pickle.loads(pickle.dumps(s, proto))
                  for proto in range(pickle.HIGHEST_PROTOCOL + 1)]
-# NSKIP001 https://github.com/nanvix/cpython/issues/371
+# NSKIP001 https://github.com/nanvix/cpython/issues/469
 _nanvix_pickle_warned = False
 if support.is_nanvix:
     support.print_warning("NSKIP001: disabling picklecopiers on Nanvix (32-bit corrupt)")
@@ -124,7 +119,7 @@ if support.is_nanvix:
 
 class TestBasicOps(unittest.TestCase):
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     def pickletest(self, protocol, it, stop=4, take=1, compare=None):
         """Test that an iterator is the same after pickling, also when part-consumed"""
         if support.is_nanvix:
@@ -731,7 +726,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(islice(cycle(gen3()),10)), [0,1,2,0,1,2,0,1,2,0])
 
     @pickle_deprecated
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_cycle_copy_pickle(self):
         # check copy, deepcopy, pickle
@@ -770,7 +765,7 @@ class TestBasicOps(unittest.TestCase):
             self.assertEqual(take(20, d), list('cdeabcdeabcdeabcdeab'))
 
     @pickle_deprecated
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_cycle_unpickle_compat(self):
         testcases = [
@@ -860,7 +855,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(s, dup)
 
         # Check normal pickled
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 dup = []
@@ -881,7 +876,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(s, dup)
 
         # Check nested and pickled
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 dup = []
@@ -913,7 +908,7 @@ class TestBasicOps(unittest.TestCase):
         list(it)  # exhaust the groupby iterator
         self.assertEqual(list(g3), [])
 
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 it = groupby(s, testR)
@@ -995,7 +990,7 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(copy.copy(c)), ans)
         c = filter(isEven, range(6))
         self.assertEqual(list(copy.deepcopy(c)), ans)
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 c = filter(isEven, range(6))
@@ -1051,7 +1046,7 @@ class TestBasicOps(unittest.TestCase):
         ans = [(x,y) for x, y in copy.deepcopy(zip('abc',count()))]
         self.assertEqual(ans, [('a', 0), ('b', 1), ('c', 2)])
 
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 ans = [(x,y) for x, y in pickle.loads(pickle.dumps(zip('abc',count()), proto))]
@@ -1746,8 +1741,8 @@ class TestBasicOps(unittest.TestCase):
         script_helper.assert_python_ok("-c", script)
 
     # Issue 13454: Crash when deleting backward iterator from tee()
-    # NSKIP015 https://github.com/nanvix/cpython/issues/371
-    @unittest.skipIf(support.is_nanvix, "NSKIP015: 20M-element tee exhausts Nanvix memory")
+    # NSKIP015 https://github.com/nanvix/cpython/issues/483
+    @unittest.skipIf(support.is_nanvix, "NSKIP015: OOM — test allocation exceeds available heap")
     def test_tee_del_backward(self):
         forward, backward = tee(repeat(None, 20000000))
         try:
@@ -1900,7 +1895,7 @@ class TestExamples(unittest.TestCase):
         self.assertEqual(list(accumulate([1,2,3,4,5])), [1, 3, 6, 10, 15])
 
     @pickle_deprecated
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_accumulate_reducible(self):
         # check copy, deepcopy, pickle
@@ -1918,7 +1913,7 @@ class TestExamples(unittest.TestCase):
         self.assertEqual(list(copy.copy(it)), accumulated[1:])
 
     @pickle_deprecated
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_accumulate_reducible_none(self):
         # Issue #25718: total is None

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -321,7 +321,7 @@ class OrderedDictTests:
         self.assertIsNot(dup.z, od.z)
         self.assertFalse(hasattr(dup, 'y'))
         # pickle directly pulls the module, so we have to fake it
-        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        # NSKIP001 https://github.com/nanvix/cpython/issues/469
         if not support.is_nanvix:
             with replaced_module('collections', self.module):
                 for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -358,7 +358,7 @@ class OrderedDictTests:
         self.assertEqual(od.__dict__['x'], 10)
         self.assertEqual(od.__reduce__()[2], {'x': 10})
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_recursive(self):
         OrderedDict = self.OrderedDict
@@ -825,7 +825,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
                 del od['c']
         self.assertEqual(list(od), list('bdeaf'))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterators_pickling(self):
         OrderedDict = self.OrderedDict

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -321,14 +321,16 @@ class OrderedDictTests:
         self.assertIsNot(dup.z, od.z)
         self.assertFalse(hasattr(dup, 'y'))
         # pickle directly pulls the module, so we have to fake it
-        with replaced_module('collections', self.module):
-            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-                with self.subTest(proto=proto):
-                    dup = pickle.loads(pickle.dumps(od, proto))
-                    check(dup)
-                    self.assertEqual(dup.x, od.x)
-                    self.assertEqual(dup.z, od.z)
-                    self.assertFalse(hasattr(dup, 'y'))
+        # NSKIP001 https://github.com/nanvix/cpython/issues/371
+        if not support.is_nanvix:
+            with replaced_module('collections', self.module):
+                for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                    with self.subTest(proto=proto):
+                        dup = pickle.loads(pickle.dumps(od, proto))
+                        check(dup)
+                        self.assertEqual(dup.x, od.x)
+                        self.assertEqual(dup.z, od.z)
+                        self.assertFalse(hasattr(dup, 'y'))
         check(eval(repr(od)))
         update_test = OrderedDict()
         update_test.update(od)
@@ -356,6 +358,8 @@ class OrderedDictTests:
         self.assertEqual(od.__dict__['x'], 10)
         self.assertEqual(od.__reduce__()[2], {'x': 10})
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle_recursive(self):
         OrderedDict = self.OrderedDict
         od = OrderedDict()
@@ -821,6 +825,8 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
                 del od['c']
         self.assertEqual(list(od), list('bdeaf'))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterators_pickling(self):
         OrderedDict = self.OrderedDict
         pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1,16 +1,10 @@
 # Some simple queue module tests, plus some failure conditions
 # to ensure the Queue locks remain stable.
 
-# NSKIP015 https://github.com/nanvix/cpython/issues/371
-# This module is excluded from standalone mode via STANDALONE_EXCLUDE in
-# .nanvix/config.py (32MB heap too small for threading tests).
-#
-# In non-standalone modes (256MB), two categories of failure remain:
-#   NSKIP015: CSimpleQueueTest.test_reentrancy OOMs from circular __del__ loop
-#   NSKIP016: Nanvix has a low thread creation limit; pure-Python queue classes
-#             (Py*) exhaust it, and BaseSimpleQueueTest thread-heavy methods
-#             (test_order, test_many_threads*) fail even for C variants due to
-#             cumulative thread exhaustion across the test run.
+# NSKIP019 https://github.com/nanvix/cpython/issues/487
+# Module is excluded from standalone mode (32 MB heap too small).  Remaining
+# skips in non-standalone modes are NSKIP016 (thread limit) and NSKIP018
+# (CSimpleQueueTest.test_reentrancy circular __del__ leak).
 
 import itertools
 import random
@@ -202,7 +196,7 @@ class BaseQueueTestMixin(BlockingTestMixin):
         else:
             self.fail("Did not detect task count going negative")
 
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_queue_join(self):
         # Test that a queue join()s successfully, and before anything else
@@ -262,7 +256,7 @@ class QueueTest(BaseQueueTestMixin):
         self.type2test = self.queue.Queue
         super().setUp()
 
-# NSKIP016 https://github.com/nanvix/cpython/issues/371
+# NSKIP016 https://github.com/nanvix/cpython/issues/484
 # Nanvix has a low thread creation limit; pure-Python queue tests exceed it.
 @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyQueueTest(QueueTest, unittest.TestCase):
@@ -281,7 +275,7 @@ class LifoQueueTest(BaseQueueTestMixin):
         super().setUp()
 
 
-# NSKIP016 https://github.com/nanvix/cpython/issues/371
+# NSKIP016 https://github.com/nanvix/cpython/issues/484
 @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyLifoQueueTest(LifoQueueTest, unittest.TestCase):
     queue = py_queue
@@ -299,7 +293,7 @@ class PriorityQueueTest(BaseQueueTestMixin):
         super().setUp()
 
 
-# NSKIP016 https://github.com/nanvix/cpython/issues/371
+# NSKIP016 https://github.com/nanvix/cpython/issues/484
 @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyPriorityQueueTest(PriorityQueueTest, unittest.TestCase):
     queue = py_queue
@@ -431,7 +425,7 @@ class FailingQueueTest(BlockingTestMixin):
 
 
 
-# NSKIP016 https://github.com/nanvix/cpython/issues/371
+# NSKIP016 https://github.com/nanvix/cpython/issues/484
 @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyFailingQueueTest(FailingQueueTest, unittest.TestCase):
     queue = py_queue
@@ -566,7 +560,7 @@ class BaseSimpleQueueTest:
         with self.assertRaises(ValueError):
             q.get(timeout=-1)
 
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     # Nanvix exhausts its thread limit during the test run; by the time
     # SimpleQueue tests execute, new thread creation fails.
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
@@ -579,7 +573,7 @@ class BaseSimpleQueueTest:
         # One producer, one consumer => results appended in well-defined order
         self.assertEqual(results, inputs)
 
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_many_threads(self):
         # Test multiple concurrent put() and get()
@@ -592,7 +586,7 @@ class BaseSimpleQueueTest:
         # results in random order
         self.assertEqual(sorted(results), inputs)
 
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_many_threads_nonblock(self):
         # Test multiple concurrent put() and get(block=False)
@@ -604,7 +598,7 @@ class BaseSimpleQueueTest:
 
         self.assertEqual(sorted(results), inputs)
 
-    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
     @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_many_threads_timeout(self):
         # Test multiple concurrent put() and get(timeout=...)
@@ -653,8 +647,8 @@ class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         self.assertIs(self.type2test, self.queue.SimpleQueue)
         self.assertIs(self.type2test, self.queue.SimpleQueue)
 
-    # NSKIP015 https://github.com/nanvix/cpython/issues/371
-    @unittest.skipIf(support.is_nanvix, "NSKIP015: circular __del__ OOM on Nanvix")
+    # NSKIP018 https://github.com/nanvix/cpython/issues/486
+    @unittest.skipIf(support.is_nanvix, "NSKIP018: OOM from leak — circular __del__ not collected")
     def test_reentrancy(self):
         # bpo-14976: put() may be called reentrantly in an asynchronous
         # callback.

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -1,5 +1,17 @@
 # Some simple queue module tests, plus some failure conditions
 # to ensure the Queue locks remain stable.
+
+# NSKIP015 https://github.com/nanvix/cpython/issues/371
+# This module is excluded from standalone mode via STANDALONE_EXCLUDE in
+# .nanvix/config.py (32MB heap too small for threading tests).
+#
+# In non-standalone modes (256MB), two categories of failure remain:
+#   NSKIP015: CSimpleQueueTest.test_reentrancy OOMs from circular __del__ loop
+#   NSKIP016: Nanvix has a low thread creation limit; pure-Python queue classes
+#             (Py*) exhaust it, and BaseSimpleQueueTest thread-heavy methods
+#             (test_order, test_many_threads*) fail even for C variants due to
+#             cumulative thread exhaustion across the test run.
+
 import itertools
 import random
 import threading
@@ -7,6 +19,7 @@ import time
 import unittest
 import weakref
 from test.support import gc_collect
+from test import support
 from test.support import import_helper
 from test.support import threading_helper
 
@@ -189,6 +202,8 @@ class BaseQueueTestMixin(BlockingTestMixin):
         else:
             self.fail("Did not detect task count going negative")
 
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_queue_join(self):
         # Test that a queue join()s successfully, and before anything else
         # (done twice for insurance).
@@ -247,6 +262,9 @@ class QueueTest(BaseQueueTestMixin):
         self.type2test = self.queue.Queue
         super().setUp()
 
+# NSKIP016 https://github.com/nanvix/cpython/issues/371
+# Nanvix has a low thread creation limit; pure-Python queue tests exceed it.
+@unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyQueueTest(QueueTest, unittest.TestCase):
     queue = py_queue
 
@@ -263,6 +281,8 @@ class LifoQueueTest(BaseQueueTestMixin):
         super().setUp()
 
 
+# NSKIP016 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyLifoQueueTest(LifoQueueTest, unittest.TestCase):
     queue = py_queue
 
@@ -279,6 +299,8 @@ class PriorityQueueTest(BaseQueueTestMixin):
         super().setUp()
 
 
+# NSKIP016 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyPriorityQueueTest(PriorityQueueTest, unittest.TestCase):
     queue = py_queue
 
@@ -409,6 +431,8 @@ class FailingQueueTest(BlockingTestMixin):
 
 
 
+# NSKIP016 https://github.com/nanvix/cpython/issues/371
+@unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
 class PyFailingQueueTest(FailingQueueTest, unittest.TestCase):
     queue = py_queue
 
@@ -542,6 +566,10 @@ class BaseSimpleQueueTest:
         with self.assertRaises(ValueError):
             q.get(timeout=-1)
 
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    # Nanvix exhausts its thread limit during the test run; by the time
+    # SimpleQueue tests execute, new thread creation fails.
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_order(self):
         # Test a pair of concurrent put() and get()
         q = self.q
@@ -551,6 +579,8 @@ class BaseSimpleQueueTest:
         # One producer, one consumer => results appended in well-defined order
         self.assertEqual(results, inputs)
 
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_many_threads(self):
         # Test multiple concurrent put() and get()
         N = 50
@@ -562,6 +592,8 @@ class BaseSimpleQueueTest:
         # results in random order
         self.assertEqual(sorted(results), inputs)
 
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_many_threads_nonblock(self):
         # Test multiple concurrent put() and get(block=False)
         N = 50
@@ -572,6 +604,8 @@ class BaseSimpleQueueTest:
 
         self.assertEqual(sorted(results), inputs)
 
+    # NSKIP016 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_many_threads_timeout(self):
         # Test multiple concurrent put() and get(timeout=...)
         N = 50
@@ -619,6 +653,8 @@ class CSimpleQueueTest(BaseSimpleQueueTest, unittest.TestCase):
         self.assertIs(self.type2test, self.queue.SimpleQueue)
         self.assertIs(self.type2test, self.queue.SimpleQueue)
 
+    # NSKIP015 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP015: circular __del__ OOM on Nanvix")
     def test_reentrancy(self):
         # bpo-14976: put() may be called reentrantly in an asynchronous
         # callback.

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -225,6 +225,8 @@ class TestJointOps:
         self.assertFalse(set('a').issubset('cbs'))
         self.assertFalse(set('cbs').issuperset('a'))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         for i in range(pickle.HIGHEST_PROTOCOL + 1):
             if type(self.s) not in (set, frozenset):
@@ -239,6 +241,8 @@ class TestJointOps:
                 self.assertFalse(hasattr(self.s, 'y'))
                 del self.s.x, self.s.z
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             itorg = iter(self.s)
@@ -923,6 +927,8 @@ class TestBasicOps:
         setiter = iter(self.set)
         self.assertEqual(setiter.__length_hint__(), len(self.set))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             p = pickle.dumps(self.set, proto)

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -225,7 +225,7 @@ class TestJointOps:
         self.assertFalse(set('a').issubset('cbs'))
         self.assertFalse(set('cbs').issuperset('a'))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         for i in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -241,7 +241,7 @@ class TestJointOps:
                 self.assertFalse(hasattr(self.s, 'y'))
                 del self.s.x, self.s.z
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -927,7 +927,7 @@ class TestBasicOps:
         setiter = iter(self.set)
         self.assertEqual(setiter.__length_hint__(), len(self.set))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -132,6 +132,8 @@ class ReferencesTestCase(TestBase):
         self.check_basic_callback(create_function)
         self.check_basic_callback(create_bound_method)
 
+    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     @support.cpython_only
     def test_cfunction(self):
         import _testcapi

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -132,7 +132,7 @@ class ReferencesTestCase(TestBase):
         self.check_basic_callback(create_function)
         self.check_basic_callback(create_bound_method)
 
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     @support.cpython_only
     def test_cfunction(self):


### PR DESCRIPTION
Closes #371.

Adds 28 CPython test modules covering data structures, algorithms, iterators, generators, and related standard library functionality to the Nanvix test suite. All 93 modules (28 new + 65 existing) pass across all three deployment modes (standalone, multi-process, single-process).

## New modules

`test_listcomps`, `test_dictcomps`, `test_setcomps`, `test_genexps`, `test_set`, `test_heapq`, `test_bisect`, `test_queue`, `test_sort`, `test_iter`, `test_itertools`, `test_iterlen`, `test_generators`, `test_generator_stop`, `test_yield_from`, `test_coroutines`, `test_functools`, `test_funcattrs`, `test_decorators`, `test_copy`, `test_copyreg`, `test_collections`, `test_defaultdict`, `test_ordered_dict`, `test_deque`, `test_array`, `test_weakref`, `test_weakset`, `test_buffer`

## Proposed NSKIP codes

This PR introduces two new NSKIP codes. These should be added to the registry in #371.

| Code | Description |
|------|-------------|
| **NSKIP015** | **OOM — test exhausts available memory.** In standalone mode (32 MB heap), entire modules are excluded via `STANDALONE_EXCLUDE`. In non-standalone modes (256 MB), individual tests that allocate extreme amounts of memory are skipped at test level. |
| **NSKIP016** | **Exceeds Nanvix thread limit.** Nanvix has a low thread creation ceiling and threads from earlier tests are not fully cleaned up, causing cumulative exhaustion. Tests that spawn many threads or depend on pure-Python queue classes (which use background threads) are skipped. |

## Skipped tests

All skip reasons are documented inline at the skip site. Codes reference #371.

- **NSKIP001** (pickle corrupt on 32-bit): `test_array`, `test_collections`, `test_defaultdict`, `test_deque`, `test_functools`, `test_iter`, `test_itertools`, `test_ordered_dict`, `test_set`
- **NSKIP002** (`_testcapi` unavailable): `test_coroutines`, `test_weakref`
- **NSKIP008** (tempfile names garbled): `test_array`
- **NSKIP013** (event loop vs coroutine warning): `test_coroutines`
- **NSKIP014** (asyncio needs poll/selectors): `test_coroutines`
- **NSKIP015** (OOM): `test_itertools`, `test_queue`; standalone excludes: `test_queue`, `test_itertools`, `test_functools`
- **NSKIP016** (thread limit): `test_functools`, `test_queue`

## Functional changes

### Build system (`config.py`, `test.py`)

- Added 28 modules to `NANVIX_TEST_LIST`.
- `STANDALONE_EXCLUDE` now lists test_queue, test_itertools, and test_functools (NSKIP015). Removed `test_filter_dealloc` (not in test list, no-op) and `test_tokenize` (passes).
- ~~Standalone exclusions are now filtered host-side from `test_list` before the module names reach nanvixd, instead of passing them via `NANVIX_EXCLUDE_TESTS` → regrtest `--ignore` flags. The `NANVIX_EXCLUDE_TESTS` env var and its consumers in `run-tests.py` / `run-regrtest.py` have been removed.~~ --> Migrated to #468 

### test_itertools — `pickle_deprecated` decorator

The `pickle_deprecated` decorator wraps test functions in three phases: (1) `assertWarns(DeprecationWarning)`, (2) run with warnings suppressed, (3) `assertRaises` with warnings-as-errors. On Nanvix, `picklecopiers` is emptied (NSKIP001), so `pickle.dumps` is never called, the `DeprecationWarning` is never emitted, and phases 1 and 3 fail. Fix: guard phases 1 and 3 with `if not support.is_nanvix`. Phase 2 still runs, exercising the non-pickle logic.

### test_itertools — `picklecopiers` and `pickletest`

`picklecopiers` is set to `[]` on Nanvix (NSKIP001). The `pickletest` helper early-returns with a warning. Both emit `warnings.warn` so skips are visible in test output.