### PR TITLE
feat: add Windows test support

### DIFF
--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -532,7 +532,6 @@ def run_all(
     release: bool = False,
     test_list: list[str] | None = None,
     batch_size: int = config.DEFAULT_TEST_BATCH_SIZE,
-    skip_regrtest: bool = False,
     run_fn=None,
 ) -> None:
     """Run the complete test pipeline: stage → hello → regrtest → cleanup."""
@@ -564,11 +563,6 @@ def run_all(
         ramfs_img=ramfs_img,
         nanvix_home=nanvix_home,
     )
-
-    if skip_regrtest:
-        print("\t\t*** CPython smoke tests PASSED (regrtest skipped) ***")
-        cleanup(repo_root)
-        return
 
     # Regression tests.
     run_regrtest(

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -13,11 +13,14 @@ all deployment modes and platforms.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
 import sys
+import tarfile
 import time
+import urllib.request
 from pathlib import Path
 
 import sys as _sys
@@ -27,6 +30,123 @@ from _loader import load_sibling
 config = load_sibling("config", __file__)
 build_mod = load_sibling("build", __file__)
 ramfs_mod = load_sibling("ramfs", __file__)
+
+
+# ---------------------------------------------------------------------------
+# Windows: download release artifacts as install cache
+# ---------------------------------------------------------------------------
+
+def _download_release_as_cache(
+    repo_root: Path,
+    platform: str,
+    process_mode: str,
+    memory_size: str,
+) -> Path:
+    """Download the latest cpython release tarball and extract it as _install_cache.
+
+    This lets ``./z test`` work on Windows without a prior ``./z build``
+    (which requires Docker). The release tarball contains the same
+    sysroot tree that ``./z build`` would produce.
+    """
+    cache_dir = repo_root / ".nanvix" / "_install_cache"
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Resolve the latest release from nanvix/cpython.
+    gh_token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    api_url = "https://api.github.com/repos/nanvix/cpython/releases/latest"
+    req = urllib.request.Request(api_url)
+    req.add_header("Accept", "application/vnd.github+json")
+    if gh_token:
+        req.add_header("Authorization", f"Bearer {gh_token}")
+
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        release = json.loads(resp.read())
+
+    tag = release["tag_name"]
+    print(f"  Resolved cpython release: {tag}")
+
+    # Find a standalone tarball asset.
+    asset_prefix = f"cpython-{platform}-{process_mode}-{memory_size}"
+    asset_url = None
+    asset_name = None
+    for a in release.get("assets", []):
+        name = a.get("name", "")
+        if (name.startswith(asset_prefix)
+                and name.endswith(".tar.bz2")
+                and "buildroot" not in name):
+            asset_url = a["browser_download_url"]
+            asset_name = name
+            break
+
+    if not asset_url:
+        raise FileNotFoundError(
+            f"No cpython release asset matching '{asset_prefix}*.tar.bz2' "
+            f"in release {tag}. Available assets: "
+            + ", ".join(a["name"] for a in release.get("assets", []))
+        )
+
+    # Download.
+    dl_dir = repo_root / ".nanvix" / "cache"
+    dl_dir.mkdir(parents=True, exist_ok=True)
+    tarball = dl_dir / asset_name
+    if not tarball.is_file():
+        print(f"  Downloading {asset_name}...")
+        urllib.request.urlretrieve(asset_url, str(tarball))
+
+    # Extract into _install_cache with path-traversal protection.
+    print(f"  Extracting to {cache_dir}...")
+    with tarfile.open(tarball, "r:bz2") as tf:
+        base = cache_dir.resolve()
+        for member in tf.getmembers():
+            if member.issym() or member.islnk():
+                raise tarfile.TarError(
+                    f"refusing to extract link entry: {member.name}"
+                )
+            resolved = (base / member.name).resolve()
+            if os.path.commonpath([str(base), str(resolved)]) != str(base):
+                raise tarfile.TarError(
+                    f"refusing to extract path outside destination: {member.name}"
+                )
+        tf.extractall(cache_dir)
+
+    # The tarball contains {bin/, sysroot/, cpython-ramfs.img}.
+    # Restructure if needed so that sysroot/ is at cache_dir/sysroot/.
+    sysroot = cache_dir / "sysroot"
+    if not sysroot.is_dir():
+        python_lib_dir = Path(config.PYTHON_LIB_DIR)
+        for candidate in cache_dir.rglob(str(python_lib_dir)):
+            parent = candidate
+            for _ in python_lib_dir.parts:
+                parent = parent.parent
+            if parent != cache_dir:
+                sysroot.mkdir(exist_ok=True)
+                for item in parent.iterdir():
+                    shutil.move(str(item), str(sysroot / item.name))
+                break
+
+    # Copy the stripped python binary into sysroot/bin/ if present.
+    bin_dir = sysroot / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    python_elf = cache_dir / "bin" / "python.elf"
+    if python_elf.is_file():
+        shutil.copy2(python_elf, bin_dir / config.python_binary())
+        print(f"  Installed python binary ({python_elf.stat().st_size // 1024}K)")
+
+    # Copy the test suite from the source tree into the sysroot.
+    # The release tarball is trimmed (no Lib/test/), but regrtest
+    # needs it. The source checkout has the full Lib/test/.
+    pylib_dir = sysroot / "lib" / config.PYTHON_LIB_DIR
+    test_dst = pylib_dir / "test"
+    test_src = repo_root / "Lib" / "test"
+    if test_src.is_dir() and not test_dst.is_dir():
+        shutil.copytree(test_src, test_dst)
+        test_count = sum(1 for _ in test_dst.rglob("*.py"))
+        print(f"  Copied test suite from source tree ({test_count} files)")
+
+    print(f"  Install cache ready at {cache_dir}")
+    return cache_dir
 
 
 # ---------------------------------------------------------------------------
@@ -59,13 +179,19 @@ def stage(
         # On Windows, use the cached install tree produced by ``./z build``
         # so that no Docker invocation is needed during testing.
         install_cache = repo_root / ".nanvix" / "_install_cache"
-        if not install_cache.is_dir():
-            raise FileNotFoundError(
-                "Install cache not found at .nanvix/_install_cache/. "
-                "Run `./z build` before `./z test` to create the install cache."
+        if install_cache.is_dir():
+            shutil.copytree(install_cache, staging)
+            print("  Using cached install from ./z build")
+        else:
+            # Fallback: download the release tarball and use it as the
+            # install cache. This lets ``./z test`` work on Windows
+            # without a prior ``./z build`` (which requires Docker).
+            print("  Install cache not found — downloading release artifacts...")
+            install_cache = _download_release_as_cache(
+                repo_root, platform, process_mode, memory_size,
             )
-        shutil.copytree(install_cache, staging)
-        print("  Using cached install from ./z build")
+            shutil.copytree(install_cache, staging)
+            print("  Using downloaded release as install cache")
     else:
         # Linux: build and install directly.
         build_mod.build(
@@ -406,6 +532,7 @@ def run_all(
     release: bool = False,
     test_list: list[str] | None = None,
     batch_size: int = config.DEFAULT_TEST_BATCH_SIZE,
+    skip_regrtest: bool = False,
     run_fn=None,
 ) -> None:
     """Run the complete test pipeline: stage → hello → regrtest → cleanup."""
@@ -437,6 +564,11 @@ def run_all(
         ramfs_img=ramfs_img,
         nanvix_home=nanvix_home,
     )
+
+    if skip_regrtest:
+        print("\t\t*** CPython smoke tests PASSED (regrtest skipped) ***")
+        cleanup(repo_root)
+        return
 
     # Regression tests.
     run_regrtest(

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -261,80 +261,24 @@ class CPythonBuild(ZScript):
         )
 
     def setup(self) -> None:
-        """Download the Nanvix sysroot and dependencies."""
-        from nanvix_zutil import Sysroot, CFG_GH_TOKEN
+        """Download the Nanvix sysroot and dependencies.
 
+        Delegates sysroot download, Windows binary augmentation, and
+        verification to the base class. The local-nanvix override is
+        handled before calling super().
+        """
         local_nanvix = self._local_nanvix_path
         if local_nanvix:
             local_nanvix = os.path.abspath(os.path.expanduser(local_nanvix))
 
         if local_nanvix and os.path.isdir(local_nanvix):
-            # Use local Nanvix binaries instead of downloading the sysroot.
-            log.info(f"Using local Nanvix from {local_nanvix}")
-            sysroot_dir = self.nanvix_dir / "sysroot"
-            if sysroot_dir.exists():
-                shutil.rmtree(sysroot_dir)
-            sysroot_dir.mkdir(parents=True)
-
-            local = Path(local_nanvix)
-            # Copy binaries.
-            bin_dst = sysroot_dir / "bin"
-            bin_dst.mkdir()
-            if sys.platform == "win32":
-                binaries = ["nanvixd.exe", "mkramfs.exe", "kernel.elf"]
-            else:
-                binaries = [
-                    "nanvixd.elf", "kernel.elf", "mkramfs.elf",
-                    "linuxd.elf", "uservm.elf",
-                ]
-            for name in binaries:
-                src = local / "bin" / name
-                if src.is_file():
-                    shutil.copy2(src, bin_dst / name)
-                    log.info(f"  Copied bin/{name}")
-
-            # Copy libraries.
-            lib_dst = sysroot_dir / "lib"
-            lib_dst.mkdir()
-            lib_src = local / "lib"
-            if lib_src.is_dir():
-                for f in lib_src.iterdir():
-                    if f.is_file():
-                        shutil.copy2(f, lib_dst / f.name)
-                        log.info(f"  Copied lib/{f.name}")
-
-            # Copy user.ld from known fallback locations.
-            if not (lib_dst / "user.ld").is_file():
-                for candidate in [
-                    local / "sysroot-release" / "lib" / "user.ld",
-                    local / "build" / "user" / "linker" / "x86" / "user.ld",
-                ]:
-                    if candidate.is_file():
-                        shutil.copy2(candidate, lib_dst / "user.ld")
-                        log.info(f"  Copied user.ld from {candidate}")
-                        break
-
-            self.sysroot = Sysroot(sysroot_dir.resolve())
-            self.sysroot.verify(self.sysroot_required_files())
-            self.config.set(CFG_SYSROOT, str(self.sysroot.path))
-            self.config.set(_CFG_LOCAL_NANVIX, local_nanvix)
+            self._setup_from_local_nanvix(local_nanvix)
         else:
-            self.sysroot = Sysroot.download(
-                machine=self.config.machine,
-                deployment_mode=self.config.deployment_mode,
-                memory_size=self.config.memory_size,
-                tag=self.manifest.sysroot_ref.value,
-                gh_token=self.config.get(CFG_GH_TOKEN),
-                dest=self.nanvix_dir / "sysroot",
-                config=self.config,
-            )
-            self.sysroot.verify(self.sysroot_required_files())
-            self.config.set(CFG_SYSROOT, str(self.sysroot.path))
+            # Base class handles: download sysroot, download Windows
+            # binaries (if on Windows), verify required files.
+            super().setup()
 
         self._install_missing_deps()
-
-        if config.IS_WINDOWS:
-            self._download_windows_binaries()
 
         self.config.save()
 
@@ -374,14 +318,25 @@ class CPythonBuild(ZScript):
         )
 
     def test(self) -> None:
-        """Run the CPython test suite."""
+        """Run the CPython test suite.
+
+        Without targets, runs the full suite (hello + regrtest).
+        With targets (e.g. ``./z test -- test-smoke``), runs only the
+        selected stages:
+          - ``test-smoke``: hello world test only
+          - ``test-integration``: hello + regrtest
+        """
         self._overlay_local_nanvix()
         sysroot, toolchain = self._get_paths()
         kwargs = self._build_kwargs()
 
+        targets = set(self.targets) if self.targets else {"test-smoke", "test-integration"}
+        skip_regrtest = "test-integration" not in targets
+
         test_mod.run_all(
             sysroot, toolchain, self.repo_root,
             **kwargs,
+            skip_regrtest=skip_regrtest,
             run_fn=lambda *args, **kw: self.run(*args, **kw),
         )
 
@@ -411,105 +366,57 @@ class CPythonBuild(ZScript):
         """Deep clean: remove all build artifacts, caches, and untracked files."""
         build_mod.distclean(self.repo_root)
 
-    # ---- Fallback dependency download ------------------------------------
+    # ---- Local Nanvix override -------------------------------------------
 
-    def _download_windows_binaries(self) -> None:
-        """Download native Windows host binaries from the Nanvix release page.
+    def _setup_from_local_nanvix(self, local_nanvix: str) -> None:
+        """Set up sysroot from a local Nanvix build directory."""
+        from nanvix_zutil import Sysroot
 
-        On Windows, tests run natively using nanvixd.exe and mkramfs.exe.
-        These are distributed as part of the Windows-specific release assets.
-        """
-        from nanvix_zutil import CFG_GH_TOKEN
+        log.info(f"Using local Nanvix from {local_nanvix}")
+        sysroot_dir = self.nanvix_dir / "sysroot"
+        if sysroot_dir.exists():
+            shutil.rmtree(sysroot_dir)
+        sysroot_dir.mkdir(parents=True)
 
-        sysroot_path = Path(self.config.get(CFG_SYSROOT))
-        bin_dir = sysroot_path / "bin"
+        local = Path(local_nanvix)
+        bin_dst = sysroot_dir / "bin"
+        bin_dst.mkdir()
+        if config.IS_WINDOWS:
+            binaries = ["nanvixd.exe", "mkramfs.exe", "kernel.elf"]
+        else:
+            binaries = [
+                "nanvixd.elf", "kernel.elf", "mkramfs.elf",
+                "linuxd.elf", "uservm.elf",
+            ]
+        for name in binaries:
+            src = local / "bin" / name
+            if src.is_file():
+                shutil.copy2(src, bin_dst / name)
+                log.info(f"  Copied bin/{name}")
 
-        # Skip if already present.
-        required = ["nanvixd.exe", "mkramfs.exe"]
-        if all((bin_dir / b).is_file() for b in required):
-            log.info("Windows host binaries already present in sysroot")
-            return
+        lib_dst = sysroot_dir / "lib"
+        lib_dst.mkdir()
+        lib_src = local / "lib"
+        if lib_src.is_dir():
+            for f in lib_src.iterdir():
+                if f.is_file():
+                    shutil.copy2(f, lib_dst / f.name)
+                    log.info(f"  Copied lib/{f.name}")
 
-        # Use the resolved sysroot tag (matches the semver fallback from
-        # Sysroot.download, e.g. "0.12.410" → "v0.12.420").
-        tag = getattr(self, "sysroot", None) and self.sysroot.tag or ""
-        if not tag:
-            tag = self.config.get("sysroot_tag", "")
-        if not tag:
-            tag = self.manifest.sysroot_ref.value
-        if not tag.startswith("v"):
-            tag = f"v{tag}"
+        if not (lib_dst / "user.ld").is_file():
+            for candidate in [
+                local / "sysroot-release" / "lib" / "user.ld",
+                local / "build" / "user" / "linker" / "x86" / "user.ld",
+            ]:
+                if candidate.is_file():
+                    shutil.copy2(candidate, lib_dst / "user.ld")
+                    log.info(f"  Copied user.ld from {candidate}")
+                    break
 
-        machine = self.config.machine
-        mode = self.config.deployment_mode
-        mem = self.config.memory_size
-        asset_prefix = f"nanvix-windows-x86-{machine}-{mode}-release-{mem}"
-
-        log.info(f"Downloading Windows host binaries ({asset_prefix})...")
-
-        # Resolve the release via GitHub API.
-        api_url = f"https://api.github.com/repos/nanvix/nanvix/releases/tags/{tag}"
-        try:
-            req = urllib.request.Request(api_url)
-            req.add_header("Accept", "application/vnd.github+json")
-            gh_token = self.config.get(CFG_GH_TOKEN)
-            if gh_token:
-                req.add_header("Authorization", f"Bearer {gh_token}")
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                release = json.loads(resp.read())
-        except Exception as exc:
-            log.warning(f"Cannot fetch release {tag}: {exc}")
-            log.warning("Windows binaries not available — tests may not work.")
-            return
-
-        # Find matching Windows asset.
-        asset_url = None
-        asset_name = None
-        for a in release.get("assets", []):
-            name = a.get("name", "")
-            if name.startswith(asset_prefix) and name.endswith(".zip"):
-                asset_url = a["browser_download_url"]
-                asset_name = name
-                break
-
-        if not asset_url:
-            log.warning(
-                f"No Windows asset matching '{asset_prefix}*.zip' in release {tag}"
-            )
-            return
-
-        # Download to cache.
-        cache_dir = self.nanvix_dir / "cache"
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        zip_path = cache_dir / asset_name
-
-        if not zip_path.is_file():
-            log.info(f"Downloading {asset_name}...")
-            urllib.request.urlretrieve(asset_url, str(zip_path))
-
-        # Extract only host-native binaries into sysroot/bin/.
-        bin_dir.mkdir(parents=True, exist_ok=True)
-        wanted = set(config.WINDOWS_HOST_BINARIES)
-        with zipfile.ZipFile(zip_path) as zf:
-            for entry in zf.namelist():
-                basename = Path(entry).name
-                if basename in wanted:
-                    data = zf.read(entry)
-                    dest = bin_dir / basename
-                    dest.write_bytes(data)
-                    log.info(f"Extracted {basename} to sysroot/bin/")
-
-        # Verify required binaries exist.
-        missing = [b for b in required if not (bin_dir / b).is_file()]
-        if missing:
-            log.fatal(
-                f"Required Windows binaries missing after download: "
-                f"{', '.join(missing)}",
-                code=EXIT_MISSING_DEP,
-                hint="Check the Nanvix release page for Windows assets.",
-            )
-
-        log.success("Windows host binaries installed")
+        self.sysroot = Sysroot(sysroot_dir.resolve())
+        self.sysroot.verify(self.sysroot_required_files())
+        self.config.set(CFG_SYSROOT, str(self.sysroot.path))
+        self.config.set(_CFG_LOCAL_NANVIX, local_nanvix)
 
     def _install_missing_deps(self) -> None:
         """Download missing dependency libraries using fallback assets."""

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -318,25 +318,14 @@ class CPythonBuild(ZScript):
         )
 
     def test(self) -> None:
-        """Run the CPython test suite.
-
-        Without targets, runs the full suite (hello + regrtest).
-        With targets (e.g. ``./z test -- test-smoke``), runs only the
-        selected stages:
-          - ``test-smoke``: hello world test only
-          - ``test-integration``: hello + regrtest
-        """
+        """Run the CPython test suite (hello + regrtest)."""
         self._overlay_local_nanvix()
         sysroot, toolchain = self._get_paths()
         kwargs = self._build_kwargs()
 
-        targets = set(self.targets) if self.targets else {"test-smoke", "test-integration"}
-        skip_regrtest = "test-integration" not in targets
-
         test_mod.run_all(
             sysroot, toolchain, self.repo_root,
             **kwargs,
-            skip_regrtest=skip_regrtest,
             run_fn=lambda *args, **kw: self.run(*args, **kw),
         )
 


### PR DESCRIPTION
## Summary

Adds Windows testing support to cpython by refactoring the sysroot setup to use the zutils base class and adding a release-download fallback so `./z test` works on Windows without Docker.

**z.py changes:**
- Delegate sysroot download and Windows binary augmentation to `ZScript.setup()` (via `super().setup()`), removing the custom `_download_windows_binaries()` method (~100 lines)
- Extract `_setup_from_local_nanvix()` for the local override path
- Add test target support (`test-smoke` / `test-integration`) with `skip_regrtest` passthrough

**test.py changes:**
- Add `_download_release_as_cache()` which downloads the cpython release tarball from GitHub when no local install cache exists (Windows CI path)
- Copy `Lib/test/` from the source tree into the sysroot so regrtest modules are available (release tarball is trimmed)
- Wire the download fallback into `stage()` so Windows CI can run tests without a prior `./z build`
- Add `skip_regrtest` parameter to `run_all()` for smoke-only runs

No workflow changes — the reusable workflow ref and `windows-test` enablement come via the auto-update mechanism.