### PR TITLE
[ci] E: Update nanvix workflow refs to v1.10.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.9.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.10.1
     with:
       zutil-version: "v0.7.25"
       platforms: '["microvm"]'
@@ -43,7 +43,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.9.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.10.1
     with:
       zutil-version: "v0.7.25"
       platforms: '["microvm"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v1.10.1`](https://github.com/nanvix/workflows/releases/tag/v1.10.1).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.