### PR TITLE
Add linting infra

### DIFF
--- a/.nanvix/.gitignore
+++ b/.nanvix/.gitignore
@@ -11,3 +11,5 @@ cpython-rootfs.img
 cpython_*.log
 __pycache__/
 release/
+uv.lock
+.venv

--- a/.nanvix/pyproject.toml
+++ b/.nanvix/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "zutils-dev"
+version = "0"
+requires-python = ">=3.12"
+dependencies = ["nanvix-zutil"]
+
+[tool.uv.sources]
+nanvix-zutil = { git = "https://github.com/nanvix/zutils" }
+
+[dependency-groups]
+dev = [
+    "basedpyright",
+    "ruff",
+]

--- a/.nanvix/pyproject.toml
+++ b/.nanvix/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "zutils-dev"
 version = "0"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = ["nanvix-zutil"]
 
 [tool.uv.sources]

--- a/.nanvix/pyrightconfig.json
+++ b/.nanvix/pyrightconfig.json
@@ -1,0 +1,5 @@
+{
+    "venvPath": ".",
+    "venv": "venv",
+    "pythonVersion": "3.12"
+}


### PR DESCRIPTION
## What
Add linting infra -- ruff and basedpyright.

## Why
Enforce correctness going forward, makes edits easier by automating style rules and python best practices. 

## Priority
🟡 Medium - enforces correctness going forward. The sooner we fix this the better.

## Follow-ups
- Fix linting errors.
- Add .nanvix/ linting to CI - enforce at the zutils/workflows level.
- https://github.com/nanvix/zutils/issues/128