### PR TITLE
Fix: let ZScript.run() control Docker wrapping in build

### DIFF
--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -79,7 +79,7 @@ def run_make(
             ``subprocess.run`` with check=True.
     """
     if run_fn:
-        run_fn(*args, cwd=cwd, docker=False, kvm=kvm)
+        run_fn(*args, cwd=cwd, kvm=kvm)
     else:
         subprocess.run(args, cwd=cwd, check=True)
 


### PR DESCRIPTION
`run_make()` in `.nanvix/build.py` was passing `docker=False` to `run_fn` (`ZScript.run()`), which unconditionally disabled Docker wrapping even when `--with-docker` was passed on the command line.

This removes the `docker=False` override so that `ZScript.run()` respects the `DockerConfig` set by the CLI flag.

### Why

This is needed for [nanvix/zutils#130](https://github.com/nanvix/zutils/pull/130), which moves Docker flags from the top-level parser to subcommand-level (`build` / `release` only). With that change:

- `nanvix-zutil build --with-docker` → builds inside Docker (wrapping handled by `ZScript.run()`)
- `nanvix-zutil test` → runs natively on the host (no Docker flag accepted)

Without this fix, `--with-docker` is silently ignored because `run_make()` always opts out of Docker wrapping.

### Change

```diff
-        run_fn(*args, cwd=cwd, docker=False, kvm=kvm)
+        run_fn(*args, cwd=cwd, kvm=kvm)
```