### PR TITLE
fix(z.py): translate sysroot/toolchain paths for Docker mode

### DIFF
--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -218,7 +218,9 @@ class CPythonBuild(ZScript):
                 hint="Run `./z setup` first to download the sysroot.",
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, config.TOOLCHAIN_DEFAULT_PATH)
-        return sysroot, toolchain
+        sysroot_p = str(self.translate_path(Path(sysroot)))
+        toolchain_p = str(self.translate_path(Path(toolchain)))
+        return sysroot_p, toolchain_p
 
     def _build_kwargs(self, release: bool = False) -> dict:
         """Return common keyword arguments for build/test/package modules."""


### PR DESCRIPTION
Use `self.translate_path()` in `_get_paths()` so that host paths are correctly mapped to container paths when Docker wrapping is active.

Without this, `make` receives host-side paths (e.g. `/home/.../sysroot`) in `NANVIX_HOME` and throughout `CFLAGS`/`LDFLAGS`. Inside the Docker container these paths don't exist — the sysroot is mounted at `/mnt/sysroot` — causing `./configure` to fail with "C compiler cannot create executables".

`translate_path()` is a no-op when Docker is not active, so native builds are unaffected.
