### PR TITLE
build: filter standalone exclusions host-side

### DIFF
--- a/.nanvix/run-regrtest.py
+++ b/.nanvix/run-regrtest.py
@@ -20,7 +20,6 @@
 # Environment variables:
 #   NANVIX_TEST_LIST_FILE  - path to the test list file (default: test-list.txt)
 #   REGRTEST_TIMEOUT       - per-test timeout in seconds (default: 120)
-#   NANVIX_EXCLUDE_TESTS   - space-separated patterns passed to regrtest --ignore
 
 import os
 import sys
@@ -58,10 +57,6 @@ def main() -> int:
     # -- Build regrtest arguments ----------------------------------------------
     timeout = os.environ.get("REGRTEST_TIMEOUT", "120")
     args = [f"--timeout={timeout}"] + modules
-
-    excludes = os.environ.get("NANVIX_EXCLUDE_TESTS", "").split()
-    for pat in excludes:
-        args.extend(["-i", pat])
 
     # -- Run -------------------------------------------------------------------
     sys.argv[1:] = args

--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -23,8 +23,6 @@
 #     NANVIX_TEST_BATCH_SIZE - modules per nanvixd invocation (default: 4)
 #     NANVIXD_EXTRA_ARGS     - extra flags passed to nanvixd (optional)
 #     NANVIX_STANDALONE      - set to "1" to enable standalone mode
-#     NANVIX_EXCLUDE_TESTS   - space-separated patterns passed to regrtest
-#                              --ignore (optional)
 #     REGRTEST_TIMEOUT       - per-test timeout in seconds (default: 120)
 
 import os
@@ -46,22 +44,12 @@ SYSCONFIGDATA_NAME = os.environ.get(
 REGRTEST_TIMEOUT = os.environ.get("REGRTEST_TIMEOUT", "120")
 
 
-def _build_exclude_args() -> list[str]:
-    """Convert NANVIX_EXCLUDE_TESTS into regrtest --ignore flags."""
-    excludes = os.environ.get("NANVIX_EXCLUDE_TESTS", "").split()
-    args: list[str] = []
-    for pat in excludes:
-        args.extend(["-i", pat])
-    return args
-
-
 def run_batch(
     batch_num: int,
     batch: list[str],
     nanvixd_extra: list[str],
 ) -> tuple[int, int, list[str]]:
     """Run a single batch. Returns (batch_num, returncode, modules)."""
-    exclude_args = _build_exclude_args()
 
     # Each batch gets its own temp directory so parallel nanvixd instances
     # don't collide in /tmp (the guest shares the host filesystem in direct
@@ -74,12 +62,9 @@ def run_batch(
             # string.  nanvixd splits on spaces for argv and on semicolons
             # for environment variables.
             modules_str = " ".join(batch)
-            exclude_str = " ".join(exclude_args)
             regrtest_args = (
                 f"-B -m test --timeout={REGRTEST_TIMEOUT} {modules_str}"
             )
-            if exclude_str:
-                regrtest_args += f" {exclude_str}"
             python_arg = (
                 f"{regrtest_args};PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
                 f" TMPDIR=/tmp"

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -472,7 +472,8 @@ def run_regrtest(
             extra_str += " " + " ".join(nanvixd_extra)
         env["NANVIXD_EXTRA_ARGS"] = extra_str
         env["NANVIX_STANDALONE"] = "1"
-        env["NANVIX_EXCLUDE_TESTS"] = " ".join(config.STANDALONE_EXCLUDE)
+        exclude_set = set(config.STANDALONE_EXCLUDE)
+        test_list = [m for m in test_list if m not in exclude_set]
     else:
         # Direct mode: host filesystem, no ramfs.
         if nanvixd_extra:

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -454,8 +454,6 @@ def run_regrtest(
     nanvixd_extra = nanvixd_extra or config.PLATFORM_NANVIXD_ARGS.get(platform, [])
     standalone = process_mode == "standalone"
 
-    print(f"Test: regrtest ({len(test_list)} modules, {process_mode})...")
-
     sysroot = staging / "sysroot"
     run_tests_script = repo_root / ".nanvix" / "run-tests.py"
 
@@ -484,6 +482,7 @@ def run_regrtest(
 
     cmd = [sys.executable, str(run_tests_script)] + test_list
 
+    print(f"Test: regrtest ({len(test_list)} modules, {process_mode})...")
     result = subprocess.run(cmd, cwd=sysroot, env=env)
     if result.returncode != 0:
         raise RuntimeError(


### PR DESCRIPTION
## What

Filter STANDALONE_EXCLUDE modules from test_list host-side in test.py instead of passing them via NANVIX_EXCLUDE_TESTS env var through nanvixd's fixed-size command-line buffer. Remove the now-dead env var and its consumers in run-tests.py and run-regrtest.py.

## Why

Strict length requirements on nanvixd means we cannot be using '-i {test}' ad nauseum to filter tests. Instead, filter on the host-side to minimize the number of arguments passed to nanvixd.

## Priority
🔴 High - Without this change, tests will break if STANDALONE_EXCLUDE grows to exceed the 255 character limit.