### PR TITLE
fix(build): use relative DESTDIR for Docker compatibility

### DIFF
--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -146,8 +146,14 @@ def install(
             release=release,
         )
         return
+    # When running inside Docker, repo_root maps to /mnt/workspace.
+    # Use a relative DESTDIR so it resolves correctly inside the container.
+    try:
+        rel_destdir = destdir.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        rel_destdir = destdir
     args = make_args(
-        sysroot, toolchain, "install", f"DESTDIR={destdir}",
+        sysroot, toolchain, "install", f"DESTDIR={rel_destdir}",
         platform=platform,
         process_mode=process_mode,
         memory_size=memory_size,


### PR DESCRIPTION
When running inside Docker, repo_root maps to /mnt/workspace. The install DESTDIR was passed as an absolute host path (e.g. /home/user/repos/.nanvix/_test_staging) which does not exist inside the container, causing:

\/usr/bin/install: cannot create directory /home/ppenna: Permission denied
\
This change computes a relative DESTDIR from repo_root so it resolves correctly under /mnt/workspace in Docker mode.

**Context:** nanvix/zutils#130 moves Docker flags to setup (persisted to env.json). All subsequent commands (build, test, release) auto-load Docker. This exposed a latent bug where test -> build_mod.install() passed an absolute host DESTDIR into the Docker container.