### PR TITLE
Fix existing nanvix skip comments to point to new issues

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -898,7 +898,7 @@ class AST_Tests(unittest.TestCase):
         x = ast.Sub()
         self.assertEqual(x._fields, ())
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         import pickle
@@ -1083,7 +1083,7 @@ class AST_Tests(unittest.TestCase):
         enum._test_simple_enum(_Precedence, ast._Precedence)
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
-    # NSKIP007 https://github.com/nanvix/cpython/issues/371
+    # NSKIP007 https://github.com/nanvix/cpython/issues/475
     @unittest.skipIf(support.is_nanvix, "NSKIP007: deep recursion crashes 32-bit VM")
     @support.cpython_only
     def test_ast_recursion_limit(self):
@@ -2886,7 +2886,7 @@ class ModuleStateTests(unittest.TestCase):
                 import _ast
                 self.assertIs(_ast, lazy_mod)
 
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_subinterpreter(self):
         # bpo-41631: Importing and using the _ast module in a subinterpreter

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -401,7 +401,7 @@ class BuiltinTest(unittest.TestCase):
                                 msg=f"source={source} mode={mode}")
 
 
-    # NSKIP011 https://github.com/nanvix/cpython/issues/371
+    # NSKIP011 https://github.com/nanvix/cpython/issues/479
     @unittest.skipIf(
         support.is_emscripten or support.is_wasi or support.is_nanvix,
         "NSKIP011: socket.accept not supported"
@@ -961,7 +961,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(list(filter(lambda x: x>=3, (1, 2, 3, 4))), [3, 4])
         self.assertRaises(TypeError, list, filter(42, (1, 2)))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_filter_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1186,7 +1186,7 @@ class BuiltinTest(unittest.TestCase):
             raise RuntimeError
         self.assertRaises(RuntimeError, list, map(badfunc, range(5)))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_map_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1546,7 +1546,7 @@ class BuiltinTest(unittest.TestCase):
         a[0] = a
         self.assertEqual(repr(a), '{0: {...}}')
 
-    # NSKIP005 https://github.com/nanvix/cpython/issues/371
+    # NSKIP005 https://github.com/nanvix/cpython/issues/473
     @unittest.skipIf(support.is_nanvix, "NSKIP005: round-half-up, not round-half-to-even")
     def test_round(self):
         self.assertEqual(round(0.0), 0.0)
@@ -1632,7 +1632,7 @@ class BuiltinTest(unittest.TestCase):
     linux_alpha = (platform.system().startswith('Linux') and
                    platform.machine().startswith('alpha'))
     system_round_bug = round(5e15+1) != 5e15+1
-    # NSKIP005 https://github.com/nanvix/cpython/issues/371
+    # NSKIP005 https://github.com/nanvix/cpython/issues/473
     @unittest.skipIf((linux_alpha and system_round_bug) or support.is_nanvix,
                      "NSKIP005: round-half-up, not round-half-to-even")
     def test_round_large(self):
@@ -1808,7 +1808,7 @@ class BuiltinTest(unittest.TestCase):
                     return i
         self.assertRaises(ValueError, list, zip(BadSeq(), BadSeq()))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_zip_pickle(self):
         a = (1, 2, 3)
@@ -1818,7 +1818,7 @@ class BuiltinTest(unittest.TestCase):
             z1 = zip(a, b)
             self.check_iter_pickle(z1, t, proto)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_zip_pickle_strict(self):
         a = (1, 2, 3)
@@ -1828,7 +1828,7 @@ class BuiltinTest(unittest.TestCase):
             z1 = zip(a, b, strict=True)
             self.check_iter_pickle(z1, t, proto)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_zip_pickle_strict_fail(self):
         a = (1, 2, 3)

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -172,7 +172,7 @@ def external_getitem(self, i):
 class CodeTest(unittest.TestCase):
 
     @cpython_only
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(is_nanvix, "NSKIP002: _testcapi not available")
     def test_newempty(self):
         import _testcapi

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -89,7 +89,7 @@ class ContextManagerTestCase(unittest.TestCase):
                 raise ZeroDivisionError()
         self.assertEqual(state, [1, 42, 999])
 
-    # NSKIP006 https://github.com/nanvix/cpython/issues/371
+    # NSKIP006 https://github.com/nanvix/cpython/issues/474
     @unittest.skipIf(support.is_nanvix, "NSKIP006: traceback source line formatting differs")
     def test_contextmanager_traceback(self):
         @contextmanager
@@ -433,7 +433,7 @@ class NullcontextTestCase(unittest.TestCase):
 
 class FileContextTestCase(unittest.TestCase):
 
-    # NSKIP008 https://github.com/nanvix/cpython/issues/371
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
     @unittest.skipIf(support.is_nanvix, "NSKIP008: tempfile names garbled")
     def testWithOpen(self):
         tfn = tempfile.mktemp()
@@ -838,7 +838,7 @@ class TestBaseExitStack:
             stack.push(lambda *exc: True)
             1/0
 
-    # NSKIP006 https://github.com/nanvix/cpython/issues/371
+    # NSKIP006 https://github.com/nanvix/cpython/issues/474
     @unittest.skipIf(support.is_nanvix, "NSKIP006: traceback source line formatting differs")
     def test_exit_exception_traceback(self):
         # This test captures the current behavior of ExitStack so that we know

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -2560,7 +2560,7 @@ class PythonAPItests:
         self.assertIsInstance(Decimal(0), numbers.Number)
         self.assertNotIsInstance(Decimal(0), numbers.Real)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -2946,7 +2946,7 @@ class ContextAPItests:
         s = _testcapi.unicode_legacy_string('ROUND_\x00UP')
         self.assertRaises(TypeError, setattr, c, 'rounding', s)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
 

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1109,7 +1109,7 @@ class DictTest(unittest.TestCase):
         self.assertGreater(sys.getsizeof(d), before_resize)
         self.assertEqual(list(d), ['x', 2])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1129,7 +1129,7 @@ class DictTest(unittest.TestCase):
             del data[drop]
             self.assertEqual(list(it), list(data))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_itemiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1153,7 +1153,7 @@ class DictTest(unittest.TestCase):
             del data[drop[0]]
             self.assertEqual(dict(it), data)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_valuesiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1171,7 +1171,7 @@ class DictTest(unittest.TestCase):
             values = list(it) + [drop]
             self.assertEqual(sorted(values), sorted(list(data.values())))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reverseiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1191,7 +1191,7 @@ class DictTest(unittest.TestCase):
             del data[drop]
             self.assertEqual(list(it), list(reversed(data)))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reverseitemiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -1215,7 +1215,7 @@ class DictTest(unittest.TestCase):
             del data[drop[0]]
             self.assertEqual(dict(it), data)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reversevaluesiterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -30,7 +30,7 @@ class BadConstructorArgs(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, MSG):
             ExceptionGroup('eg', [ValueError('too')], [TypeError('many')])
 
-    # NSKIP013 https://github.com/nanvix/cpython/issues/371
+    # NSKIP013 https://github.com/nanvix/cpython/issues/481
     @unittest.skipIf(support.is_nanvix, "NSKIP013: 32-bit arg numbering garbled")
     def test_bad_EG_construction__bad_message(self):
         MSG = 'argument 1 must be str, not '

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -334,7 +334,7 @@ class ExceptionTests(unittest.TestCase):
             compile(src, '<fragment>', 'exec')
 
     @cpython_only
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def testSettingException(self):
         # test that setting an exception at the C level works even if the
@@ -430,7 +430,7 @@ class ExceptionTests(unittest.TestCase):
         with self.assertRaisesRegex(OSError, 'Windows Error 0x%x' % code):
             ctypes.pythonapi.PyErr_SetFromWindowsErr(code)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def testAttributes(self):
         # test that exception attributes are happy
@@ -1526,7 +1526,7 @@ class ExceptionTests(unittest.TestCase):
             self.assertIn(b'MemoryError', err)
 
     @cpython_only
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_MemoryError(self):
         # PyErr_NoMemory always raises the same exception instance.
@@ -1547,7 +1547,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(tb1, tb2)
 
     @cpython_only
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_exception_with_doc(self):
         import _testcapi
@@ -1589,7 +1589,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(error5.__doc__, "")
 
     @cpython_only
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_memory_error_cleanup(self):
         # Issue #5437: preallocated MemoryError instances should not keep
@@ -1796,7 +1796,7 @@ class ExceptionTests(unittest.TestCase):
 
             gc_collect()
 
-    # NSKIP003 https://github.com/nanvix/cpython/issues/371
+    # NSKIP003 https://github.com/nanvix/cpython/issues/471
     @unittest.skipIf(support.is_nanvix, "NSKIP003: no subprocess support")
     def test_memory_error_in_subinterp(self):
         # gh-109894: subinterpreters shouldn't count on last resort memory error
@@ -1961,7 +1961,7 @@ class ImportErrorTests(unittest.TestCase):
             exc = ImportError(arg)
             self.assertEqual(str(arg), str(exc))
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_copy_pickle(self):
         for kwargs in (dict(),
@@ -2073,7 +2073,7 @@ class SyntaxErrorTests(unittest.TestCase):
                     self.assertIn(expected, err.getvalue())
                     the_exception = exc
 
-    # NSKIP003 https://github.com/nanvix/cpython/issues/371
+    # NSKIP003 https://github.com/nanvix/cpython/issues/471
     @unittest.skipIf(support.is_nanvix, "NSKIP003: no subprocess support")
     def test_encodings(self):
         source = (
@@ -2104,7 +2104,7 @@ class SyntaxErrorTests(unittest.TestCase):
         finally:
             unlink(TESTFN)
 
-    # NSKIP003 https://github.com/nanvix/cpython/issues/371
+    # NSKIP003 https://github.com/nanvix/cpython/issues/471
     @unittest.skipIf(support.is_nanvix, "NSKIP003: no subprocess support")
     def test_non_utf8(self):
         # Check non utf-8 characters

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -834,7 +834,7 @@ class FractionTest(unittest.TestCase):
             s += num / fact * sign
         self.assertAlmostEqual(math.cos(1), s)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_copy_deepcopy_pickle(self):
         r = F(13, 7)

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -796,7 +796,7 @@ class IntStrDigitLimitsTests(unittest.TestCase):
         with self.subTest(base=base):
             self._other_base_helper(base)
 
-    # NSKIP002 https://github.com/nanvix/cpython/issues/371
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
     @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def test_int_max_str_digits_is_per_interpreter(self):
         # Changing the limit in one interpreter does not change others.

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -120,7 +120,7 @@ class ListTest(list_tests.CommonTest):
         check(10)       # check our checking code
         check(1000000)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         orig = self.type2test([4, 5, 6, 7])
@@ -158,7 +158,7 @@ class ListTest(list_tests.CommonTest):
             a[:] = data
             self.assertEqual(list(it), [])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reversed_pickle(self):
         orig = self.type2test([4, 5, 6, 7])
@@ -275,7 +275,7 @@ class ListTest(list_tests.CommonTest):
         X() in lst
 
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         super().test_pickle()

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1850,7 +1850,7 @@ class MathTests(unittest.TestCase):
             self.assertRaises(ValueError, math.sin, NINF)
         self.assertTrue(math.isnan(math.sin(NAN)))
 
-    # NSKIP010 https://github.com/nanvix/cpython/issues/371
+    # NSKIP010 https://github.com/nanvix/cpython/issues/478
     @unittest.skipIf(support.is_nanvix, "NSKIP010: 32-bit float precision loss")
     def testSinh(self):
         self.assertRaises(TypeError, math.sinh)

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -691,28 +691,28 @@ class OperatorPickleTestCase:
                 # Can't test repr consistently with multiple keyword args
                 self.assertEqual(f2(a), f(a))
 
-# NSKIP001 https://github.com/nanvix/cpython/issues/371
+# NSKIP001 https://github.com/nanvix/cpython/issues/469
 @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class PyPyOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = py_operator
     module2 = py_operator
 
 @unittest.skipUnless(c_operator, 'requires _operator')
-# NSKIP001 https://github.com/nanvix/cpython/issues/371
+# NSKIP001 https://github.com/nanvix/cpython/issues/469
 @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class PyCOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = py_operator
     module2 = c_operator
 
 @unittest.skipUnless(c_operator, 'requires _operator')
-# NSKIP001 https://github.com/nanvix/cpython/issues/371
+# NSKIP001 https://github.com/nanvix/cpython/issues/469
 @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class CPyOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = c_operator
     module2 = py_operator
 
 @unittest.skipUnless(c_operator, 'requires _operator')
-# NSKIP001 https://github.com/nanvix/cpython/issues/371
+# NSKIP001 https://github.com/nanvix/cpython/issues/469
 @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
 class CCOperatorPickleTestCase(OperatorPickleTestCase, unittest.TestCase):
     module = c_operator

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -381,7 +381,7 @@ class TestBasicOps:
         self.assertRaises(ValueError, self.gen.getrandbits, -1)
         self.assertRaises(TypeError, self.gen.getrandbits, 10.1)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -363,7 +363,7 @@ class RangeTest(unittest.TestCase):
         self.assertEqual(repr(range(1, 2)), 'range(1, 2)')
         self.assertEqual(repr(range(1, 2, 3)), 'range(1, 2, 3)')
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickling(self):
         testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1),
@@ -375,7 +375,7 @@ class RangeTest(unittest.TestCase):
                     self.assertEqual(list(pickle.loads(pickle.dumps(r, proto))),
                                      list(r))
 
-    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    # NSKIP004 https://github.com/nanvix/cpython/issues/472
     @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_iterator_pickling(self):
         testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1), (13, 21, 3),
@@ -407,7 +407,7 @@ class RangeTest(unittest.TestCase):
                     it = pickle.loads(d)
                     self.assertEqual(list(it), data[1:])
 
-    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    # NSKIP004 https://github.com/nanvix/cpython/issues/472
     @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_iterator_pickling_overflowing_index(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -418,7 +418,7 @@ class RangeTest(unittest.TestCase):
                 it = pickle.loads(d)
                 self.assertEqual(next(it), 2**32 + 1)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -433,7 +433,7 @@ class RangeTest(unittest.TestCase):
             self.assertEqual(list(i), [])
             self.assertEqual(list(i2), [])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_large_exhausted_iterator_pickling(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -448,7 +448,7 @@ class RangeTest(unittest.TestCase):
             self.assertEqual(list(i), [])
             self.assertEqual(list(i2), [])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_unpickle_compat(self):
         testcases = [
@@ -468,7 +468,7 @@ class RangeTest(unittest.TestCase):
             it = pickle.loads(t)
             self.assertEqual(list(it), [14, 16, 18])
 
-    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    # NSKIP004 https://github.com/nanvix/cpython/issues/472
     @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_iterator_setstate(self):
         it = iter(range(10, 20, 2))
@@ -545,7 +545,7 @@ class RangeTest(unittest.TestCase):
         self.assertNotIn(-1, r)
         self.assertNotIn(1, r)
 
-    # NSKIP004 https://github.com/nanvix/cpython/issues/371
+    # NSKIP004 https://github.com/nanvix/cpython/issues/472
     @unittest.skipIf(is_nanvix, "NSKIP004: 32-bit integer overflow")
     def test_range_iterators(self):
         # exercise 'fast' iterators, that use a rangeiterobject internally.

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -585,7 +585,7 @@ def write_file(path, text):
     with open(path, 'w', encoding='ASCII') as fp:
         fp.write(text)
 
-# NSKIP012 https://github.com/nanvix/cpython/issues/371
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
 @unittest.skipIf(support.is_nanvix, "NSKIP012: rmtree/rmdir returns ENOSYS")
 class LongReprTest(unittest.TestCase):
     longname = 'areallylongpackageandmodulenametotestreprtruncation'

--- a/Lib/test/test_slice.py
+++ b/Lib/test/test_slice.py
@@ -241,7 +241,7 @@ class SliceTest(unittest.TestCase):
         x[1:2] = 42
         self.assertEqual(tmp, [(slice(1, 2), 42)])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         import pickle

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -3022,7 +3022,7 @@ class TestNormalDist:
         nd2 = copy.deepcopy(nd)
         self.assertEqual(nd, nd2)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         nd = self.module.NormalDist(37.5, 5.625)

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -47,7 +47,7 @@ class G(A):
     pass
 
 
-# NSKIP009 https://github.com/nanvix/cpython/issues/371
+# NSKIP009 https://github.com/nanvix/cpython/issues/477
 @unittest.skipIf(support.is_nanvix, "NSKIP009: VM crash from __class__ cell corruption")
 class TestSuper(unittest.TestCase):
 

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -370,12 +370,12 @@ class TupleTest(seq_tests.CommonTest):
         check(10)       # check our checking code
         check(1000000)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         super().test_pickle()
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_iterator_pickle(self):
         # Userlist iterators don't support pickling yet since
@@ -393,7 +393,7 @@ class TupleTest(seq_tests.CommonTest):
             d = pickle.dumps(it, proto)
             self.assertEqual(self.type2test(it), self.type2test(data)[1:])
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_reversed_pickle(self):
         data = self.type2test([4, 5, 6, 7])

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -882,7 +882,7 @@ class UnionTests(unittest.TestCase):
         eq(x[NT], int | NT | bytes)
         eq(x[S], int | S | bytes)
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_union_pickle(self):
         orig = list[T] | int
@@ -1912,7 +1912,7 @@ class SimpleNamespaceTests(unittest.TestCase):
         self.assertIs(type(spam), Spam)
         self.assertEqual(vars(spam), {'ham': 8, 'eggs': 9})
 
-    # NSKIP001 https://github.com/nanvix/cpython/issues/371
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
     @unittest.skipIf(support.is_nanvix, "NSKIP001: pickle corrupt on 32-bit")
     def test_pickle(self):
         ns = types.SimpleNamespace(breakfast="spam", lunch="spam")


### PR DESCRIPTION
## What

Update all NSKIP links to point to new issues under #371 

## Why

Issues were pointing only to #371 - now subissues exist.

## Priority

🟢 Low - Ease of use

## Verification

`rg 'NSKIP[0-9]+ https://github\.com/nanvix/cpython/issues/371'` returns empty.