### PR TITLE
fix(test): skip rebuild when python binary exists from Docker build

### DIFF
--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -134,6 +134,7 @@ def install(
     install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
     release: bool = False,
     run_fn=None,
+    extra_make_flags: list[str] | None = None,
 ) -> None:
     """Install CPython into a staging directory."""
     if config.IS_WINDOWS:
@@ -153,7 +154,9 @@ def install(
     except ValueError:
         rel_destdir = destdir
     args = make_args(
-        sysroot, toolchain, "install", f"DESTDIR={rel_destdir}",
+        sysroot, toolchain,
+        *(extra_make_flags or []),
+        "install", f"DESTDIR={rel_destdir}",
         platform=platform,
         process_mode=process_mode,
         memory_size=memory_size,

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -194,25 +194,49 @@ def stage(
             print("  Using downloaded release as install cache")
     else:
         # Linux: build and install directly.
-        build_mod.build(
-            sysroot, toolchain, repo_root,
-            platform=platform,
-            process_mode=process_mode,
-            memory_size=memory_size,
-            install_prefix=install_prefix,
-            release=release,
-            run_fn=run_fn,
-        )
+        # If the python binary already exists (e.g. from a prior Docker
+        # build), skip the rebuild to avoid requiring Docker-only tooling
+        # (BUILD_PYTHON) that is not available on the host.
+        python_binary = repo_root / f"python{config.EXE}"
+        if python_binary.is_file():
+            print(f"  Skipping rebuild ({python_binary.name} already exists)")
+            # Install into staging, overriding the build dependency so
+            # make does not attempt a rebuild.
+            try:
+                rel_staging = staging.resolve().relative_to(repo_root.resolve())
+            except ValueError:
+                rel_staging = staging
+            install_args = build_mod.make_args(
+                sysroot, toolchain,
+                "-o", "build", "-o", "all",
+                "install", f"DESTDIR={rel_staging}",
+                platform=platform,
+                process_mode=process_mode,
+                memory_size=memory_size,
+                install_prefix=install_prefix,
+                release=release,
+            )
+            build_mod.run_make(install_args, cwd=repo_root, run_fn=run_fn)
+        else:
+            build_mod.build(
+                sysroot, toolchain, repo_root,
+                platform=platform,
+                process_mode=process_mode,
+                memory_size=memory_size,
+                install_prefix=install_prefix,
+                release=release,
+                run_fn=run_fn,
+            )
 
-        build_mod.install(
-            sysroot, toolchain, repo_root, staging,
-            platform=platform,
-            process_mode=process_mode,
-            memory_size=memory_size,
-            install_prefix=install_prefix,
-            release=release,
-            run_fn=run_fn,
-        )
+            build_mod.install(
+                sysroot, toolchain, repo_root, staging,
+                platform=platform,
+                process_mode=process_mode,
+                memory_size=memory_size,
+                install_prefix=install_prefix,
+                release=release,
+                run_fn=run_fn,
+            )
 
     sysroot_dir = staging / "sysroot"
 

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -194,29 +194,45 @@ def stage(
             print("  Using downloaded release as install cache")
     else:
         # Linux: build and install directly.
-        # If the python binary already exists (e.g. from a prior Docker
-        # build), skip the rebuild to avoid requiring Docker-only tooling
-        # (BUILD_PYTHON) that is not available on the host.
+        # Only skip the rebuild when the previously built binary exists,
+        # the build tree is properly configured, and the host cannot use
+        # BUILD_PYTHON (e.g. after a prior Docker build where that tool
+        # is unavailable outside the container).
         python_binary = repo_root / f"python{config.EXE}"
-        if python_binary.is_file():
-            print(f"  Skipping rebuild ({python_binary.name} already exists)")
+        configured_marker = repo_root / ".nanvix-configured"
+        pybuilddir = repo_root / "pybuilddir.txt"
+
+        # Determine whether BUILD_PYTHON is usable on the host.
+        build_python_path = Path(toolchain) / "bin" / "python3"
+        build_python_available = (
+            build_python_path.is_file()
+            or shutil.which(str(build_python_path)) is not None
+        )
+
+        can_skip_rebuild = (
+            python_binary.is_file()
+            and configured_marker.is_file()
+            and pybuilddir.is_file()
+            and not build_python_available
+        )
+
+        if can_skip_rebuild:
+            print(
+                f"  Skipping rebuild ({python_binary.name} already exists"
+                " and BUILD_PYTHON is unavailable)"
+            )
             # Install into staging, overriding the build dependency so
             # make does not attempt a rebuild.
-            try:
-                rel_staging = staging.resolve().relative_to(repo_root.resolve())
-            except ValueError:
-                rel_staging = staging
-            install_args = build_mod.make_args(
-                sysroot, toolchain,
-                "-o", "build", "-o", "all",
-                "install", f"DESTDIR={rel_staging}",
+            build_mod.install(
+                sysroot, toolchain, repo_root, staging,
                 platform=platform,
                 process_mode=process_mode,
                 memory_size=memory_size,
                 install_prefix=install_prefix,
                 release=release,
+                run_fn=run_fn,
+                extra_make_flags=["-o", "build", "-o", "all"],
             )
-            build_mod.run_make(install_args, cwd=repo_root, run_fn=run_fn)
         else:
             build_mod.build(
                 sysroot, toolchain, repo_root,

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -221,8 +221,8 @@ def stage(
                 f"  Skipping rebuild ({python_binary.name} already exists"
                 " and BUILD_PYTHON is unavailable)"
             )
-            # Install into staging, overriding the build dependency so
-            # make does not attempt a rebuild.
+            # Install into staging, skipping the outer build prereq
+            # and stubbing PYTHON_FOR_BUILD for the inner make.
             build_mod.install(
                 sysroot, toolchain, repo_root, staging,
                 platform=platform,
@@ -231,7 +231,7 @@ def stage(
                 install_prefix=install_prefix,
                 release=release,
                 run_fn=run_fn,
-                extra_make_flags=["-o", "build", "-o", "all"],
+                extra_make_flags=["-o", "build", "PYTHON_FOR_BUILD=:"],
             )
         else:
             build_mod.build(


### PR DESCRIPTION
When the build phase runs inside Docker (\--with-docker\), the test phase runs on the host where \/opt/nanvix/bin/python3\ (\BUILD_PYTHON\) does not exist. The test \stage()\ function unconditionally called \uild_mod.build()\ which triggered \make -f Makefile.nanvix build\, failing at \checksharedmods\ with:

\/bin/sh: 1: /opt/nanvix/bin/python3: not found
make[1]: *** [Makefile:1120: checksharedmods] Error 127
\
**Fix:** If \python.elf\ already exists (from the prior Docker build), skip the rebuild and run \make install\ with \-o build -o all\ to prevent make from re-triggering the build dependency. This mirrors how other consumers (sqlite, openssl) handle the same scenario.

When no prior build exists, the original build+install flow is preserved unchanged.