### PR TITLE
ci: Enable Windows build and bump workflows to v1.11.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,12 +25,13 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.1
     with:
       zutil-version: "v0.7.25"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       skip-full-test-modes: '[]'
+      windows-build: true
       caller-event-name: ${{ github.event_name }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -43,12 +44,13 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.1
     with:
       zutil-version: "v0.7.25"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       skip-full-test-modes: '[]'
+      windows-build: true
       caller-event-name: 'schedule'
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Bump the reusable workflow from `v1.10.1` → `v1.11.0` and enable `windows-build: true` for both CI jobs.

## Problem

The `windows-test` job downloads a pre-built binary from `releases/latest`. When nanvix has a backwards-incompatible ABI change (e.g. the `mmap` kcall signature change in v0.12.462), the stale binary crashes on the new kernel — causing the failure in #463.

## Fix

With `windows-build: true`, the Windows runner now runs `nanvix-zutil build` (Docker-based cross-compilation via `.nanvix/docker.py`) before testing. This ensures the test binary always matches the current nanvix version.

## Changes

- `nanvix/workflows` `v1.10.1` → `v1.11.0` (both `ci` and `ci-scheduled` jobs)
- Added `windows-build: true` to both jobs

## Related

- nanvix/workflows#53 — added the `windows-build` input
- #463 — the failing PR this fixes