### PR TITLE
ci: adopt docker-build / native-test workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,13 +25,14 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.1
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
       zutil-version: "v0.7.26"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
@@ -43,13 +44,14 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.11.1
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.12.0
     with:
       zutil-version: "v0.7.26"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
+      windows-test: true
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -45,14 +45,22 @@ def package(
     install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
     release: bool = True,
     run_fn=None,
+    nanvix_home: str | Path | None = None,
 ) -> None:
     """Package CPython release tarballs.
 
     Creates two tarballs in ``dist/``:
     - ``cpython-<platform>-<mode>-<memory>.tar.bz2`` — runtime sysroot + binary + ramfs
     - ``cpython-<platform>-<mode>-<memory>-buildroot.tar.bz2`` — build dependencies
+
+    Args:
+        nanvix_home: Host-side path to the Nanvix sysroot for local
+            file operations (mkramfs, etc.).  When Docker is active
+            *sysroot* is a container-internal path; *nanvix_home*
+            should be the original host path so that
+            ``subprocess.run`` and ``Path.is_file`` work correctly.
     """
-    nanvix_home = Path(sysroot)
+    nanvix_home = Path(nanvix_home) if nanvix_home else Path(sysroot)
     release_staging = repo_root / ".nanvix" / "release"
     dist_dir = repo_root / "dist"
     artifact = _artifact_base(platform, process_mode, memory_size)

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -337,10 +337,17 @@ class CPythonBuild(ZScript):
         sysroot, toolchain = self._get_paths()
         kwargs = self._build_kwargs(release=True)
 
+        # Pass raw host sysroot path for local file operations (mkramfs,
+        # etc.).  _get_paths() translates to Docker-internal paths when
+        # Docker is active, but package.py needs host paths for
+        # subprocess.run() and Path.is_file() calls.
+        sysroot_host = self.config.get(CFG_SYSROOT, "")
+
         package_mod.package(
             sysroot, toolchain, self.repo_root,
             **kwargs,
             run_fn=lambda *args, **kw: self.run(*args, **kw),
+            nanvix_home=sysroot_host,
         )
         package_mod.verify(
             self.repo_root,


### PR DESCRIPTION
## Summary
Adopt the new docker-build / native-test CI workflow (v1.12.0).

### Changes
- **Workflow**: Update to `nanvix/workflows@v1.12.0`
- **zutil**: Update to `v0.7.26`
- **Windows test**: Enable artifact-based Windows testing on `windows-latest`

### How it works
- **Linux**: Build with Docker, test natively (KVM)
- **Windows**: Download ELF binaries from Linux build, test natively (`nanvixd.exe`)
- All on GitHub-hosted runners (no self-hosted required)