### PR TITLE
tests: nanvix harness process-mode plumbing (#371)

### DIFF
--- a/.nanvix/run-regrtest.py
+++ b/.nanvix/run-regrtest.py
@@ -32,12 +32,36 @@ def main() -> int:
         os.environ["TMPDIR"] = argv[1]
         argv = argv[2:]
 
-    # -- Resolve test modules --------------------------------------------------
-    list_file = os.environ.get("NANVIX_TEST_LIST_FILE", "test-list.txt")
-    modules = None
+    # -- Split forwarded regrtest flags from positional module names ----------
+    # Anything starting with "-" is a regrtest flag we should forward (and
+    # for short flags like -m/-x/-u, the immediately following token is its
+    # value, not a module name).
+    _FLAGS_WITH_VALUE = {"-m", "-x", "-u", "--match", "--matchfile",
+                         "--ignore", "--ignorefile", "-r", "--randomize"}
+    extra_flags: list[str] = []
+    modules: list[str] | None = None
     if argv:
-        modules = argv
-    else:
+        positional: list[str] = []
+        i = 0
+        while i < len(argv):
+            tok = argv[i]
+            if tok.startswith("-"):
+                extra_flags.append(tok)
+                # If it's a known flag-with-value and not joined by =, also
+                # consume the next token as its value.
+                if tok in _FLAGS_WITH_VALUE and "=" not in tok and i + 1 < len(argv):
+                    extra_flags.append(argv[i + 1])
+                    i += 2
+                    continue
+                i += 1
+            else:
+                positional.append(tok)
+                i += 1
+        if positional:
+            modules = positional
+
+    if modules is None:
+        list_file = os.environ.get("NANVIX_TEST_LIST_FILE", "test-list.txt")
         try:
             with open(list_file) as f:
                 modules = [
@@ -53,10 +77,12 @@ def main() -> int:
         print("run-regrtest.py: no test modules specified", file=sys.stderr)
         return 1
     print(f"run-regrtest.py: Got modules: {modules}")
+    if extra_flags:
+        print(f"run-regrtest.py: Forwarding regrtest flags: {extra_flags}")
 
     # -- Build regrtest arguments ----------------------------------------------
     timeout = os.environ.get("REGRTEST_TIMEOUT", "120")
-    args = [f"--timeout={timeout}"] + modules
+    args = [f"--timeout={timeout}"] + extra_flags + modules
 
     # -- Run -------------------------------------------------------------------
     sys.argv[1:] = args

--- a/.nanvix/run-regrtest.py
+++ b/.nanvix/run-regrtest.py
@@ -33,30 +33,26 @@ def main() -> int:
         argv = argv[2:]
 
     # -- Split forwarded regrtest flags from positional module names ----------
-    # Anything starting with "-" is a regrtest flag we should forward (and
-    # for short flags like -m/-x/-u, the immediately following token is its
-    # value, not a module name).
-    _FLAGS_WITH_VALUE = {"-m", "-x", "-u", "--match", "--matchfile",
-                         "--ignore", "--ignorefile", "-r", "--randomize"}
+    # The host caller (run-tests.py) places a literal "--" between forwarded
+    # regrtest flags and module names.  This is the POSIX-standard convention
+    # and avoids us having to mirror libregrtest/cmdline.py's option table
+    # (which is wrong-by-construction: any new value-taking option upstream
+    # would silently consume a module name as its value, corrupting the
+    # batch's test list).
+    #
+    # Legacy/ad-hoc invocation (no "--"): treat any token starting with "-"
+    # as a flag, everything else as a module.  Safe because no caller passes
+    # value-taking flags via ad-hoc CLI use.
     extra_flags: list[str] = []
     modules: list[str] | None = None
     if argv:
-        positional: list[str] = []
-        i = 0
-        while i < len(argv):
-            tok = argv[i]
-            if tok.startswith("-"):
-                extra_flags.append(tok)
-                # If it's a known flag-with-value and not joined by =, also
-                # consume the next token as its value.
-                if tok in _FLAGS_WITH_VALUE and "=" not in tok and i + 1 < len(argv):
-                    extra_flags.append(argv[i + 1])
-                    i += 2
-                    continue
-                i += 1
-            else:
-                positional.append(tok)
-                i += 1
+        if "--" in argv:
+            sep = argv.index("--")
+            extra_flags = argv[:sep]
+            positional = argv[sep + 1:]
+        else:
+            extra_flags = [t for t in argv if t.startswith("-")]
+            positional = [t for t in argv if not t.startswith("-")]
         if positional:
             modules = positional
 

--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -23,8 +23,20 @@
 #     NANVIX_TEST_BATCH_SIZE - modules per nanvixd invocation (default: 4)
 #     NANVIXD_EXTRA_ARGS     - extra flags passed to nanvixd (optional)
 #     NANVIX_STANDALONE      - set to "1" to enable standalone mode
+#     NANVIX_PROCESS_MODE    - "standalone" / "single-process" / "multi-process";
+#                              forwarded into the guest so support helpers
+#                              (is_nanvix_standalone / is_nanvix_hosted in
+#                              Lib/test/support) can discriminate.  Defaulted
+#                              from NANVIX_STANDALONE when unset.
 #     REGRTEST_TIMEOUT       - per-test timeout in seconds (default: 120)
+#     NANVIX_REGRTEST_EXTRA  - extra args appended to the regrtest invocation
+#                              before the module list.  Use shell-style
+#                              quoting; parsed by shlex.  Examples:
+#                                NANVIX_REGRTEST_EXTRA='-m test_dircmp'
+#                                NANVIX_REGRTEST_EXTRA='-x test_slow'
+#                                NANVIX_REGRTEST_EXTRA='-v -m DirCompareTestCase'
 
+import json
 import os
 import shlex
 import shutil
@@ -34,6 +46,29 @@ import tempfile
 
 BATCH_SIZE = int(os.environ.get("NANVIX_TEST_BATCH_SIZE", "4"))
 STANDALONE = os.environ.get("NANVIX_STANDALONE", "") == "1"
+
+
+def _detect_process_mode() -> str:
+    """Resolve NANVIX_PROCESS_MODE from env, manifest.json, or STANDALONE.
+
+    Precedence: explicit env var > sysroot manifest > STANDALONE fallback.
+    The sysroot manifest is written by ``./z setup`` and lives at
+    ``./manifest.json`` relative to cwd (we run from the sysroot dir).
+    """
+    env_mode = os.environ.get("NANVIX_PROCESS_MODE")
+    if env_mode:
+        return env_mode
+    try:
+        with open("manifest.json") as f:
+            mode = json.load(f).get("deployment_mode")
+            if mode:
+                return mode
+    except (OSError, ValueError):
+        pass
+    return "standalone" if STANDALONE else "single-process"
+
+
+PROCESS_MODE = _detect_process_mode()
 NANVIXD = "./bin/nanvixd.exe" if sys.platform == "win32" else "./bin/nanvixd.elf"
 # Must match config.PYTHON_VERSION / config.python_binary().
 PYTHON_BIN = os.environ.get("NANVIX_PYTHON_BIN", "./bin/python3.12")
@@ -42,6 +77,7 @@ SYSCONFIGDATA_NAME = os.environ.get(
     "NANVIX_SYSCONFIGDATA_NAME", "_sysconfigdata__nanvix_"
 )
 REGRTEST_TIMEOUT = os.environ.get("REGRTEST_TIMEOUT", "120")
+REGRTEST_EXTRA = shlex.split(os.environ.get("NANVIX_REGRTEST_EXTRA", ""))
 
 
 def run_batch(
@@ -62,12 +98,14 @@ def run_batch(
             # string.  nanvixd splits on spaces for argv and on semicolons
             # for environment variables.
             modules_str = " ".join(batch)
+            extra_str = (" " + " ".join(REGRTEST_EXTRA)) if REGRTEST_EXTRA else ""
             regrtest_args = (
-                f"-B -m test --timeout={REGRTEST_TIMEOUT} {modules_str}"
+                f"-B -m test --timeout={REGRTEST_TIMEOUT}{extra_str} {modules_str}"
             )
             python_arg = (
                 f"{regrtest_args};PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
                 f" TMPDIR=/tmp"
+                f" NANVIX_PROCESS_MODE={PROCESS_MODE}"
                 f" _PYTHON_SYSCONFIGDATA_NAME={SYSCONFIGDATA_NAME}"
             )
 
@@ -81,6 +119,18 @@ def run_batch(
         else:
             # Direct mode: separate argv elements, invoke run-regrtest.py
             # in the guest.  --tmpdir must come before the module list.
+            #
+            # NANVIX_PROCESS_MODE is published into the guest via nanvixd's
+            # semicolon-env trick on the *trailing* argv token: nanvixd
+            # strips the ";KEY=VAL ..." portion from any token containing
+            # a semicolon and sets the env vars before exec.  The trick
+            # MUST go on the trailing token because nanvixd truncates all
+            # python-side argv after the first semicolon-bearing token.
+            argv_tail = list(REGRTEST_EXTRA) + list(batch)
+            if argv_tail:
+                argv_tail[-1] = (
+                    f"{argv_tail[-1]};NANVIX_PROCESS_MODE={PROCESS_MODE}"
+                )
             cmd = [
                 NANVIXD,
                 *nanvixd_extra,
@@ -89,7 +139,7 @@ def run_batch(
                 "./run-regrtest.py",
                 "--tmpdir",
                 batch_tmpdir,
-                *batch,
+                *argv_tail,
             ]
 
         try:

--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -33,8 +33,11 @@
 #                              before the module list.  Use shell-style
 #                              quoting; parsed by shlex.  Examples:
 #                                NANVIX_REGRTEST_EXTRA='-m test_dircmp'
-#                                NANVIX_REGRTEST_EXTRA='-x test_slow'
 #                                NANVIX_REGRTEST_EXTRA='-v -m DirCompareTestCase'
+#                              Note: -x/--exclude is accepted but inverts the
+#                              meaning of the batch's positional module list,
+#                              so the modules you intended to run will instead
+#                              be excluded.  Use with care.
 
 import json
 import os
@@ -77,7 +80,10 @@ SYSCONFIGDATA_NAME = os.environ.get(
     "NANVIX_SYSCONFIGDATA_NAME", "_sysconfigdata__nanvix_"
 )
 REGRTEST_TIMEOUT = os.environ.get("REGRTEST_TIMEOUT", "120")
-REGRTEST_EXTRA = shlex.split(os.environ.get("NANVIX_REGRTEST_EXTRA", ""))
+REGRTEST_EXTRA = shlex.split(
+    os.environ.get("NANVIX_REGRTEST_EXTRA", ""),
+    posix=(sys.platform != "win32"),
+)
 
 
 def run_batch(
@@ -120,17 +126,21 @@ def run_batch(
             # Direct mode: separate argv elements, invoke run-regrtest.py
             # in the guest.  --tmpdir must come before the module list.
             #
+            # A literal "--" separates forwarded regrtest flags from
+            # positional module names so run-regrtest.py doesn't have to
+            # mirror libregrtest's option table to know which short flags
+            # take values.
+            #
             # NANVIX_PROCESS_MODE is published into the guest via nanvixd's
             # semicolon-env trick on the *trailing* argv token: nanvixd
             # strips the ";KEY=VAL ..." portion from any token containing
             # a semicolon and sets the env vars before exec.  The trick
             # MUST go on the trailing token because nanvixd truncates all
             # python-side argv after the first semicolon-bearing token.
-            argv_tail = list(REGRTEST_EXTRA) + list(batch)
-            if argv_tail:
-                argv_tail[-1] = (
-                    f"{argv_tail[-1]};NANVIX_PROCESS_MODE={PROCESS_MODE}"
-                )
+            argv_tail = list(REGRTEST_EXTRA) + ["--"] + list(batch)
+            argv_tail[-1] = (
+                f"{argv_tail[-1]};NANVIX_PROCESS_MODE={PROCESS_MODE}"
+            )
             cmd = [
                 NANVIXD,
                 *nanvixd_extra,

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -500,6 +500,15 @@ def run_regrtest(
     env = os.environ.copy()
     env["NANVIX_TEST_BATCH_SIZE"] = str(batch_size)
     env["NANVIX_PYTHON_BIN"] = f"./bin/{config.python_binary()}"
+    # Publish the active process mode to run-tests.py, which forwards it
+    # into the guest via nanvixd's semicolon-env trick.  Guest-side support
+    # helpers (is_nanvix_standalone / is_nanvix_hosted in
+    # Lib/test/support) read NANVIX_PROCESS_MODE to discriminate between
+    # the standalone FAT VFS and the host-FS passthrough used by single-
+    # and multi-process modes.  nanvixd does NOT inherit host env into
+    # the guest, so this variable must be propagated explicitly through
+    # the run-tests.py argv plumbing.
+    env["NANVIX_PROCESS_MODE"] = process_mode
 
     if standalone:
         # Standalone: ramfs + semicolon env syntax.

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -541,6 +541,29 @@ is_emscripten = sys.platform == "emscripten"
 is_wasi = sys.platform == "wasi"
 is_nanvix = sys.platform == "nanvix"
 
+# Nanvix process-mode discrimination.
+#
+# Nanvix exposes three deployment modes:
+#   * standalone     - guest runs against an in-memory FAT ramfs VFS
+#   * single-process - guest accesses host filesystem via linuxd passthrough
+#   * multi-process  - same host-FS passthrough, separate VM processes
+#
+# The two hosted modes (single-/multi-process) share a Linux-passthrough VFS
+# and exhibit a *different* bug surface than standalone (FAT VFS).  Many tests
+# need to skip on standalone only, or on hosted only — not on all of nanvix.
+#
+# The active mode is published by the test harness via NANVIX_PROCESS_MODE
+# (.nanvix/test.py sets it, .nanvix/run-tests.py forwards it into the guest
+# via nanvixd's semicolon-env trick — env-segment in standalone, trailing
+# argv token in direct mode).  When the variable is unset (e.g. a bare
+# invocation outside ./z test) we conservatively assume standalone, so
+# pre-existing standalone-targeted skips keep firing.
+_NANVIX_PROCESS_MODE = os.environ.get("NANVIX_PROCESS_MODE", "standalone")
+is_nanvix_standalone = is_nanvix and _NANVIX_PROCESS_MODE == "standalone"
+is_nanvix_hosted = is_nanvix and _NANVIX_PROCESS_MODE in (
+    "single-process", "multi-process",
+)
+
 # TODO: enable fork support once nanvix implements it
 # (https://github.com/nanvix/nanvix/issues/321)
 has_fork_support = hasattr(os, "fork") and not is_emscripten and not is_wasi and not is_nanvix


### PR DESCRIPTION
## Changes

Plumbing-only PR. Wires `NANVIX_PROCESS_MODE` from host into guest via `nanvixd`'s semicolon-env trick, adds `_detect_process_mode()` fallback to the regrtest harness (env > `manifest.json` > `STANDALONE`), and defines the `is_nanvix_standalone` / `is_nanvix_hosted` helper symbols in `Lib/test/support/__init__.py`. No test module or support helper consumes the new symbols yet — the support-helper accommodations land in the next PR. No-op for non-Nanvix platforms; introduces no new NSKIP IDs.

---

Refs: [#371](https://github.com/nanvix/cpython/issues/371), [#324](https://github.com/nanvix/cpython/issues/324)
Stacked on: `nanvix/v3.12.3`
Stacked under: https://github.com/nanvix/cpython/pull/535
Replaces: [#499](https://github.com/nanvix/cpython/pull/499)
