### PR TITLE
tests: nanvix support-helper accommodations (#371)

### DIFF
--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -68,6 +68,7 @@ def run_batch(
             python_arg = (
                 f"{regrtest_args};PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
                 f" TMPDIR=/tmp"
+                f" NANVIX_STANDALONE=1"
                 f" _PYTHON_SYSCONFIGDATA_NAME={SYSCONFIGDATA_NAME}"
             )
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -5,6 +5,7 @@ if __name__ != 'test.support':
 
 import contextlib
 import dataclasses
+import errno
 import functools
 import opcode
 import os
@@ -192,6 +193,9 @@ def get_original_stdout():
     return _original_stdout or sys.stdout
 
 
+# NSKIP012: warn-once flag for rmdir errno-88 swallow under hosted Nanvix.
+_nanvix_nskip012_warned = False
+
 def _force_run(path, func, *args):
     try:
         return func(*args)
@@ -201,6 +205,29 @@ def _force_run(path, func, *args):
             print('%s: %s' % (err.__class__.__name__, err))
         raise
     except OSError as err:
+        # NSKIP012 (hosted flavor): linuxd returns errno 88 from rmdir() on
+        # non-empty directories instead of POSIX ENOTEMPTY.  This is a
+        # distinct flavor of NSKIP012 from the standalone ENOSYS case
+        # (handled in os_helper.rmtree/rmdir); both are umbrella'd under
+        # #480 as "rmdir cleanup misbehavior on Nanvix".  Swallow the
+        # cleanup error here (regrtest's _rmtree calls _force_run for
+        # every leaf); the test's actual assertions are already done by
+        # the time framework teardown runs.  Standalone path doesn't go
+        # through linuxd and is unaffected, so gate on
+        # `is_nanvix and not is_nanvix_standalone`.  Restrict to os.rmdir
+        # so we don't mask unrelated errno-88 failures from other ops
+        # (_force_run is also used for unlink and listdir).
+        if (err.errno == 88 and is_nanvix and not is_nanvix_standalone
+                and func is os.rmdir):
+            global _nanvix_nskip012_warned
+            if not _nanvix_nskip012_warned:
+                print_warning(
+                    "NSKIP012: swallowing rmdir errno 88 on hosted Nanvix "
+                    "(linuxd returns 88 for non-empty dir instead of "
+                    f"ENOTEMPTY = {errno.ENOTEMPTY}); see issue #480"
+                )
+                _nanvix_nskip012_warned = True
+            return None
         if verbose >= 2:
             print('%s: %s' % (err.__class__.__name__, err))
             print('re-run %s%r' % (func.__name__, args))
@@ -540,6 +567,22 @@ else:
 is_emscripten = sys.platform == "emscripten"
 is_wasi = sys.platform == "wasi"
 is_nanvix = sys.platform == "nanvix"
+
+# Nanvix VFS-topology discrimination.
+#
+# Nanvix has two filesystem topologies that exhibit different bug surfaces:
+#   * standalone - guest runs against an in-memory FAT ramfs VFS
+#   * hosted     - guest accesses host filesystem via linuxd passthrough
+#                  (covers both single-process and multi-process deployment
+#                  modes, which share the same VFS path)
+#
+# The active topology is published by the test harness via NANVIX_STANDALONE
+# (.nanvix/test.py sets it, .nanvix/run-tests.py forwards it into the guest
+# via nanvixd's semicolon-env trick).  When the variable is unset on Nanvix
+# we treat the run as hosted (the default deployment mode).
+#
+# To gate hosted-only behavior, write `is_nanvix and not is_nanvix_standalone`.
+is_nanvix_standalone = is_nanvix and os.environ.get("NANVIX_STANDALONE") == "1"
 
 # TODO: enable fork support once nanvix implements it
 # (https://github.com/nanvix/nanvix/issues/321)

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -154,6 +154,17 @@ else:
     TESTFN_NONASCII = None
 TESTFN = TESTFN_NONASCII or TESTFN_ASCII
 
+# NSKIP008 https://github.com/nanvix/cpython/issues/476
+# Nanvix FAT VFS driver panics on non-ASCII filenames (byte-boundary panic in
+# rust-fatfs).  Force TESTFN to the ASCII-only variant so that test modules
+# which use TESTFN for temporary file names don't crash the standalone VM.
+if support.is_nanvix:
+    FS_NONASCII = ''
+    TESTFN_NONASCII = None
+    TESTFN_UNENCODABLE = None
+    TESTFN_UNDECODABLE = None
+    TESTFN = TESTFN_ASCII
+
 
 def make_bad_fd():
     """

--- a/Lib/test/support/socket_helper.py
+++ b/Lib/test/support/socket_helper.py
@@ -154,7 +154,15 @@ def skip_unless_bind_unix_socket(test):
     if _bind_nix_socket_error is None:
         from .os_helper import TESTFN, unlink
         path = TESTFN + "can_bind_unix_socket"
-        with socket.socket(socket.AF_UNIX) as sock:
+        try:
+            _sock = socket.socket(socket.AF_UNIX)
+        except OSError as e:
+            # NSKIP020 https://github.com/nanvix/cpython/issues/500
+            # Nanvix standalone does not support AF_UNIX socket creation;
+            # socket() raises OSError before bind() is reached.
+            _bind_nix_socket_error = e
+            return unittest.skip('Requires a functional unix bind(): %s' % e)(test)
+        with _sock as sock:
             try:
                 sock.bind(path)
                 _bind_nix_socket_error = False


### PR DESCRIPTION
## Changes

Three Nanvix-only adjustments to `Lib/test/support` so the wave PRs can land cleanly. 
1. `__init__.py`: tolerate hosted-mode `rmdir` errno 88 in regrtest's `_force_run` cleanup helper — linuxd returns 88 instead of `ENOTEMPTY` for non-empty directories, and the framework was treating it as a hard cleanup failure (NSKIP012).
2. `os_helper.py`: force `TESTFN` to the ASCII-only variant on Nanvix — the FAT VFS driver panics on non-ASCII filenames (NSKIP008).
3. `socket_helper.py`: guard `skip_unless_bind_unix_socket` against `socket(AF_UNIX)` raising before `bind()` is reached (NSKIP020). All three gates are no-ops off-Nanvix.

## New NSKIPS

| NSKIP code | Description |
| --- | --- |
| [NSKIP020](https://github.com/nanvix/cpython/issues/500) | AF_UNIX socket creation fails on Nanvix |

---

Refs: [NSKIP008](https://github.com/nanvix/cpython/issues/476), [NSKIP012](https://github.com/nanvix/cpython/issues/480), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: https://github.com/nanvix/cpython/pull/534
Stacked under: PRs for waves 1–9
