### PR TITLE
tests: fs & io wave 1 — paths and helpers (#371, #490)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -186,6 +186,10 @@ NANVIX_TEST_LIST: list[str] = [
     "test_copy", "test_copyreg",
     "test_collections", "test_defaultdict", "test_ordered_dict", "test_deque", "test_array",
     "test_weakref", "test_weakset", "test_buffer",
+
+    # Filesystem & I/O — paths & helpers
+    "test_genericpath", "test_posixpath", "test_ntpath", "test_pathlib",
+    "test_fnmatch", "test_glob", "test_filecmp", "test_linecache", "test_stat",
 ]
 
 # Default batch size for regrtest VM invocations.

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -4,6 +4,11 @@ import shutil
 import tempfile
 import unittest
 
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+
 from test import support
 from test.support import os_helper
 
@@ -117,6 +122,9 @@ class DirCompareTestCase(unittest.TestCase):
         self.assertEqual(sorted(actual), sorted(expected))
 
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_dircmp(self):
         # Check attributes for comparison of two identical directories
         left_dir, right_dir = self.dir, self.dir_same

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -7,7 +7,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 
 from test import support
 from test.support import os_helper

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -6,6 +6,11 @@ import genericpath
 import os
 import sys
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import warnings
 from test.support import is_emscripten
 from test.support import os_helper
@@ -156,6 +161,9 @@ class GenericTest:
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
     @unittest.skipIf(is_emscripten, "Emscripten pipe fds have no stat")
+    # NSKIP023 https://github.com/nanvix/cpython/issues/503
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP023: os.pipe() ENOSYS in standalone mode")
     def test_exists_fd(self):
         r, w = os.pipe()
         try:
@@ -215,6 +223,9 @@ class GenericTest:
         finally:
             os_helper.rmdir(filename)
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")
     def test_samefile(self):
         file1 = os_helper.TESTFN
         file2 = os_helper.TESTFN + "2"
@@ -249,12 +260,18 @@ class GenericTest:
         self._test_samefile_on_link_func(os.symlink)
 
     @unittest.skipUnless(hasattr(os, 'link'), 'requires os.link')
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link( ENOSYS despite hasattr)
     def test_samefile_on_link(self):
         try:
             self._test_samefile_on_link_func(os.link)
         except PermissionError as e:
             self.skipTest('os.link(): %s' % e)
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")
     def test_samestat(self):
         test_fn1 = os_helper.TESTFN
         test_fn2 = os_helper.TESTFN + "2"
@@ -292,6 +309,9 @@ class GenericTest:
         self._test_samestat_on_link_func(os.symlink)
 
     @unittest.skipUnless(hasattr(os, 'link'), 'requires os.link')
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link( ENOSYS despite hasattr)
     def test_samestat_on_link(self):
         try:
             self._test_samestat_on_link_func(os.link)
@@ -464,6 +484,10 @@ class CommonTest(GenericTest):
         for path in ('\x00', 'foo\x00bar', '\x00\x00', '\x00foo', 'foo\x00'):
             self.assertEqual(self.pathmodule.normpath(path), path)
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP008: FAT VFS panics on non-ASCII filenames "
+                     "(rust-fatfs UTF-8 boundary slice in dir.rs)")
     def test_abspath_issue3426(self):
         # Check that abspath returns unicode when the arg is unicode
         # with both ASCII and non-ASCII cwds.
@@ -482,6 +506,10 @@ class CommonTest(GenericTest):
                 for path in ('', 'fuu', 'f\xf9\xf9', '/fuu', 'U:\\'):
                     self.assertIsInstance(abspath(path), str)
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP008: FAT VFS rejects non-ASCII filenames "
+                     "(EINVAL on bytes paths, panic on str paths)")
     def test_nonascii_abspath(self):
         if (os_helper.TESTFN_UNDECODABLE
         # macOS and Emscripten deny the creation of a directory with an

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -10,7 +10,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import warnings
 from test.support import is_emscripten
 from test.support import os_helper

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -7,7 +7,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 
 from test.support.os_helper import (TESTFN, skip_unless_symlink,
                                     can_symlink, create_empty_file, change_cwd)

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -4,6 +4,11 @@ import shutil
 import sys
 import unittest
 
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+
 from test.support.os_helper import (TESTFN, skip_unless_symlink,
                                     can_symlink, create_empty_file, change_cwd)
 

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -6,7 +6,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import os.path
 import tempfile
 import tokenize

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -2,6 +2,11 @@
 
 import linecache
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import os.path
 import tempfile
 import tokenize

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -8,7 +8,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import warnings
 from test.support import cpython_only, os_helper
 from test.support import TestFailed, is_emscripten

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -4,6 +4,11 @@ import os
 import string
 import sys
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import warnings
 from test.support import cpython_only, os_helper
 from test.support import TestFailed, is_emscripten
@@ -870,6 +875,9 @@ class TestNtpath(NtpathTestCase):
                           ['Program Files', b'C:\\Program Files\\Foo'])
 
     @unittest.skipIf(is_emscripten, "Emscripten cannot fstat unnamed files.")
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")
     def test_sameopenfile(self):
         with TemporaryFile() as tf1, TemporaryFile() as tf2:
             # Make sure the same file is really the same

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -10,6 +10,11 @@ import socket
 import stat
 import tempfile
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 from unittest import mock
 
 from test.support import import_helper
@@ -708,6 +713,9 @@ class _BasePurePathTest(object):
         self.assertFalse(p.is_relative_to(''))
         self.assertFalse(p.is_relative_to(P('a')))
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP001: pickle proto 0 produces corrupt output on Nanvix 32-bit")
     def test_pickling_common(self):
         P = self.cls
         p = P('/a/b')
@@ -1683,6 +1691,9 @@ class _BasePathTest(object):
             env['HOME'] = os.path.join(BASE, 'home')
             self._test_home(self.cls.home())
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_with_segments(self):
         class P(_BasePurePathSubclass, self.cls):
             pass
@@ -1704,6 +1715,9 @@ class _BasePathTest(object):
         for dirpath, dirnames, filenames in p.walk():
             self.assertEqual(42, dirpath.session_id)
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")
     def test_samefile(self):
         fileA_path = os.path.join(BASE, 'fileA')
         fileB_path = os.path.join(BASE, 'dirB', 'fileB')
@@ -1730,6 +1744,9 @@ class _BasePathTest(object):
         self.assertEqual(p.stat(), os.stat('.'))
 
     @unittest.skipIf(is_wasi, "WASI has no user accounts.")
+    # NSKIP025 https://github.com/nanvix/cpython/issues/505
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP025: no HOME env var and no pwd module on Nanvix")
     def test_expanduser_common(self):
         P = self.cls
         p = P('~')
@@ -2234,6 +2251,9 @@ class _BasePathTest(object):
         self.assertFileNotFound(p.unlink)
 
     @unittest.skipUnless(hasattr(os, "link"), "os.link() is not present")
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link( ENOSYS despite hasattr)
     def test_hardlink_to(self):
         P = self.cls(BASE)
         target = P / 'fileA'
@@ -2260,6 +2280,9 @@ class _BasePathTest(object):
         with self.assertRaises(NotImplementedError):
             q.hardlink_to(p)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_rename(self):
         P = self.cls(BASE)
         p = P / 'fileA'
@@ -2277,6 +2300,9 @@ class _BasePathTest(object):
         self.assertEqual(os.stat(r).st_size, size)
         self.assertFileNotFound(q.stat)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: os.rename / os.replace
     def test_replace(self):
         P = self.cls(BASE)
         p = P / 'fileA'
@@ -2346,6 +2372,9 @@ class _BasePathTest(object):
             p.mkdir()
         self.assertEqual(cm.exception.errno, errno.EEXIST)
 
+    # NSKIP027 https://github.com/nanvix/cpython/issues/507
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP027: FAT VFS does not honor file mode bits")  # detail: mkdir mode arg (mode bits not mutable)
     def test_mkdir_parents(self):
         # Creating a chain of directories.
         p = self.cls(BASE, 'newdirB', 'newdirC')
@@ -2401,6 +2430,9 @@ class _BasePathTest(object):
         self.assertEqual(p.stat().st_ctime, st_ctime_first)
 
     @unittest.skipIf(is_emscripten, "FS root cannot be modified on Emscripten.")
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP026: FAT VFS returns wrong errno for path-edge cases")  # detail: mkdir('/' returns ENOENT not EEXIST)
     def test_mkdir_exist_ok_root(self):
         # Issue #25803: A drive root could raise PermissionError on Windows.
         self.cls('/').resolve().mkdir(exist_ok=True)
@@ -2417,6 +2449,9 @@ class _BasePathTest(object):
         with self.assertRaises(OSError):
             (p / 'child' / 'path').mkdir(parents=True)
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP026: FAT VFS returns wrong errno for path-edge cases")  # detail: mkdir-over-file returns EINVAL not EEXIST
     def test_mkdir_with_child_file(self):
         p = self.cls(BASE, 'dirB', 'fileB')
         self.assertTrue(p.exists())
@@ -2429,6 +2464,9 @@ class _BasePathTest(object):
             p.mkdir(parents=True, exist_ok=True)
         self.assertEqual(cm.exception.errno, errno.EEXIST)
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP026: FAT VFS returns wrong errno for path-edge cases")  # detail: mkdir-over-file returns EINVAL not EEXIST
     def test_mkdir_no_parents_file(self):
         p = self.cls(BASE, 'fileA')
         self.assertTrue(p.exists())
@@ -2521,6 +2559,9 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\udfff').is_file(), False)
         self.assertIs((P / 'fileA\x00').is_file(), False)
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")  # detail: ismount cascade
     def test_is_mount(self):
         P = self.cls(BASE)
         if os.name == 'nt':
@@ -2599,6 +2640,9 @@ class _BasePathTest(object):
     @unittest.skipIf(
         is_wasi, "Cannot create socket on WASI."
     )
+    # NSKIP020 https://github.com/nanvix/cpython/issues/500
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP020: AF_UNIX socket creation fails on Nanvix")
     def test_is_socket_true(self):
         P = self.cls(BASE, 'mysock')
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -2644,6 +2688,9 @@ class _BasePathTest(object):
         self.assertIs(self.cls(f'{os.devnull}\udfff').is_char_device(), False)
         self.assertIs(self.cls(f'{os.devnull}\x00').is_char_device(), False)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP001: pickle proto 0 produces corrupt output on Nanvix 32-bit")
     def test_pickling_common(self):
         p = self.cls(BASE, 'fileA')
         for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
@@ -2888,6 +2935,9 @@ class WalkTests(unittest.TestCase):
                 self.assertIn("link", dirs)
                 break
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_walk_bad_dir(self):
         errors = []
         walk_it = self.walk_path.walk(on_error=errors.append)
@@ -2986,6 +3036,9 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         is_emscripten or is_wasi,
         "umask is not implemented on Emscripten/WASI."
     )
+    # NSKIP027 https://github.com/nanvix/cpython/issues/507
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP027: FAT VFS does not honor file mode bits")  # detail: umask on file creation
     def test_open_mode(self):
         old_mask = os.umask(0)
         self.addCleanup(os.umask, old_mask)
@@ -3013,6 +3066,9 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         is_emscripten or is_wasi,
         "umask is not implemented on Emscripten/WASI."
     )
+    # NSKIP027 https://github.com/nanvix/cpython/issues/507
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP027: FAT VFS does not honor file mode bits")  # detail: umask on file creation
     def test_touch_mode(self):
         old_mask = os.umask(0)
         self.addCleanup(os.umask, old_mask)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -14,7 +14,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 from unittest import mock
 
 from test.support import import_helper

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -6,7 +6,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 from posixpath import realpath, abspath, dirname, basename
 from test import test_genericpath
 from test.support import import_helper

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -2,6 +2,11 @@ import os
 import posixpath
 import sys
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 from posixpath import realpath, abspath, dirname, basename
 from test import test_genericpath
 from test.support import import_helper
@@ -207,6 +212,9 @@ class PosixPathTest(unittest.TestCase):
         self.assertIs(posixpath.ismount(FakePath("/")), True)
         self.assertIs(posixpath.ismount(FakePath(b"/")), True)
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")  # detail: ismount cascade
     def test_ismount_non_existent(self):
         # Non-existent mountpoint.
         self.assertIs(posixpath.ismount(ABSTFN), False)

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -1,4 +1,9 @@
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import os
 import socket
 import sys

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -3,7 +3,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import os
 import socket
 import sys


### PR DESCRIPTION
## Changes

Wave 1 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490). Enables `test_genericpath`, `test_posixpath`, `test_ntpath`, `test_pathlib`, `test_fnmatch`, `test_glob`, `test_filecmp`, `test_linecache`, `test_stat` in `NANVIX_TEST_LIST`, with `@unittest.skipIf` annotations covering FAT VFS quirks (rename hangs, st_ino collisions, wrong errnos, mode-bit handling), missing `os.link/symlink/readlink`, missing `pwd`/HOME, and standalone `pipe()` ENOSYS.

## New NSKIPS

| NSKIP code | Description |
| --- | --- |
| [NSKIP021](https://github.com/nanvix/cpython/issues/501) | FAT VFS rename() hangs the kernel |
| [NSKIP022](https://github.com/nanvix/cpython/issues/502) | FAT VFS returns identical st_ino/st_dev for all files |
| [NSKIP023](https://github.com/nanvix/cpython/issues/503) | os.pipe() ENOSYS in standalone mode |
| [NSKIP024](https://github.com/nanvix/cpython/issues/504) | os.link()/symlink()/readlink() not supported on FAT VFS |
| [NSKIP025](https://github.com/nanvix/cpython/issues/505) | no HOME env var and no pwd module on Nanvix |
| [NSKIP026](https://github.com/nanvix/cpython/issues/506) | FAT VFS returns wrong errno for path-edge cases |
| [NSKIP027](https://github.com/nanvix/cpython/issues/507) | FAT VFS does not honor file mode bits |
| [NSKIP050](https://github.com/nanvix/cpython/issues/530) | hosted Nanvix unable to run this module cleanly |

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: PR for `tests/nanvix-support-tweaks`
