### PR TITLE
tests: fs & io wave 3 — core file I/O (#371, #490)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -189,6 +189,8 @@ NANVIX_TEST_LIST: list[str] = [
     "test_genericpath", "test_posixpath", "test_ntpath", "test_pathlib",
     "test_fnmatch", "test_glob", "test_filecmp", "test_linecache", "test_stat",
     "test_memoryio", "test_bufio", "test_fileinput",
+    "test_io", "test_fileio", "test_file", "test_file_eintr",
+    "test_source_encoding",
 ]
 
 # Default batch size for regrtest VM invocations.
@@ -199,6 +201,7 @@ STANDALONE_EXCLUDE: list[str] = [
     "test_queue",      # NSKIP019: standalone 32 MB heap too small for module
     "test_itertools",  # NSKIP019: standalone 32 MB heap too small for module
     "test_functools",  # NSKIP019: standalone 32 MB heap too small for module
+    "test_io",         # NSKIP019: standalone 32 MB heap too small for module
 ]
 
 # Platform-specific nanvixd extra arguments.

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -1,6 +1,11 @@
 import sys
 import os
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 from array import array
 from weakref import proxy
 

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -5,7 +5,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 from array import array
 from weakref import proxy
 

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -5,6 +5,11 @@ import os
 import io
 import errno
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 from array import array
 from weakref import proxy
 from functools import wraps
@@ -575,6 +580,8 @@ class COtherFileTests(OtherFileTests, unittest.TestCase):
     modulename = '_io'
 
     @cpython_only
+    # NSKIP002 https://github.com/nanvix/cpython/issues/470
+    @unittest.skipIf(support.is_nanvix, "NSKIP002: _testcapi not available")
     def testInvalidFd_overflow(self):
         # Issue 15989
         import _testcapi

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -9,7 +9,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 from array import array
 from weakref import proxy
 from functools import wraps

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -36,12 +36,11 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import warnings
 import weakref
 from collections import deque, UserList
 from itertools import cycle, count
-from test import support
 from test.support.script_helper import (
     assert_python_ok, assert_python_failure, run_python_until_end)
 from test.support import import_helper

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -32,6 +32,11 @@ import textwrap
 import threading
 import time
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import warnings
 import weakref
 from collections import deque, UserList

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+from test import support
 from test.support import script_helper, captured_stdout, requires_subprocess, requires_resource
 from test.support.os_helper import TESTFN, unlink, rmtree
 from test.support.import_helper import unload
@@ -114,6 +115,9 @@ class MiscSourceEncodingTest(unittest.TestCase):
         exec(b'# coding: cp949\na = "\xaa\xa7"\n', d)
         self.assertEqual(d['a'], '\u3047')
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: __import__ writes __pycache__/*.pyc via atomic os.rename
     def test_file_parse(self):
         # issue1134: all encodings outside latin-1 and utf-8 fail on
         # multiline strings and long lines (>512 columns)
@@ -326,6 +330,9 @@ class BytesSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
         self.assertEqual(out.rstrip(), expected)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class FileSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
 
     def check_script_output(self, src, expected):

--- a/Lib/test/test_source_encoding.py
+++ b/Lib/test/test_source_encoding.py
@@ -332,7 +332,7 @@ class BytesSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
 
 # NSKIP012 https://github.com/nanvix/cpython/issues/480
 @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
-                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
+                 "NSKIP012: rmtree/rmdir returns ENOSYS")  # detail: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests
 class FileSourceEncodingTest(AbstractSourceEncodingTest, unittest.TestCase):
 
     def check_script_output(self, src, expected):


### PR DESCRIPTION
## Changes

Wave 3 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490). Enables `test_io`, `test_fileio`, `test_file`, `test_file_eintr`, `test_source_encoding` in `NANVIX_TEST_LIST` with `@unittest.skipIf` annotations covering FAT-rename hangs, `_testcapi` unavailability, and `rmtree` ENOSYS. Adds `test_io` to `STANDALONE_EXCLUDE` (32 MB heap insufficient under standalone). (`test_open` isn't a separate file in CPython 3.12 — its content is covered by `test_io`.)

No new NSKIP IDs introduced; this wave reuses NSKIP002, NSKIP012, NSKIP019, NSKIP021, NSKIP050.

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: PR for `tests/nanvix-support-tweaks`
