### PR TITLE
tests: fs & io wave 4 — OS interfaces (#371, #490)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -191,6 +191,7 @@ NANVIX_TEST_LIST: list[str] = [
     "test_memoryio", "test_bufio", "test_fileinput",
     "test_io", "test_fileio", "test_file", "test_file_eintr",
     "test_source_encoding",
+    "test_os", "test_posix",
 ]
 
 # Default batch size for regrtest VM invocations.

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -109,6 +109,9 @@ class MiscTests(unittest.TestCase):
         cwd = os.getcwd()
         self.assertIsInstance(cwd, str)
 
+    # NSKIP051 https://github.com/nanvix/cpython/issues/531
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP051: long-path mkdir fails with errno 77 on hosted Nanvix")
     def test_getcwd_long_path(self):
         # bpo-37412: On Linux, PATH_MAX is usually around 4096 bytes. On
         # Windows, MAX_PATH is defined as 260 characters, but Windows supports
@@ -190,6 +193,9 @@ class FileTests(unittest.TestCase):
     @unittest.skipIf(
         support.is_wasi, "WASI does not support dup."
     )
+    # NSKIP035 https://github.com/nanvix/cpython/issues/515
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP035: os.dup() raises ENOTSUP via fcntl(F_DUPFD_CLOEXEC)")
     def test_closerange(self):
         first = os.open(os_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         # We must allocate two consecutive file descriptors, otherwise
@@ -292,6 +298,9 @@ class FileTests(unittest.TestCase):
         self.fdopen_helper('r')
         self.fdopen_helper('r', 100)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_replace(self):
         TESTFN2 = os_helper.TESTFN + ".2"
         self.addCleanup(os_helper.unlink, os_helper.TESTFN)
@@ -613,6 +622,9 @@ class StatAttributeTests(unittest.TestCase):
             self.skipTest("cannot encode %a for the filesystem" % self.fname)
         self.check_stat_attributes(fname)
 
+    # NSKIP001 https://github.com/nanvix/cpython/issues/469
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP001: pickle proto 0 corrupt on 32-bit Nanvix")
     def test_stat_result_pickle(self):
         result = os.stat(self.fname)
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
@@ -762,6 +774,9 @@ class StatAttributeTests(unittest.TestCase):
         self.assertEqual(result.st_mode, stat.S_IFBLK)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class UtimeTests(unittest.TestCase):
     def setUp(self):
         self.dirname = os_helper.TESTFN
@@ -810,6 +825,9 @@ class UtimeTests(unittest.TestCase):
         self.assertEqual(st.st_atime_ns, atime_ns)
         self.assertEqual(st.st_mtime_ns, mtime_ns)
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     def test_utime(self):
         def set_time(filename, ns):
             # test the ns keyword parameter
@@ -823,6 +841,9 @@ class UtimeTests(unittest.TestCase):
         # issue, os.utime() rounds towards minus infinity.
         return (ns * 1e-9) + 0.5e-9
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     def test_utime_by_indexed(self):
         # pass times as floating point seconds as the second indexed parameter
         def set_time(filename, ns):
@@ -834,6 +855,9 @@ class UtimeTests(unittest.TestCase):
             os.utime(filename, (atime, mtime))
         self._test_utime(set_time)
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     def test_utime_by_times(self):
         def set_time(filename, ns):
             atime_ns, mtime_ns = ns
@@ -846,6 +870,9 @@ class UtimeTests(unittest.TestCase):
     @unittest.skipUnless(os.utime in os.supports_follow_symlinks,
                          "follow_symlinks support for utime required "
                          "for this test.")
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.symlink()
     def test_utime_nofollow_symlinks(self):
         def set_time(filename, ns):
             # use follow_symlinks=False to test utimensat(timespec)
@@ -855,6 +882,9 @@ class UtimeTests(unittest.TestCase):
 
     @unittest.skipUnless(os.utime in os.supports_fd,
                          "fd support for utime required for this test.")
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     def test_utime_fd(self):
         def set_time(filename, ns):
             with open(filename, 'wb', 0) as fp:
@@ -865,6 +895,9 @@ class UtimeTests(unittest.TestCase):
 
     @unittest.skipUnless(os.utime in os.supports_dir_fd,
                          "dir_fd support for utime required for this test.")
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     def test_utime_dir_fd(self):
         def set_time(filename, ns):
             dirname, name = os.path.split(filename)
@@ -873,6 +906,9 @@ class UtimeTests(unittest.TestCase):
                 os.utime(name, dir_fd=dirfd, ns=ns)
         self._test_utime(set_time)
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     def test_utime_directory(self):
         def set_time(filename, ns):
             # test calling os.utime() on a directory
@@ -901,12 +937,18 @@ class UtimeTests(unittest.TestCase):
         self.assertAlmostEqual(st.st_mtime, current,
                                delta=delta, msg=msg)
 
+    # NSKIP049 https://github.com/nanvix/cpython/issues/529
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP049: os.utime(path, None) raises EINVAL on Nanvix (utimensat NULL gap)")
     def test_utime_current(self):
         def set_time(filename):
             # Set to the current time in the new way
             os.utime(self.fname)
         self._test_utime_current(set_time)
 
+    # NSKIP049 https://github.com/nanvix/cpython/issues/529
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP049: os.utime(path, None) raises EINVAL on Nanvix (utimensat NULL gap)")
     def test_utime_current_old(self):
         def set_time(filename):
             # Set to the current time in the old explicit way.
@@ -1137,6 +1179,9 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
                                   stdout=subprocess.PIPE, text=True)
             self.assertEqual(proc.stdout.rstrip(), repr(None))
 
+    # NSKIP033 https://github.com/nanvix/cpython/issues/513
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP033: os.putenv('', val) does not raise")
     # On OS X < 10.6, unsetenv() doesn't return a value (bpo-13415).
     @support.requires_mac_ver(10, 6)
     def test_putenv_unsetenv_error(self):
@@ -1288,6 +1333,9 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
         self._test_underlying_process_env(overridden_key, original_value)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class WalkTests(unittest.TestCase):
     """Tests for os.walk()."""
     is_fwalk = False
@@ -1449,6 +1497,9 @@ class WalkTests(unittest.TestCase):
             self.assertRaises(FileNotFoundError, next, walk_it)
         self.assertRaises(StopIteration, next, walk_it)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_walk_bad_dir(self):
         # Walk top-down.
         errors = []
@@ -1703,6 +1754,9 @@ class BytesFwalkTests(FwalkTests):
             bfiles[:] = list(map(os.fsencode, files))
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class MakedirTests(unittest.TestCase):
     def setUp(self):
         os.mkdir(os_helper.TESTFN)
@@ -1726,6 +1780,9 @@ class MakedirTests(unittest.TestCase):
         support.is_emscripten or support.is_wasi,
         "Emscripten's/WASI's umask is a stub."
     )
+    # NSKIP027 https://github.com/nanvix/cpython/issues/507
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP027: FAT VFS does not honor file mode bits")
     def test_mode(self):
         with os_helper.temp_umask(0o002):
             base = os_helper.TESTFN
@@ -1810,6 +1867,9 @@ class MakedirTests(unittest.TestCase):
 
 
 @unittest.skipUnless(hasattr(os, "chown"), "requires os.chown()")
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class ChownFileTests(unittest.TestCase):
 
     @classmethod
@@ -1869,6 +1929,9 @@ class ChownFileTests(unittest.TestCase):
         os.rmdir(os_helper.TESTFN)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class RemoveDirsTests(unittest.TestCase):
     def setUp(self):
         os.makedirs(os_helper.TESTFN)
@@ -1912,6 +1975,9 @@ class RemoveDirsTests(unittest.TestCase):
 
 @unittest.skipIf(support.is_wasi, "WASI has no /dev/null")
 class DevNullTests(unittest.TestCase):
+    # NSKIP032 https://github.com/nanvix/cpython/issues/512
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP032: /dev/null does not exist on Nanvix standalone")
     def test_devnull(self):
         with open(os.devnull, 'wb', 0) as f:
             f.write(b'hello')
@@ -2258,6 +2324,9 @@ class Win32ErrorTests(unittest.TestCase):
 
 
 @unittest.skipIf(support.is_wasi, "Cannot create invalid FD on WASI.")
+# NSKIP052 https://github.com/nanvix/cpython/issues/532
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP052: os_helper.make_bad_fd() returns FD whose ops fail with EAGAIN(11) instead of EBADF(9) on hosted Nanvix")
 class TestInvalidFD(unittest.TestCase):
     singles = ["fchdir", "dup", "fdatasync", "fstat",
                "fstatvfs", "fsync", "tcgetpgrp", "ttyname"]
@@ -2303,6 +2372,9 @@ class TestInvalidFD(unittest.TestCase):
                 "Unable to acquire a range of invalid file descriptors")
         self.assertEqual(os.closerange(fd, fd + i-1), None)
 
+    # NSKIP030 https://github.com/nanvix/cpython/issues/510
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP030: os.dup2() not implemented on Nanvix")
     @unittest.skipUnless(hasattr(os, 'dup2'), 'test needs os.dup2()')
     def test_dup2(self):
         self.check(os.dup2, 20)
@@ -2312,6 +2384,9 @@ class TestInvalidFD(unittest.TestCase):
         support.is_emscripten,
         "dup2() with negative fds is broken on Emscripten (see gh-102179)"
     )
+    # NSKIP030 https://github.com/nanvix/cpython/issues/510
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP030: os.dup2() not implemented on Nanvix")
     def test_dup2_negative_fd(self):
         valid_fd = os.open(__file__, os.O_RDONLY)
         self.addCleanup(os.close, valid_fd)
@@ -2327,10 +2402,16 @@ class TestInvalidFD(unittest.TestCase):
                         os.dup2(fd, fd2)
                     self.assertEqual(ctx.exception.errno, errno.EBADF)
 
+    # NSKIP029 https://github.com/nanvix/cpython/issues/509
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP029: os.fchmod/fchown accepts invalid fd silently")  # detail: os.fchmod
     @unittest.skipUnless(hasattr(os, 'fchmod'), 'test needs os.fchmod()')
     def test_fchmod(self):
         self.check(os.fchmod, 0)
 
+    # NSKIP029 https://github.com/nanvix/cpython/issues/509
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP029: os.fchmod/fchown accepts invalid fd silently")  # detail: os.fchown
     @unittest.skipUnless(hasattr(os, 'fchown'), 'test needs os.fchown()')
     def test_fchown(self):
         self.check(os.fchown, -1, -1)
@@ -2381,6 +2462,9 @@ class TestInvalidFD(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'get_blocking'),
                          'needs os.get_blocking() and os.set_blocking()')
+    # NSKIP031 https://github.com/nanvix/cpython/issues/511
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP031: os.set_blocking() is a no-op on Nanvix")
     def test_blocking(self):
         self.check(os.get_blocking)
         self.check(os.set_blocking, True)
@@ -2407,13 +2491,22 @@ class LinkTests(unittest.TestCase):
         with open(file1, "rb") as f1, open(file2, "rb") as f2:
             self.assertTrue(os.path.sameopenfile(f1.fileno(), f2.fileno()))
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link()
     def test_link(self):
         self._test_link(self.file1, self.file2)
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link()
     def test_link_bytes(self):
         self._test_link(bytes(self.file1, sys.getfilesystemencoding()),
                         bytes(self.file2, sys.getfilesystemencoding()))
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link()
     def test_unicode_name(self):
         try:
             os.fsencode("\xf1")
@@ -2496,6 +2589,9 @@ class PosixUidGidTests(unittest.TestCase):
                 'import os,sys;os.setregid(-1,-1);sys.exit(0)'])
 
 @unittest.skipIf(sys.platform == "win32", "Posix specific tests")
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class Pep383Tests(unittest.TestCase):
     def setUp(self):
         if os_helper.TESTFN_UNENCODABLE:
@@ -2818,6 +2914,9 @@ class ReadlinkTests(unittest.TestCase):
         self.assertRaises(OSError, os.readlink, self.filelink_target)
         self.assertRaises(OSError, os.readlink, filelink_target)
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.readlink( returns wrong errno)
     def test_missing_link(self):
         self.assertRaises(FileNotFoundError, os.readlink, 'missing-link')
         self.assertRaises(FileNotFoundError, os.readlink,
@@ -3212,6 +3311,9 @@ class Win32NtTests(unittest.TestCase):
 
 
 @os_helper.skip_unless_symlink
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class NonLocalSymlinkTests(unittest.TestCase):
 
     def setUp(self):
@@ -3914,6 +4016,9 @@ class TermsizeTests(unittest.TestCase):
         self.assertGreaterEqual(size.columns, 0)
         self.assertGreaterEqual(size.lines, 0)
 
+    # NSKIP003 https://github.com/nanvix/cpython/issues/471
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP003: no subprocess support")
     def test_stty_match(self):
         """Check if stty returns the same results
 
@@ -4077,6 +4182,9 @@ class OSErrorTests(unittest.TestCase):
 
         self.filenames = self.bytes_filenames + self.unicode_filenames
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_oserror_filename(self):
         funcs = [
             (self.filenames, os.chdir,),
@@ -4331,6 +4439,9 @@ class PathTConverterTests(unittest.TestCase):
                      'needs os.get_blocking() and os.set_blocking()')
 @unittest.skipIf(support.is_emscripten, "Cannot unset blocking flag")
 @unittest.skipIf(sys.platform == 'win32', 'Windows only supports blocking on pipes')
+# NSKIP031 https://github.com/nanvix/cpython/issues/511
+@unittest.skipIf(support.is_nanvix,
+                 "NSKIP031: os.set_blocking() is a no-op on Nanvix")
 class BlockingTests(unittest.TestCase):
     def test_blocking(self):
         fd = os.open(__file__, os.O_RDONLY)
@@ -4351,6 +4462,9 @@ class ExportsTests(unittest.TestCase):
         self.assertIn('walk', os.__all__)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class TestDirEntry(unittest.TestCase):
     def setUp(self):
         self.path = os.path.realpath(os_helper.TESTFN)
@@ -4369,6 +4483,9 @@ class TestDirEntry(unittest.TestCase):
         self.assertRaises(TypeError, pickle.dumps, entry, filename)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmdir errno 88 cascade on hosted Nanvix leaves @test_1_tmp behind, breaking setUp in subsequent tests")
 class TestScandir(unittest.TestCase):
     check_no_resource_warning = warnings_helper.check_no_resource_warning
 
@@ -4446,6 +4563,9 @@ class TestScandir(unittest.TestCase):
                                entry_lstat,
                                os.name == 'nt')
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link()
     def test_attributes(self):
         link = hasattr(os, 'link')
         symlink = os_helper.can_symlink()
@@ -4653,6 +4773,9 @@ class TestScandir(unittest.TestCase):
                     st = os.stat(entry.name, dir_fd=fd, follow_symlinks=False)
                     self.assertEqual(entry.stat(follow_symlinks=False), st)
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP026: FAT VFS returns wrong errno for path-edge cases")  # detail: scandir('' returns EINVAL not FileNotFoundError)
     @unittest.skipIf(support.is_wasi, "WASI maps '' to cwd")
     def test_empty_path(self):
         self.assertRaises(FileNotFoundError, os.scandir, '')

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1181,7 +1181,7 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
     # NSKIP033 https://github.com/nanvix/cpython/issues/513
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP033: os.putenv('', val) does not raise")
+                     "NSKIP033: os.putenv() accepts invalid input silently")  # detail: empty name, =name, embedded NUL etc. do not raise
     # On OS X < 10.6, unsetenv() doesn't return a value (bpo-13415).
     @support.requires_mac_ver(10, 6)
     def test_putenv_unsetenv_error(self):
@@ -2374,7 +2374,7 @@ class TestInvalidFD(unittest.TestCase):
 
     # NSKIP030 https://github.com/nanvix/cpython/issues/510
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP030: os.dup2() not implemented on Nanvix")
+                     "NSKIP030: os.dup2() accepts invalid fd silently")
     @unittest.skipUnless(hasattr(os, 'dup2'), 'test needs os.dup2()')
     def test_dup2(self):
         self.check(os.dup2, 20)
@@ -2386,7 +2386,7 @@ class TestInvalidFD(unittest.TestCase):
     )
     # NSKIP030 https://github.com/nanvix/cpython/issues/510
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP030: os.dup2() not implemented on Nanvix")
+                     "NSKIP030: os.dup2() accepts invalid fd silently")
     def test_dup2_negative_fd(self):
         valid_fd = os.open(__file__, os.O_RDONLY)
         self.addCleanup(os.close, valid_fd)
@@ -2464,7 +2464,7 @@ class TestInvalidFD(unittest.TestCase):
                          'needs os.get_blocking() and os.set_blocking()')
     # NSKIP031 https://github.com/nanvix/cpython/issues/511
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP031: os.set_blocking() is a no-op on Nanvix")
+                     "NSKIP031: os.set_blocking() accepts invalid fd silently")  # detail: no-op on Nanvix
     def test_blocking(self):
         self.check(os.get_blocking)
         self.check(os.set_blocking, True)

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -53,7 +53,7 @@ requires_sched = unittest.skipUnless(_supports_sched(), 'requires POSIX schedule
 
 # NSKIP053 https://github.com/nanvix/cpython/issues/533
 @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
-                 "NSKIP053: hosted Nanvix hangs the VM somewhere in this class; root cause not bisected, see #480")
+                 "NSKIP053: hosted Nanvix hangs the VM somewhere in this class; root cause not bisected")  # detail: see #533
 class PosixTester(unittest.TestCase):
 
     def setUp(self):
@@ -186,7 +186,7 @@ class PosixTester(unittest.TestCase):
 
     # NSKIP037 https://github.com/nanvix/cpython/issues/517
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP037: os.truncate() not implemented on Nanvix")
+                     "NSKIP037: os.truncate() not supported")
     @unittest.skipUnless(hasattr(posix, 'truncate'), "test needs posix.truncate()")
     def test_truncate(self):
         with open(os_helper.TESTFN, 'w') as fp:
@@ -524,7 +524,7 @@ class PosixTester(unittest.TestCase):
 
     # NSKIP041 https://github.com/nanvix/cpython/issues/521
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP041: os.writev() returns ENOSPC instead of EINVAL on overflow")
+                     "NSKIP041: os.writev() not supported")  # detail: ENOSPC instead of EINVAL on overflow
     @unittest.skipUnless(hasattr(posix, 'writev'), "test needs posix.writev()")
     @requires_32b
     def test_writev_overflow_32bits(self):
@@ -596,7 +596,7 @@ class PosixTester(unittest.TestCase):
                          'test needs posix.dup2()')
     # NSKIP030 https://github.com/nanvix/cpython/issues/510
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP030: os.dup2() not implemented on Nanvix")
+                     "NSKIP030: os.dup2() accepts invalid fd silently")
     @unittest.skipIf(support.is_wasi, "WASI does not have dup2()")
     def test_dup2(self):
         fp1 = open(os_helper.TESTFN)
@@ -820,7 +820,7 @@ class PosixTester(unittest.TestCase):
 
     # NSKIP042 https://github.com/nanvix/cpython/issues/522
     @unittest.skipIf(support.is_nanvix,
-                     "NSKIP042: os.chown() is a no-op on FAT VFS")
+                     "NSKIP042: os.chown() not supported")  # detail: no-op on FAT VFS
     @unittest.skipUnless(hasattr(os, "chown"), "requires os.chown()")
     @unittest.skipIf(support.is_emscripten, "getgid() is a stub")
     def test_chown(self):
@@ -1502,7 +1502,7 @@ class PosixTester(unittest.TestCase):
 # tests for the posix *at functions follow
 # NSKIP053 https://github.com/nanvix/cpython/issues/533
 @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
-                 "NSKIP053: hosted Nanvix hangs the VM somewhere in this class; root cause not bisected, see #480")
+                 "NSKIP053: hosted Nanvix hangs the VM somewhere in this class; root cause not bisected")  # detail: see #533
 class TestPosixDirFd(unittest.TestCase):
     count = 0
 

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -51,6 +51,9 @@ def _supports_sched():
 requires_sched = unittest.skipUnless(_supports_sched(), 'requires POSIX scheduler API')
 
 
+# NSKIP053 https://github.com/nanvix/cpython/issues/533
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP053: hosted Nanvix hangs the VM somewhere in this class; root cause not bisected, see #480")
 class PosixTester(unittest.TestCase):
 
     def setUp(self):
@@ -181,6 +184,9 @@ class PosixTester(unittest.TestCase):
         finally:
             fp.close()
 
+    # NSKIP037 https://github.com/nanvix/cpython/issues/517
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP037: os.truncate() not implemented on Nanvix")
     @unittest.skipUnless(hasattr(posix, 'truncate'), "test needs posix.truncate()")
     def test_truncate(self):
         with open(os_helper.TESTFN, 'w') as fp:
@@ -388,6 +394,9 @@ class PosixTester(unittest.TestCase):
         finally:
             os.close(fd)
 
+    # NSKIP040 https://github.com/nanvix/cpython/issues/520
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP040: os.pwritev() with overflow-sized iovecs hangs on Nanvix")
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     @requires_32b
     def test_pwritev_overflow_32bits(self):
@@ -439,6 +448,9 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'posix_fadvise'),
         "test needs posix.posix_fadvise()")
+    # NSKIP038 https://github.com/nanvix/cpython/issues/518
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP038: os.posix_fadvise() not implemented on Nanvix")
     def test_posix_fadvise_errno(self):
         try:
             posix.posix_fadvise(-42, 0, 0, posix.POSIX_FADV_WILLNEED)
@@ -446,6 +458,9 @@ class PosixTester(unittest.TestCase):
             if inst.errno != errno.EBADF:
                 raise
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     @unittest.skipUnless(os.utime in os.supports_fd, "test needs fd support in os.utime")
     def test_utime_with_fd(self):
         now = time.time()
@@ -467,6 +482,9 @@ class PosixTester(unittest.TestCase):
         finally:
             os.close(fd)
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     @unittest.skipUnless(os.utime in os.supports_follow_symlinks, "test needs follow_symlinks support in os.utime")
     def test_utime_nofollow_symlinks(self):
         now = time.time()
@@ -504,6 +522,9 @@ class PosixTester(unittest.TestCase):
         finally:
             os.close(fd)
 
+    # NSKIP041 https://github.com/nanvix/cpython/issues/521
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP041: os.writev() returns ENOSPC instead of EINVAL on overflow")
     @unittest.skipUnless(hasattr(posix, 'writev'), "test needs posix.writev()")
     @requires_32b
     def test_writev_overflow_32bits(self):
@@ -552,6 +573,9 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'dup'),
                          'test needs posix.dup()')
+    # NSKIP035 https://github.com/nanvix/cpython/issues/515
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP035: os.dup() raises ENOTSUP via fcntl(F_DUPFD_CLOEXEC)")
     @unittest.skipIf(support.is_wasi, "WASI does not have dup()")
     def test_dup(self):
         fp = open(os_helper.TESTFN)
@@ -570,6 +594,9 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'dup2'),
                          'test needs posix.dup2()')
+    # NSKIP030 https://github.com/nanvix/cpython/issues/510
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP030: os.dup2() not implemented on Nanvix")
     @unittest.skipIf(support.is_wasi, "WASI does not have dup2()")
     def test_dup2(self):
         fp1 = open(os_helper.TESTFN)
@@ -791,6 +818,9 @@ class PosixTester(unittest.TestCase):
             self.assertRaises(TypeError, chown_func, first_param, uid, t(gid))
             check_stat(uid, gid)
 
+    # NSKIP042 https://github.com/nanvix/cpython/issues/522
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP042: os.chown() is a no-op on FAT VFS")
     @unittest.skipUnless(hasattr(os, "chown"), "requires os.chown()")
     @unittest.skipIf(support.is_emscripten, "getgid() is a stub")
     def test_chown(self):
@@ -826,6 +856,9 @@ class PosixTester(unittest.TestCase):
         self._test_all_chown_common(posix.lchown, os_helper.TESTFN,
                                     getattr(posix, 'lstat', None))
 
+    # NSKIP036 https://github.com/nanvix/cpython/issues/516
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP036: os.chdir() succeeds on non-directory targets")
     @unittest.skipUnless(hasattr(posix, 'chdir'), 'test needs posix.chdir()')
     def test_chdir(self):
         posix.chdir(os.curdir)
@@ -879,6 +912,9 @@ class PosixTester(unittest.TestCase):
     def test_strerror(self):
         self.assertTrue(posix.strerror(0))
 
+    # NSKIP023 https://github.com/nanvix/cpython/issues/503
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP023: os.pipe() ENOSYS in standalone mode")
     @unittest.skipUnless(hasattr(posix, 'pipe'), 'test needs posix.pipe()')
     def test_pipe(self):
         reader, writer = posix.pipe()
@@ -922,6 +958,9 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(OverflowError, os.pipe2, _testcapi.INT_MAX + 1)
         self.assertRaises(OverflowError, os.pipe2, _testcapi.UINT_MAX + 1)
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     @unittest.skipUnless(hasattr(posix, 'utime'), 'test needs posix.utime()')
     def test_utime(self):
         now = time.time()
@@ -971,11 +1010,17 @@ class PosixTester(unittest.TestCase):
         target = self.tempdir()
         self.check_chmod(posix.chmod, target)
 
+    # NSKIP027 https://github.com/nanvix/cpython/issues/507
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP027: FAT VFS does not honor file mode bits")
     @unittest.skipUnless(hasattr(posix, 'lchmod'), 'test needs os.lchmod()')
     def test_lchmod_file(self):
         self.check_chmod(posix.lchmod, os_helper.TESTFN)
         self.check_chmod(posix.chmod, os_helper.TESTFN, follow_symlinks=False)
 
+    # NSKIP027 https://github.com/nanvix/cpython/issues/507
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP027: FAT VFS does not honor file mode bits")
     @unittest.skipUnless(hasattr(posix, 'lchmod'), 'test needs os.lchmod()')
     def test_lchmod_dir(self):
         target = self.tempdir()
@@ -1385,6 +1430,9 @@ class PosixTester(unittest.TestCase):
                 # http://lists.freebsd.org/pipermail/freebsd-amd64/2012-January/014332.html
                 raise unittest.SkipTest("OSError raised!")
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")
     def test_path_error2(self):
         """
         Test functions that call path_error2(), providing two filenames in their exceptions.
@@ -1452,6 +1500,9 @@ class PosixTester(unittest.TestCase):
 
 
 # tests for the posix *at functions follow
+# NSKIP053 https://github.com/nanvix/cpython/issues/533
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP053: hosted Nanvix hangs the VM somewhere in this class; root cause not bisected, see #480")
 class TestPosixDirFd(unittest.TestCase):
     count = 0
 
@@ -1474,6 +1525,9 @@ class TestPosixDirFd(unittest.TestCase):
             self.addCleanup(posix.unlink, fullname)
             yield (dir_fd, name, fullname)
 
+    # NSKIP039 https://github.com/nanvix/cpython/issues/519
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP039: *at() syscalls return wrong errno with dir_fd on Nanvix")
     @unittest.skipUnless(os.access in os.supports_dir_fd, "test needs dir_fd support for os.access()")
     def test_access_dir_fd(self):
         with self.prepare_file() as (dir_fd, name, fullname):
@@ -1515,6 +1569,9 @@ class TestPosixDirFd(unittest.TestCase):
             self.assertRaises(OverflowError,
                     posix.stat, name, dir_fd=10**20)
 
+    # NSKIP034 https://github.com/nanvix/cpython/issues/514
+    @unittest.skipIf(support.is_nanvix_standalone,
+                     "NSKIP034: os.utime(times) does not modify mtime/atime on FAT VFS")
     @unittest.skipUnless(os.utime in os.supports_dir_fd, "test needs dir_fd support in os.utime()")
     def test_utime_dir_fd(self):
         with self.prepare_file() as (dir_fd, name, fullname):
@@ -1554,6 +1611,9 @@ class TestPosixDirFd(unittest.TestCase):
         hasattr(os, "link") and os.link in os.supports_dir_fd,
         "test needs dir_fd support in os.link()"
     )
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link()
     def test_link_dir_fd(self):
         with self.prepare_file() as (dir_fd, name, fullname), \
              self.prepare() as (dir_fd2, linkname, fulllinkname):
@@ -1566,6 +1626,9 @@ class TestPosixDirFd(unittest.TestCase):
             self.assertEqual(posix.stat(fullname)[1],
                 posix.stat(fulllinkname)[1])
 
+    # NSKIP039 https://github.com/nanvix/cpython/issues/519
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP039: *at() syscalls return wrong errno with dir_fd on Nanvix")
     @unittest.skipUnless(os.mkdir in os.supports_dir_fd, "test needs dir_fd support in os.mkdir()")
     def test_mkdir_dir_fd(self):
         with self.prepare() as (dir_fd, name, fullname):
@@ -1607,12 +1670,18 @@ class TestPosixDirFd(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'readlink') and (os.readlink in os.supports_dir_fd),
                          "test needs dir_fd support in os.readlink()")
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.symlink( (test setup))
     def test_readlink_dir_fd(self):
         with self.prepare() as (dir_fd, name, fullname):
             os.symlink('symlink', fullname)
             self.addCleanup(posix.unlink, fullname)
             self.assertEqual(posix.readlink(name, dir_fd=dir_fd), 'symlink')
 
+    # NSKIP039 https://github.com/nanvix/cpython/issues/519
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP039: *at() syscalls return wrong errno with dir_fd on Nanvix")
     @unittest.skipUnless(os.rename in os.supports_dir_fd, "test needs dir_fd support in os.rename()")
     def test_rename_dir_fd(self):
         with self.prepare_file() as (dir_fd, name, fullname), \
@@ -1622,6 +1691,9 @@ class TestPosixDirFd(unittest.TestCase):
             posix.stat(fullname2) # should not raise exception
             posix.rename(fullname2, fullname)
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.symlink()
     @unittest.skipUnless(os.symlink in os.supports_dir_fd, "test needs dir_fd support in os.symlink()")
     def test_symlink_dir_fd(self):
         with self.prepare() as (dir_fd, name, fullname):
@@ -1629,6 +1701,9 @@ class TestPosixDirFd(unittest.TestCase):
             self.addCleanup(posix.unlink, fullname)
             self.assertEqual(posix.readlink(fullname), 'symlink')
 
+    # NSKIP039 https://github.com/nanvix/cpython/issues/519
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP039: *at() syscalls return wrong errno with dir_fd on Nanvix")
     @unittest.skipUnless(os.unlink in os.supports_dir_fd, "test needs dir_fd support in os.unlink()")
     def test_unlink_dir_fd(self):
         with self.prepare() as (dir_fd, name, fullname):


### PR DESCRIPTION
## Changes

Wave 4 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490) — by far the largest wave. Enables `test_os` and `test_posix` in `NANVIX_TEST_LIST` with `@unittest.skipIf` annotations covering the long tail of OS-interface limitations: missing fd validation across `fchmod/fchown/dup2/set_blocking/chdir`, missing `os.dup`/`utime(times)`/`putenv` validation, unsupported syscalls (`truncate`, `posix_fadvise`, `*at`, `pwritev`, `writev`, `chown`), `/dev/null` absence in standalone, hosted-mode VM hangs, and the `make_bad_fd` errno mismatch.

## New NSKIPS

| NSKIP code | Description |
| --- | --- |
| [NSKIP029](https://github.com/nanvix/cpython/issues/509) | os.fchmod/fchown accepts invalid fd silently |
| [NSKIP030](https://github.com/nanvix/cpython/issues/510) | os.dup2() accepts invalid fd silently |
| [NSKIP031](https://github.com/nanvix/cpython/issues/511) | os.set_blocking()/get_blocking() accepts invalid fd silently |
| [NSKIP032](https://github.com/nanvix/cpython/issues/512) | /dev/null does not exist on Nanvix standalone |
| [NSKIP033](https://github.com/nanvix/cpython/issues/513) | os.putenv() accepts invalid input silently |
| [NSKIP034](https://github.com/nanvix/cpython/issues/514) | os.utime(times) does not modify mtime/atime on FAT VFS |
| [NSKIP035](https://github.com/nanvix/cpython/issues/515) | os.dup() raises ENOTSUP via fcntl(F_DUPFD_CLOEXEC) |
| [NSKIP036](https://github.com/nanvix/cpython/issues/516) | os.chdir() accepts invalid path silently |
| [NSKIP037](https://github.com/nanvix/cpython/issues/517) | os.truncate() not supported |
| [NSKIP038](https://github.com/nanvix/cpython/issues/518) | os.posix_fadvise() not supported |
| [NSKIP039](https://github.com/nanvix/cpython/issues/519) | *at() syscalls not supported |
| [NSKIP040](https://github.com/nanvix/cpython/issues/520) | os.pwritev() ENOTSUP / overflow hangs the kernel |
| [NSKIP041](https://github.com/nanvix/cpython/issues/521) | os.writev() not supported |
| [NSKIP042](https://github.com/nanvix/cpython/issues/522) | os.chown() not supported |
| [NSKIP049](https://github.com/nanvix/cpython/issues/529) | os.utime(path, None) raises EINVAL on Nanvix |
| [NSKIP051](https://github.com/nanvix/cpython/issues/531) | long-path mkdir fails with errno 77 on hosted Nanvix |
| [NSKIP052](https://github.com/nanvix/cpython/issues/532) | os_helper.make_bad_fd() returns FD whose ops fail with EAGAIN(11) instead of EBADF(9) on hosted Nanvix |
| [NSKIP053](https://github.com/nanvix/cpython/issues/533) | hosted Nanvix hangs the VM somewhere in this class |

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: PR for `tests/nanvix-support-tweaks`
