### PR TITLE
tests: fs & io wave 5 — tempfiles and utilities (#371, #490)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -192,6 +192,7 @@ NANVIX_TEST_LIST: list[str] = [
     "test_io", "test_fileio", "test_file", "test_file_eintr",
     "test_source_encoding",
     "test_os", "test_posix",
+    "test_tempfile", "test_shutil",
 ]
 
 # Default batch size for regrtest VM invocations.

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -6,7 +6,7 @@ import unittest.mock
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import shutil
 import tempfile
 import sys
@@ -35,7 +35,6 @@ try:
 except ImportError:
     posix = None
 
-from test import support
 from test.support import os_helper
 from test.support.os_helper import TESTFN, FakePath
 from test.support import warnings_helper

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -2,6 +2,11 @@
 
 import unittest
 import unittest.mock
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import shutil
 import tempfile
 import sys
@@ -708,6 +713,9 @@ class TestCopyTree(BaseTest, unittest.TestCase):
         actual = read_file((dst_dir, 'test_dir', 'test.txt'))
         self.assertEqual(actual, '456')
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")  # detail: causes shutil.SameFileError on distinct files
     def test_copytree_dirs_exist_ok(self):
         src_dir = self.mkdtemp()
         dst_dir = self.mkdtemp()
@@ -1447,6 +1455,9 @@ class TestCopy(BaseTest, unittest.TestCase):
         shutil.copyfile(link, dst)
         self.assertFalse(os.path.islink(dst))
 
+    # NSKIP024 https://github.com/nanvix/cpython/issues/504
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP024: os.link()/symlink()/readlink() not supported on FAT VFS")  # detail: os.link()
     @unittest.skipUnless(hasattr(os, 'link'), 'requires os.link')
     def test_dont_copy_file_onto_link_to_itself(self):
         # bug 851123.
@@ -1527,6 +1538,9 @@ class TestCopy(BaseTest, unittest.TestCase):
         # Make sure file is not corrupted.
         self.assertEqual(read_file(src_file), 'foo')
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP026: FAT VFS returns wrong errno for path-edge cases")  # detail: shutil.copyfile to nonexistent dst dir does not raise FileNotFoundError
     @unittest.skipIf(MACOS or SOLARIS or _winapi, 'On MACOS, Solaris and Windows the errors are not confusing (though different)')
     # gh-92670: The test uses a trailing slash to force the OS consider
     # the path as a directory, but on AIX the trailing slash has no effect
@@ -1540,6 +1554,9 @@ class TestCopy(BaseTest, unittest.TestCase):
         write_file(src_file, 'foo')
         self.assertRaises(FileNotFoundError, shutil.copyfile, src_file, dst)
 
+    # NSKIP022 https://github.com/nanvix/cpython/issues/502
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP022: FAT VFS returns identical st_ino/st_dev for all files")  # detail: causes shutil.SameFileError on distinct files
     def test_copyfile_copy_dir(self):
         # Issue 45234
         # test copy() and copyfile() raising proper exceptions when src and/or
@@ -1563,6 +1580,9 @@ class TestArchives(BaseTest, unittest.TestCase):
 
     ### shutil.make_archive
 
+    # NSKIP044 https://github.com/nanvix/cpython/issues/524
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP044: tarfile/archive workflow corruption on Nanvix VFS")  # detail: deferred to Wave 6
     @support.requires_zlib()
     def test_make_tarball(self):
         # creating something to tar
@@ -1984,6 +2004,9 @@ class TestArchives(BaseTest, unittest.TestCase):
                 ('Python 3.14', DeprecationWarning)):
             self.check_unpack_archive(format)
 
+    # NSKIP044 https://github.com/nanvix/cpython/issues/524
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP044: tarfile/archive workflow corruption on Nanvix VFS")  # detail: deferred to Wave 6
     def test_unpack_archive_tar(self):
         self.check_unpack_tarball('tar')
 
@@ -1991,6 +2014,9 @@ class TestArchives(BaseTest, unittest.TestCase):
     def test_unpack_archive_gztar(self):
         self.check_unpack_tarball('gztar')
 
+    # NSKIP044 https://github.com/nanvix/cpython/issues/524
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP044: tarfile/archive workflow corruption on Nanvix VFS")  # detail: deferred to Wave 6
     @support.requires_bz2()
     def test_unpack_archive_bztar(self):
         self.check_unpack_tarball('bztar')
@@ -2472,19 +2498,31 @@ class TestMove(BaseTest, unittest.TestCase):
         self.assertEqual(contents, sorted(os.listdir(real_dst)))
         self.assertFalse(os.path.exists(src))
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_file(self):
         # Move a file to another location on the same filesystem.
         self._check_move_file(self.src_file, self.dst_file, self.dst_file)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_file_to_dir(self):
         # Move a file inside an existing dir on the same filesystem.
         self._check_move_file(self.src_file, self.dst_dir, self.dst_file)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_file_to_dir_pathlike_src(self):
         # Move a pathlike file to another location on the same filesystem.
         src = pathlib.Path(self.src_file)
         self._check_move_file(src, self.dst_dir, self.dst_file)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_file_to_dir_pathlike_dst(self):
         # Move a file to another pathlike location on the same filesystem.
         dst = pathlib.Path(self.dst_dir)
@@ -2495,11 +2533,17 @@ class TestMove(BaseTest, unittest.TestCase):
         # Move a file to an existing dir on another filesystem.
         self.test_move_file()
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive samefile breaks shutil.move samefile branch
     @mock_rename
     def test_move_file_to_dir_other_fs(self):
         # Move a file to another location on another filesystem.
         self.test_move_file_to_dir()
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_dir(self):
         # Move a dir to another location on the same filesystem.
         dst_dir = tempfile.mktemp(dir=self.mkdtemp())
@@ -2513,16 +2557,25 @@ class TestMove(BaseTest, unittest.TestCase):
         # Move a dir to another location on another filesystem.
         self.test_move_dir()
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_dir_to_dir(self):
         # Move a dir inside an existing dir on the same filesystem.
         self._check_move_dir(self.src_dir, self.dst_dir,
             os.path.join(self.dst_dir, os.path.basename(self.src_dir)))
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive samefile breaks shutil.move samefile branch
     @mock_rename
     def test_move_dir_to_dir_other_fs(self):
         # Move a dir inside an existing dir on another filesystem.
         self.test_move_dir_to_dir()
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_dir_sep_to_dir(self):
         self._check_move_dir(self.src_dir + os.path.sep, self.dst_dir,
             os.path.join(self.dst_dir, os.path.basename(self.src_dir)))
@@ -2532,12 +2585,18 @@ class TestMove(BaseTest, unittest.TestCase):
         self._check_move_dir(self.src_dir + os.path.altsep, self.dst_dir,
             os.path.join(self.dst_dir, os.path.basename(self.src_dir)))
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_existing_file_inside_dest_dir(self):
         # A file with the same name inside the destination dir already exists.
         with open(self.dst_file, "wb"):
             pass
         self.assertRaises(shutil.Error, shutil.move, self.src_file, self.dst_dir)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_dont_move_dir_in_itself(self):
         # Moving a dir inside itself raises an Error.
         dst = os.path.join(self.src_dir, "bar")
@@ -2610,15 +2669,24 @@ class TestMove(BaseTest, unittest.TestCase):
         self.assertTrue(os.path.islink(dst_link))
         self.assertTrue(os.path.samefile(src, dst_link))
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_return_value(self):
         rv = shutil.move(self.src_file, self.dst_dir)
         self.assertEqual(rv,
                 os.path.join(self.dst_dir, os.path.basename(self.src_file)))
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_as_rename_return_value(self):
         rv = shutil.move(self.src_file, os.path.join(self.dst_dir, 'bar'))
         self.assertEqual(rv, os.path.join(self.dst_dir, 'bar'))
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive samefile breaks shutil.move samefile branch
     @mock_rename
     def test_move_file_special_function(self):
         moved = []
@@ -2627,6 +2695,9 @@ class TestMove(BaseTest, unittest.TestCase):
         shutil.move(self.src_file, self.dst_dir, copy_function=_copy)
         self.assertEqual(len(moved), 1)
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive samefile breaks shutil.move samefile branch
     @mock_rename
     def test_move_dir_special_function(self):
         moved = []
@@ -2637,6 +2708,9 @@ class TestMove(BaseTest, unittest.TestCase):
         shutil.move(self.src_dir, self.dst_dir, copy_function=_copy)
         self.assertEqual(len(moved), 3)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shutil.move uses rename
     def test_move_dir_caseinsensitive(self):
         # Renames a folder to the same name
         # but a different case.
@@ -3148,6 +3222,9 @@ class TestGetTerminalSize(unittest.TestCase):
     @unittest.skipUnless(os.isatty(sys.__stdout__.fileno()), "not on tty")
     @unittest.skipUnless(hasattr(os, 'get_terminal_size'),
                          'need os.get_terminal_size()')
+    # NSKIP003 https://github.com/nanvix/cpython/issues/471
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP003: no subprocess support")
     def test_stty_match(self):
         """Check if stty returns the same results ignoring env
 
@@ -3169,6 +3246,9 @@ class TestGetTerminalSize(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
+    # NSKIP032 https://github.com/nanvix/cpython/issues/512
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP032: /dev/null does not exist on Nanvix standalone")
     @unittest.skipIf(support.is_wasi, "WASI has no /dev/null")
     def test_fallback(self):
         with os_helper.EnvironmentVarGuard() as env:

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -16,7 +16,11 @@ import shutil
 from unittest import mock
 
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 from test.support import os_helper
 from test.support import script_helper
 from test.support import warnings_helper
@@ -358,6 +362,9 @@ class TestBadTempdir:
                 with self.assertRaises(FileNotFoundError):
                     self.make_temp()
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP026: FAT VFS returns wrong errno for path-edge cases")  # detail: path-under-file returns EINVAL not NotADirectoryError
     def test_non_directory(self):
         with _inside_empty_temp_dir():
             tempdir = os.path.join(tempfile.tempdir, 'file')
@@ -431,6 +438,9 @@ class TestMkstempInner(TestBadTempdir, BaseTestCase):
         with self.assertRaises(TypeError):
             self.do_create(dir=dir_b, pre=b"", suf="").write(b"blat")
 
+    # NSKIP035 https://github.com/nanvix/cpython/issues/515
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP035: os.dup() raises ENOTSUP via fcntl(F_DUPFD_CLOEXEC)")  # detail: leads to EMFILE in tight tempfile loops
     def test_basic_many(self):
         # _mkstemp_inner can create many files (stochastic)
         extant = list(range(TEST_FILES))
@@ -518,6 +528,9 @@ class TestMkstempInner(TestBadTempdir, BaseTestCase):
                                        tempfile._bin_openflags,
                                        str)
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive mkstemp candidate-name collision detection fails
     def test_collision_with_existing_file(self):
         # _mkstemp_inner tries another name when a file with
         # the chosen name already exists
@@ -531,6 +544,9 @@ class TestMkstempInner(TestBadTempdir, BaseTestCase):
             os.close(fd2)
             self.assertTrue(name2.endswith('bbb'))
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive mkstemp candidate-name collision detection fails
     def test_collision_with_existing_directory(self):
         # _mkstemp_inner tries another name when a directory with
         # the chosen name already exists
@@ -765,6 +781,9 @@ class TestMkdtemp(TestBadTempdir, BaseTestCase):
         with self.assertRaises(TypeError):
             os.rmdir(self.do_create(dir="", pre=b"aa", suf=b".txt"))
 
+    # NSKIP035 https://github.com/nanvix/cpython/issues/515
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP035: os.dup() raises ENOTSUP via fcntl(F_DUPFD_CLOEXEC)")  # detail: leads to EMFILE in tight tempfile loops
     def test_basic_many(self):
         # mkdtemp can create many directories (stochastic)
         extant = list(range(TEST_FILES))
@@ -803,6 +822,9 @@ class TestMkdtemp(TestBadTempdir, BaseTestCase):
         finally:
             os.rmdir(dir)
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive mkstemp candidate-name collision detection fails
     def test_collision_with_existing_file(self):
         # mkdtemp tries another name when a file with
         # the chosen name already exists
@@ -814,6 +836,9 @@ class TestMkdtemp(TestBadTempdir, BaseTestCase):
             dir = tempfile.mkdtemp()
             self.assertTrue(dir.endswith('bbb'))
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: case-insensitive mkstemp candidate-name collision detection fails
     def test_collision_with_existing_directory(self):
         # mkdtemp tries another name when a directory with
         # the chosen name already exists
@@ -978,6 +1003,9 @@ class TestNamedTemporaryFile(BaseTestCase):
         self.assertTrue(os.path.exists(f.name),
                         "NamedTemporaryFile %s does not exist" % f.name)
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: 8.3 short-name entries retained after unlink
     def test_del_on_close(self):
         # A NamedTemporaryFile is deleted when closed
         dir = tempfile.mkdtemp()
@@ -1192,6 +1220,9 @@ class TestSpooledTemporaryFile(BaseTestCase):
             'IOBase/BufferedIOBase/TextIOBase'
         )
 
+    # NSKIP043 https://github.com/nanvix/cpython/issues/523
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention")  # detail: 8.3 short-name entries retained after unlink
     def test_del_on_close(self):
         # A SpooledTemporaryFile is deleted when closed
         dir = tempfile.mkdtemp()

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -20,7 +20,7 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 from test.support import os_helper
 from test.support import script_helper
 from test.support import warnings_helper


### PR DESCRIPTION
## Changes

Wave 5 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490). Enables `test_tempfile` and `test_shutil` in `NANVIX_TEST_LIST` with `@unittest.skipIf` annotations covering FAT-rename hangs, st_ino collisions, missing `link/symlink`, wrong errnos, missing `/dev/null`, missing `os.dup`, FAT case-insensitivity / 8.3 short names, and tarfile archive corruption. Also adds module-level `unittest.SkipTest` guards reusing NSKIP050.

## New NSKIPS

| NSKIP code | Description |
| --- | --- |
| [NSKIP043](https://github.com/nanvix/cpython/issues/523) | FAT VFS case-insensitivity / 8.3 short-name retention |
| [NSKIP044](https://github.com/nanvix/cpython/issues/524) | tarfile/archive workflow corruption on Nanvix VFS |

This wave also reuses NSKIP050 (introduced in wave 1, [#530](https://github.com/nanvix/cpython/issues/530)).

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: PR for `tests/nanvix-support-tweaks`
