### PR TITLE
tests: fs & io wave 7 — file-backed DBs (#371, #490)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -195,6 +195,7 @@ NANVIX_TEST_LIST: list[str] = [
     "test_tempfile", "test_shutil",
     "test_zipfile", "test_zipapp", "test_zipimport",
     "test_tarfile", "test_gzip", "test_bz2", "test_zlib",
+    "test_dbm_dumb", "test_shelve",
 ]
 
 # Default batch size for regrtest VM invocations.

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -19,7 +19,7 @@ from functools import partial
 # every dbm.dumb operation that touches the directory file triggers
 # the commit path.
 if support.is_nanvix:
-    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")  # detail: dbm.dumb._commit( uses os.rename)
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")  # detail: dbm.dumb._commit() uses os.rename
 
 _fname = os_helper.TESTFN
 

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -13,6 +13,14 @@ from test import support
 from test.support import os_helper
 from functools import partial
 
+# NSKIP021 https://github.com/nanvix/cpython/issues/501
+# dbm.dumb uses os.rename() in _commit() (Lib/dbm/dumb.py:126) which
+# hangs the kernel on Nanvix's FAT VFS.  Skip the entire module since
+# every dbm.dumb operation that touches the directory file triggers
+# the commit path.
+if support.is_nanvix:
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")  # detail: dbm.dumb._commit( uses os.rename)
+
 _fname = os_helper.TESTFN
 
 

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -4,9 +4,17 @@ import shelve
 import pickle
 import os
 
+from test import support
 from test.support import os_helper
 from collections.abc import MutableMapping
 from test.test_dbm import dbm_iterator
+
+# NSKIP021 https://github.com/nanvix/cpython/issues/501
+# shelve layers pickle over dbm.  The default dbm backend on Nanvix
+# is dbm.dumb (since _dbm/_gdbm/_ndbm are N/A — see configure.ac:7268),
+# and dbm.dumb._commit() uses os.rename which hangs the kernel.
+if support.is_nanvix:
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shelve uses dbm.dumb whose _commit( uses os.rename)
 
 def L1(s):
     return s.decode("latin-1")

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -14,7 +14,7 @@ from test.test_dbm import dbm_iterator
 # is dbm.dumb (since _dbm/_gdbm/_ndbm are N/A — see configure.ac:7268),
 # and dbm.dumb._commit() uses os.rename which hangs the kernel.
 if support.is_nanvix:
-    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shelve uses dbm.dumb whose _commit( uses os.rename)
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")  # detail: shelve uses dbm.dumb whose _commit() uses os.rename
 
 def L1(s):
     return s.decode("latin-1")


### PR DESCRIPTION
## Changes

Wave 7 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490). Enables `test_dbm_dumb` and `test_shelve` (the two pure-Python file-backed databases) in `NANVIX_TEST_LIST` with module-level `unittest.SkipTest` guards for FAT-rename hangs. The C-backed dbm variants (`test_dbm_gnu`, `test_dbm_ndbm`, `test_dbm`) remain disabled; they're covered by the wave 9 skip-guards PR.

No new NSKIP IDs introduced; this wave reuses NSKIP021.

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: PR for `tests/nanvix-support-tweaks`
