### PR TITLE
tests: fs & io wave 8 — import system (#371, #490)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -196,6 +196,7 @@ NANVIX_TEST_LIST: list[str] = [
     "test_zipfile", "test_zipapp", "test_zipimport",
     "test_tarfile", "test_gzip", "test_bz2", "test_zlib",
     "test_dbm_dumb", "test_shelve",
+    "test_import", "test_pkgutil", "test_modulefinder",
 ]
 
 # Default batch size for regrtest VM invocations.
@@ -208,6 +209,7 @@ STANDALONE_EXCLUDE: list[str] = [
     "test_functools",  # NSKIP019: standalone 32 MB heap too small for module
     "test_io",         # NSKIP019: standalone 32 MB heap too small for module
     "test_zipfile",    # NSKIP019: standalone too slow / heap too small for module
+    "test_import",     # NSKIP019: standalone 32 MB heap too small for module
 ]
 
 # Platform-specific nanvixd extra arguments.

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -24,13 +24,15 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 from unittest import mock
 try:
     import _testinternalcapi
 except ImportError:
     # NSKIP002: _testinternalcapi not available on Nanvix
-    _testinternalcapi = None
+    if support.is_nanvix:
+        raise unittest.SkipTest("NSKIP002: _testinternalcapi not available on Nanvix")
+    raise
 import _imp
 
 from test.support import os_helper

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -20,8 +20,17 @@ import threading
 import time
 import types
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 from unittest import mock
-import _testinternalcapi
+try:
+    import _testinternalcapi
+except ImportError:
+    # NSKIP002: _testinternalcapi not available on Nanvix
+    _testinternalcapi = None
 import _imp
 
 from test.support import os_helper

--- a/Lib/test/test_modulefinder.py
+++ b/Lib/test/test_modulefinder.py
@@ -4,6 +4,11 @@ import importlib.machinery
 import py_compile
 import shutil
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+from test import support
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import tempfile
 
 from test import support
@@ -380,6 +385,9 @@ class ModuleFinderTest(unittest.TestCase):
     def test_same_name_as_bad(self):
         self._do_test(same_name_as_bad_test)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP021: FAT VFS rename() hangs the kernel")  # detail: py_compile.compile( uses os.replace)
     def test_bytecode(self):
         base_path = os.path.join(self.test_dir, 'a')
         source_path = base_path + importlib.machinery.SOURCE_SUFFIXES[0]
@@ -400,6 +408,9 @@ class ModuleFinderTest(unittest.TestCase):
         expected = "co_filename %r changed to %r" % (old_path, new_path)
         self.assertIn(expected, output)
 
+    # NSKIP019 https://github.com/nanvix/cpython/issues/487
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP019: 2**16 constants in compiled module exceed standalone 32MB heap")
     def test_extended_opargs(self):
         extended_opargs_test = [
             "a",

--- a/Lib/test/test_modulefinder.py
+++ b/Lib/test/test_modulefinder.py
@@ -8,10 +8,8 @@ import unittest
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 from test import support
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import tempfile
-
-from test import support
 
 import modulefinder
 

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -6,7 +6,7 @@ import unittest
 
 # NSKIP050 https://github.com/nanvix/cpython/issues/530
 if support.is_nanvix and not support.is_nanvix_standalone:
-    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues)")  # detail: not bisected, see #530
 import sys
 import importlib
 from importlib.util import spec_from_file_location

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -1,7 +1,12 @@
 from pathlib import Path
+from test import support
 from test.support.import_helper import unload, CleanImport
 from test.support.warnings_helper import check_warnings, ignore_warnings
 import unittest
+
+# NSKIP050 https://github.com/nanvix/cpython/issues/530
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP050: hosted Nanvix unable to run this module cleanly (rmdir errno 88 cascade and/or other linuxd VFS issues); not bisected, see #480")
 import sys
 import importlib
 from importlib.util import spec_from_file_location
@@ -227,6 +232,9 @@ class PkgutilTests(unittest.TestCase):
         with self.assertRaises((TypeError, ValueError)):
             list(pkgutil.walk_packages(bytes_input))
 
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
+    @unittest.skipIf(support.is_nanvix,
+                     "NSKIP008: rust-fatfs panics on non-ASCII (Devanagari/CJK) filenames")
     def test_name_resolution(self):
         import logging
         import logging.handlers


### PR DESCRIPTION
## Changes

Wave 8 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490). Enables `test_import` (package `__init__.py` only — the rest of the sub-package stays out for now), `test_pkgutil`, `test_modulefinder` in `NANVIX_TEST_LIST` with `@unittest.skipIf` annotations for FAT-rename hangs, `_testcapi` unavailability, and tempfile name handling. Adds `test_import` to `STANDALONE_EXCLUDE` (32 MB heap insufficient). The 45-file `test_importlib` sub-package is deferred to a future sub-issue.

No new NSKIP IDs introduced; this wave reuses NSKIP002/008/019/021/050.

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371)
Stacked on: PR for `tests/nanvix-support-tweaks`
