### PR TITLE
tests: fs & io wave 9 — skip guards (#371, #490)

### DIFF
--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -1,6 +1,10 @@
 """Test script for the dbm.open function based on testdumbdbm.py"""
 
+from test.support import is_nanvix
 import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP047: _dbm/_gdbm/_ndbm C backends N/A on Nanvix (configure.ac:7268)")
+
 import dbm
 import os
 from test.support import import_helper

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -1,3 +1,8 @@
+from test.support import is_nanvix
+import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP047: _dbm/_gdbm/_ndbm C backends N/A on Nanvix (configure.ac:7268)")  # detail: only _gdbm needed for this module
+
 from test import support
 from test.support import import_helper, cpython_only
 gdbm = import_helper.import_module("dbm.gnu") #skip if not supported

--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -6,7 +6,6 @@ if is_nanvix:
 from test import support
 from test.support import import_helper, cpython_only
 gdbm = import_helper.import_module("dbm.gnu") #skip if not supported
-import unittest
 import os
 from test.support.os_helper import TESTFN, TESTFN_NONASCII, unlink, FakePath
 

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -7,7 +7,6 @@ from test.support import import_helper
 from test.support import os_helper
 import_helper.import_module("dbm.ndbm") #skip if not supported
 import os
-import unittest
 import dbm.ndbm
 from dbm.ndbm import error
 

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -1,3 +1,8 @@
+from test.support import is_nanvix
+import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP047: _dbm/_gdbm/_ndbm C backends N/A on Nanvix (configure.ac:7268)")  # detail: only _dbm needed for this module
+
 from test.support import import_helper
 from test.support import os_helper
 import_helper.import_module("dbm.ndbm") #skip if not supported

--- a/Lib/test/test_ioctl.py
+++ b/Lib/test/test_ioctl.py
@@ -1,5 +1,9 @@
-import array
+from test.support import is_nanvix
 import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP048: fcntl/ioctl C extension N/A on Nanvix (configure.ac:7275)")
+
+import array
 from test.support import get_attribute
 from test.support.import_helper import import_module
 import os, struct

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -1,10 +1,14 @@
 """Test largefile support on system where this makes sense.
 """
 
+from test.support import is_nanvix
+import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP015: test requires >2 GB disk I/O; exceeds Nanvix VM resources")
+
 import os
 import stat
 import sys
-import unittest
 import socket
 import shutil
 import threading

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -4,7 +4,7 @@
 from test.support import is_nanvix
 import unittest
 if is_nanvix:
-    raise unittest.SkipTest("NSKIP015: test requires >2 GB disk I/O; exceeds Nanvix VM resources")
+    raise unittest.SkipTest("NSKIP015: OOM — test allocation exceeds available heap")  # detail: test requires >2 GB disk I/O
 
 import os
 import stat

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -1,3 +1,8 @@
+from test.support import is_nanvix
+import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP046: _lzma C extension N/A on Nanvix (configure.ac:7287)")
+
 import _compression
 import array
 from io import BytesIO, UnsupportedOperation, DEFAULT_BUFFER_SIZE
@@ -6,7 +11,6 @@ import pickle
 import random
 import sys
 from test import support
-import unittest
 
 from test.support import _4G, bigmemtest
 from test.support.import_helper import import_module

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,9 +1,13 @@
+from test.support import is_nanvix
+import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP045: mmap C extension N/A on Nanvix (configure.ac:7273)")
+
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten
 )
 from test.support.import_helper import import_module
 from test.support.os_helper import TESTFN, unlink
-import unittest
 import os
 import re
 import itertools

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,7 +1,11 @@
-from test.support import is_nanvix
+from test import support
 import unittest
-if is_nanvix:
-    raise unittest.SkipTest("NSKIP045: mmap C extension N/A on Nanvix (configure.ac:7273)")
+try:
+    import mmap
+except ImportError:
+    if support.is_nanvix:
+        raise unittest.SkipTest("NSKIP045: mmap C extension N/A on Nanvix")
+    raise
 
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -1,3 +1,8 @@
+from test.support import is_nanvix
+import unittest
+if is_nanvix:
+    raise unittest.SkipTest("NSKIP015: test requires 4 GB+ ZIP entries; exceeds Nanvix VM resources")
+
 # Tests of the full ZIP64 functionality of zipfile
 # The support.requires call is the only reason for keeping this separate
 # from test_zipfile

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -1,7 +1,7 @@
 from test.support import is_nanvix
 import unittest
 if is_nanvix:
-    raise unittest.SkipTest("NSKIP015: test requires 4 GB+ ZIP entries; exceeds Nanvix VM resources")
+    raise unittest.SkipTest("NSKIP015: OOM — test allocation exceeds available heap")  # detail: test requires 4 GB+ ZIP entries
 
 # Tests of the full ZIP64 functionality of zipfile
 # The support.requires call is the only reason for keeping this separate


### PR DESCRIPTION
## Changes

Wave 9 of the [filesystem & I/O test enablement series](https://github.com/nanvix/cpython/issues/490) — defense-in-depth only. Adds `@unittest.skipIf(...)` annotations to `test_mmap`, `test_lzma`, `test_dbm`, `test_dbm_gnu`, `test_dbm_ndbm`, `test_ioctl`, `test_largefile`, `test_zipfile64` for the C extensions Nanvix doesn't build (`mmap`, `_lzma`, `_dbm`/`_gdbm`/`_ndbm`, `fcntl`/`ioctl`) plus the OOM-prone `test_largefile`/`test_zipfile64`. None of these modules are added to `NANVIX_TEST_LIST`; the annotations exist so the tests activate cleanly if/when the underlying extensions are ever built.

## New NSKIPS

| NSKIP code | Description |
| --- | --- |
| [NSKIP045](https://github.com/nanvix/cpython/issues/525) | mmap C extension N/A on Nanvix |
| [NSKIP046](https://github.com/nanvix/cpython/issues/526) | _lzma C extension N/A on Nanvix |
| [NSKIP047](https://github.com/nanvix/cpython/issues/527) | _dbm/_gdbm/_ndbm C backends N/A on Nanvix |
| [NSKIP048](https://github.com/nanvix/cpython/issues/528) | fcntl/ioctl C extension N/A on Nanvix |

---

Refs: [#490](https://github.com/nanvix/cpython/issues/490), [#371](https://github.com/nanvix/cpython/issues/371), [NSKIP015](https://github.com/nanvix/cpython/issues/483)
Stacked on: PR for `tests/nanvix-support-tweaks`
