### PR TITLE
tests: enable test_importlib subpackage (#491)

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -197,6 +197,7 @@ NANVIX_TEST_LIST: list[str] = [
     "test_tarfile", "test_gzip", "test_bz2", "test_zlib",
     "test_dbm_dumb", "test_shelve",
     "test_import", "test_pkgutil", "test_modulefinder",
+    "test_importlib",
 ]
 
 # Default batch size for regrtest VM invocations.

--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -82,11 +82,23 @@ def run_batch(
         else:
             # Direct mode: separate argv elements, invoke run-regrtest.py
             # in the guest.  --tmpdir must come before the module list.
+            #
+            # -B (no bytecode) is mandatory on hosted Nanvix: writing a
+            # __pycache__/*.pyc via os.replace hangs the guest kernel
+            # indefinitely (see NSKIP055 — linuxd's rename handler never
+            # returns, the VM becomes unresponsive, and the test harness
+            # hits its 600s wall-clock timeout).  Without -B, importing
+            # any source file whose mtime is newer than its compiled pyc
+            # — which happens after every code edit, since the
+            # install-time compileall snapshot goes stale — locks up the
+            # VM.  Mirrors the standalone branch above which sets -B for
+            # NSKIP021 (FAT VFS rename hang).
             cmd = [
                 NANVIXD,
                 *nanvixd_extra,
                 "--",
                 PYTHON_BIN,
+                "-B",
                 "./run-regrtest.py",
                 "--tmpdir",
                 batch_tmpdir,

--- a/Lib/test/test_importlib/extension/test_finder.py
+++ b/Lib/test/test_importlib/extension/test_finder.py
@@ -5,6 +5,14 @@ machinery = util.import_importlib('importlib.machinery')
 import unittest
 import sys
 
+from test.support import is_nanvix
+
+# NSKIP054 https://github.com/nanvix/cpython/issues/553
+if is_nanvix:
+    raise unittest.SkipTest(
+        "NSKIP054: Nanvix is built static-only; no dynamic extension modules (.so) available"
+    )
+
 
 class FinderTests(abc.FinderTests):
 

--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -11,7 +11,15 @@ import warnings
 import importlib.util
 import importlib
 from test.support import MISSING_C_DOCSTRINGS
+from test.support import is_nanvix
 from test.support.script_helper import assert_python_failure
+
+# NSKIP054 https://github.com/nanvix/cpython/issues/553
+if is_nanvix:
+    raise unittest.SkipTest(
+        "NSKIP054: Nanvix is built static-only; no dynamic extension modules (.so) available"
+    )
+
 
 
 class LoaderTests:

--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -1,4 +1,5 @@
 from test.test_importlib import util
+from test.support import is_nanvix, is_nanvix_standalone
 
 importlib = util.import_importlib('importlib')
 machinery = util.import_importlib('importlib.machinery')
@@ -131,6 +132,9 @@ class FinderTests:
             got = self.machinery.PathFinder.find_spec('whatever', [path])
         self.assertEqual(got, success_finder.spec)
 
+    # NSKIP012 https://github.com/nanvix/cpython/issues/480
+    @unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                     "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
     def test_deleted_cwd(self):
         # Issue #22834
         old_dir = os.getcwd()

--- a/Lib/test/test_importlib/resources/test_path.py
+++ b/Lib/test/test_importlib/resources/test_path.py
@@ -2,8 +2,20 @@ import io
 import unittest
 
 from importlib import resources
+from test.support import is_nanvix, is_nanvix_standalone
 from . import data01
 from . import util
+
+
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+# detail: on hosted Nanvix the cleanup-via-shutil.rmtree path triggers an
+# rmdir errno-88 cascade, leaving stale directories that exhaust
+# tempfile.mkdtemp's candidate-name search.  Skip the whole module on
+# hosted; standalone is unaffected.
+if is_nanvix and not is_nanvix_standalone:
+    raise unittest.SkipTest(
+        "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)"
+    )
 
 
 class CommonTests(util.CommonTests, unittest.TestCase):

--- a/Lib/test/test_importlib/resources/test_resource.py
+++ b/Lib/test/test_importlib/resources/test_resource.py
@@ -8,7 +8,7 @@ from . import data01
 from . import zipdata01, zipdata02
 from . import util
 from importlib import resources, import_module
-from test.support import import_helper, os_helper
+from test.support import import_helper, os_helper, is_nanvix, is_nanvix_standalone
 from test.support.os_helper import unlink
 
 
@@ -114,6 +114,9 @@ class ResourceFromZipsTest01(util.ZipSetupBase, unittest.TestCase):
             {'__init__.py', 'binary.file'},
         )
 
+    # NSKIP012 https://github.com/nanvix/cpython/issues/480
+    @unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                     "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
     def test_as_file_directory(self):
         with resources.as_file(resources.files('ziptestdata')) as data:
             assert data.name == 'ziptestdata'
@@ -192,6 +195,9 @@ class DeletingZipsTest(unittest.TestCase):
     def test_as_file_does_not_keep_open(self):  # pragma: no cover
         resources.as_file(resources.files('ziptestdata') / 'binary.file')
 
+    # NSKIP012 https://github.com/nanvix/cpython/issues/480
+    @unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                     "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
     def test_entered_path_does_not_keep_open(self):
         """
         Mimic what certifi does on import to make its bundle

--- a/Lib/test/test_importlib/source/test_case_sensitivity.py
+++ b/Lib/test/test_importlib/source/test_case_sensitivity.py
@@ -7,9 +7,15 @@ importlib = util.import_importlib('importlib')
 machinery = util.import_importlib('importlib.machinery')
 
 import os
-from test.support import os_helper
+from test.support import os_helper, is_nanvix_standalone
 import unittest
 import warnings
+
+# NSKIP043 https://github.com/nanvix/cpython/issues/523
+if is_nanvix_standalone:
+    raise unittest.SkipTest(
+        "NSKIP043: FAT VFS case-insensitivity / 8.3 short-name retention"
+    )
 
 
 @util.case_insensitive_tests

--- a/Lib/test/test_importlib/source/test_file_loader.py
+++ b/Lib/test/test_importlib/source/test_file_loader.py
@@ -17,9 +17,20 @@ import unittest
 import warnings
 
 from test.support.import_helper import make_legacy_pyc, unload
+from test import support
 
 from test.test_py_compile import without_source_date_epoch
 from test.test_py_compile import SourceDateEpochTestMeta
+
+
+# NSKIP021 https://github.com/nanvix/cpython/issues/501
+if support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")
+# NSKIP055 https://github.com/nanvix/cpython/issues/552
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest(
+        "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix"
+    )
 
 
 class SimpleTest(abc.LoaderTests):

--- a/Lib/test/test_importlib/source/test_finder.py
+++ b/Lib/test/test_importlib/source/test_finder.py
@@ -9,8 +9,19 @@ import stat
 import sys
 import tempfile
 from test.support.import_helper import make_legacy_pyc
+from test import support
 import unittest
 import warnings
+
+
+# NSKIP021 https://github.com/nanvix/cpython/issues/501
+if support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")
+# NSKIP055 https://github.com/nanvix/cpython/issues/552
+if support.is_nanvix and not support.is_nanvix_standalone:
+    raise unittest.SkipTest(
+        "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix"
+    )
 
 
 class FinderTests(abc.FinderTests):

--- a/Lib/test/test_importlib/source/test_source_encoding.py
+++ b/Lib/test/test_importlib/source/test_source_encoding.py
@@ -1,4 +1,5 @@
 from test.test_importlib import util
+from test import support
 
 machinery = util.import_importlib('importlib.machinery')
 
@@ -11,6 +12,11 @@ import types
 import unicodedata
 import unittest
 import warnings
+
+
+# NSKIP021 https://github.com/nanvix/cpython/issues/501
+if support.is_nanvix_standalone:
+    raise unittest.SkipTest("NSKIP021: FAT VFS rename() hangs the kernel")
 
 
 CODING_RE = re.compile(r'^[ \t\f]*#.*?coding[:=][ \t]*([-\w.]+)', re.ASCII)

--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 from test.support import import_helper
 from test.support import os_helper
+from test import support
 import types
 import unittest
 import warnings
@@ -222,6 +223,11 @@ class ReloadTests:
             self.assertIs(reloaded, types)
             self.assertIs(sys.modules['types'], types)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_reload_location_changed(self):
         name = 'spam'
         with os_helper.temp_cwd(None) as cwd:
@@ -273,6 +279,11 @@ class ReloadTests:
                     self.maxDiff = None
                     self.assertEqual(ns, expected)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_reload_namespace_changed(self):
         name = 'spam'
         with os_helper.temp_cwd(None) as cwd:
@@ -332,6 +343,11 @@ class ReloadTests:
                     self.assertEqual(loader.path, init_path)
                     self.assertEqual(ns, expected)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_reload_submodule(self):
         # See #19851.
         name = 'spam'

--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -8,6 +8,7 @@ import types
 import unittest
 
 from test.support import threading_helper
+from test import support
 from test.test_importlib import util as test_util
 
 
@@ -148,6 +149,8 @@ class LazyLoaderTests(unittest.TestCase):
             module.__name__
 
     @threading_helper.requires_working_threading()
+    # NSKIP016 https://github.com/nanvix/cpython/issues/484
+    @unittest.skipIf(support.is_nanvix, "NSKIP016: exceeds Nanvix thread limit")
     def test_module_load_race(self):
         with test_util.uncache(TestingImporter.module_name):
             loader = TestingImporter()

--- a/Lib/test/test_importlib/test_locks.py
+++ b/Lib/test/test_importlib/test_locks.py
@@ -14,6 +14,10 @@ from test import lock_tests
 
 threading_helper.requires_working_threading(module=True)
 
+# NSKIP016 https://github.com/nanvix/cpython/issues/484
+if support.is_nanvix:
+    raise unittest.SkipTest("NSKIP016: exceeds Nanvix thread limit")
+
 
 class ModuleLockAsRLockTests:
     locktype = classmethod(lambda cls: cls.LockType("some_lock"))

--- a/Lib/test/test_importlib/test_main.py
+++ b/Lib/test/test_importlib/test_main.py
@@ -6,6 +6,8 @@ import importlib.metadata
 import contextlib
 import itertools
 
+from test.support import is_nanvix, is_nanvix_standalone
+
 try:
     import pyfakefs.fake_filesystem_unittest as ffs
 except ImportError:
@@ -33,6 +35,9 @@ def suppress_known_deprecation():
         yield ctx
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
     version_pattern = r'\d+\.\d+(\.\d)?'
 
@@ -73,6 +78,9 @@ class BasicTests(fixtures.DistInfoPkg, unittest.TestCase):
             Distribution.from_name(name)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class ImportTests(fixtures.DistInfoPkg, unittest.TestCase):
     def test_import_nonexistent_module(self):
         # Ensure that the MetadataPathFinder does not crash an import of a
@@ -97,6 +105,9 @@ class ImportTests(fixtures.DistInfoPkg, unittest.TestCase):
         assert ep.load() is importlib.metadata
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class NameNormalizationTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
     @staticmethod
     def make_pkg(name):
@@ -144,6 +155,9 @@ class NameNormalizationTests(fixtures.OnSysPath, fixtures.SiteDir, unittest.Test
         assert len(after) == len(before)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
     @staticmethod
     def pkg_with_non_ascii_description(site_dir):
@@ -187,6 +201,9 @@ class NonASCIITests(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
         assert meta['Description'] == 'pôrˈtend'
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class DiscoveryTests(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoToplevel,
@@ -209,6 +226,9 @@ class DiscoveryTests(
             list(distributions(context='something', name='else'))
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class DirectoryTest(fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase):
     def test_egg_info(self):
         # make an `EGG-INFO` directory that's unrelated
@@ -304,6 +324,8 @@ class TestEntryPoints(unittest.TestCase):
 class FileSystem(
     fixtures.OnSysPath, fixtures.SiteDir, fixtures.FileBuilder, unittest.TestCase
 ):
+    # NSKIP008 https://github.com/nanvix/cpython/issues/476
+    @unittest.skipIf(is_nanvix, "NSKIP008: tempfile names garbled")
     def test_unicode_dir_on_sys_path(self):
         """
         Ensure a Unicode subdirectory of a directory on sys.path
@@ -330,6 +352,9 @@ class PackagesDistributionsPrebuiltTest(fixtures.ZipFixtures, unittest.TestCase)
         assert packages_distributions()['example2'] == ['example2']
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class PackagesDistributionsTest(
     fixtures.OnSysPath, fixtures.SiteDir, unittest.TestCase
 ):
@@ -390,6 +415,9 @@ class PackagesDistributionsTest(
         assert not any(name.endswith('.dist-info') for name in distributions)
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class PackagesDistributionsEggTest(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoToplevel,

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -5,6 +5,7 @@ import warnings
 import importlib
 import contextlib
 
+from test.support import is_nanvix, is_nanvix_standalone
 from . import fixtures
 from importlib.metadata import (
     Distribution,
@@ -25,6 +26,9 @@ def suppress_known_deprecation():
         yield ctx
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class APITests(
     fixtures.EggInfoPkg,
     fixtures.EggInfoPkgPipInstalledNoToplevel,
@@ -88,6 +92,8 @@ class APITests(
                 ][0]
                 self.assertEqual(top_level.read_text(), expect_content)
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_entry_points(self):
         eps = entry_points()
         assert 'entries' in eps.groups
@@ -97,6 +103,8 @@ class APITests(
         self.assertEqual(ep.value, 'mod:main')
         self.assertEqual(ep.extras, [])
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_entry_points_distribution(self):
         entries = entry_points(group='entries')
         for entry in ("main", "ns:sub"):
@@ -104,6 +112,8 @@ class APITests(
             self.assertIn(ep.dist.name, ('distinfo-pkg', 'egginfo-pkg'))
             self.assertEqual(ep.dist.version, "1.0.0")
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_entry_points_unique_packages_normalized(self):
         """
         Entry points should only be exposed for the first package
@@ -132,13 +142,19 @@ class APITests(
         # ns:sub doesn't exist in alt_pkg
         assert 'ns:sub' not in entries.names
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_entry_points_missing_name(self):
         with self.assertRaises(KeyError):
             entry_points(group='entries')['missing']
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_entry_points_missing_group(self):
         assert entry_points(group='missing') == ()
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_entry_points_allows_no_attributes(self):
         ep = entry_points().select(group='entries', name='main')
         with self.assertRaises(AttributeError):
@@ -200,9 +216,13 @@ class APITests(
         self._test_files(files('egg_with_no_modules-pkg'))
         self._test_files(files('sources_fallback-pkg'))
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_version_egg_info_file(self):
         self.assertEqual(version('egginfo-file'), '0.1')
 
+    # NSKIP026 https://github.com/nanvix/cpython/issues/506
+    @unittest.skipIf(is_nanvix_standalone, "NSKIP026: FAT VFS returns wrong errno for path-edge cases")
     def test_requires_egg_info_file(self):
         requirements = requires('egginfo-file')
         self.assertIsNone(requirements)
@@ -285,6 +305,9 @@ class APITests(
         assert md['keywords'] == ['SAMPLE', 'PACKAGE']
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):
     def test_name_normalization(self):
         names = 'pkg.dot', 'pkg_dot', 'pkg-dot', 'pkg..dot', 'Pkg.Dot'
@@ -299,6 +322,9 @@ class LegacyDots(fixtures.DistInfoPkgWithDotLegacy, unittest.TestCase):
                 assert distribution(name).metadata['Name'] == 'pkg.lot'
 
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class OffSysPathTests(fixtures.DistInfoPkgOffPath, unittest.TestCase):
     def test_find_distributions_specified_path(self):
         dists = Distribution.discover(path=[str(self.site_dir)])

--- a/Lib/test/test_importlib/test_namespace_pkgs.py
+++ b/Lib/test/test_importlib/test_namespace_pkgs.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 import warnings
 
+from test.support import is_nanvix, is_nanvix_standalone
 from test.test_importlib import util
 
 # needed tests:
@@ -126,6 +127,9 @@ class SeparatedNamespacePackages(NamespacePackageTest):
 class SeparatedNamespacePackagesCreatedWhileRunning(NamespacePackageTest):
     paths = ['portion1']
 
+    # NSKIP012 https://github.com/nanvix/cpython/issues/480
+    @unittest.skipIf(is_nanvix and not is_nanvix_standalone,
+                     "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
     def test_invalidate_caches(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             # we manipulate sys.path before anything is imported to avoid

--- a/Lib/test/test_importlib/test_pkg_import.py
+++ b/Lib/test/test_importlib/test_pkg_import.py
@@ -8,7 +8,11 @@ import unittest
 
 from importlib.util import cache_from_source
 from test.support.os_helper import create_empty_file
+from test import support
 
+# NSKIP012 https://github.com/nanvix/cpython/issues/480
+@unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                 "NSKIP012: rmtree/rmdir cleanup failures on Nanvix (ENOSYS standalone, errno 88 hosted)")
 class TestImport(unittest.TestCase):
 
     def __init__(self, *args, **kw):
@@ -45,6 +49,11 @@ class TestImport(unittest.TestCase):
         with open(self.module_path, 'w', encoding='utf-8') as f:
             f.write(contents)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_package_import__semantics(self):
 
         # Generate a couple of broken modules to try importing.

--- a/Lib/test/test_importlib/test_threaded_import.py
+++ b/Lib/test/test_importlib/test_threaded_import.py
@@ -18,8 +18,13 @@ from test.support import verbose
 from test.support.import_helper import forget, mock_register_at_fork
 from test.support.os_helper import (TESTFN, unlink, rmtree)
 from test.support import script_helper, threading_helper
+from test import support
 
 threading_helper.requires_working_threading(module=True)
+
+# NSKIP016 https://github.com/nanvix/cpython/issues/484
+if support.is_nanvix:
+    raise unittest.SkipTest("NSKIP016: exceeds Nanvix thread limit")
 
 def task(N, done, done_tasks, errors):
     try:

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -246,6 +246,11 @@ class FindSpecTests:
         # None is returned upon failure to find a loader.
         self.assertIsNone(self.util.find_spec('nevergoingtofindthismodule'))
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_find_submodule(self):
         name = 'spam'
         subname = 'ham'
@@ -259,6 +264,11 @@ class FindSpecTests:
             spec_again = self.util.find_spec(fullname)
             self.assertEqual(spec_again, spec)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_find_submodule_parent_already_imported(self):
         name = 'spam'
         subname = 'ham'
@@ -273,6 +283,11 @@ class FindSpecTests:
             spec_again = self.util.find_spec(fullname)
             self.assertEqual(spec_again, spec)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_find_relative_module(self):
         name = 'spam'
         subname = 'ham'
@@ -287,6 +302,11 @@ class FindSpecTests:
             spec_again = self.util.find_spec(fullname)
             self.assertEqual(spec_again, spec)
 
+    # NSKIP021 https://github.com/nanvix/cpython/issues/501
+    # NSKIP055 https://github.com/nanvix/cpython/issues/552
+    @unittest.skipIf(support.is_nanvix_standalone, "NSKIP021: FAT VFS rename() hangs the kernel")
+    @unittest.skipIf(support.is_nanvix and not support.is_nanvix_standalone,
+                     "NSKIP055: linuxd rename()/replace() hangs the kernel on hosted Nanvix")
     def test_find_relative_module_missing_package(self):
         name = 'spam'
         subname = 'ham'


### PR DESCRIPTION
## Summary

## Changes

Enables the full `test_importlib` sub-package (45 test files across 9 sub-areas: `source`, `frozen`, `extension`, `resources`, `import_`, `builtin`, `namespace_pkgs`, `partial`, `data`) on Nanvix. Adds `test_importlib` to `NANVIX_TEST_LIST` with `@unittest.skipIf` annotations for the failure classes that surface on FAT VFS, linuxd, and the static-link build.

Verified GREEN on both modes:

| Mode | Result |
|---|---|
| **standalone** | 91/91 modules / 23/23 batches PASS |
| **single-process** | 94/94 modules / 24/24 batches PASS |

Also: `.nanvix/run-tests.py` direct (hosted) branch now passes `-B`, symmetric with the standalone branch which already does so. Without `-B`, importing any source whose mtime is newer than its compiled pyc hangs the guest kernel via NSKIP055 (linuxd `os.replace` hang); this is mandatory infrastructure for hosted, not a test-specific workaround.

## New NSKIPS

| NSKIP code | Description |
| --- | --- |
| [NSKIP054](https://github.com/nanvix/cpython/issues/553) | Nanvix is built static-only; no dynamic extension modules (.so) available |
| [NSKIP055](https://github.com/nanvix/cpython/issues/552) | linuxd rename()/replace() hangs the kernel on hosted Nanvix |

NSKIP055 is the hosted analog of [NSKIP021](https://github.com/nanvix/cpython/issues/501): same user-visible symptom (`os.rename`/`os.replace` hangs the kernel), but a distinct bug in a different VFS layer (linuxd RPC vs rust-fatfs). Independently fixable, so it gets its own ID. Every test that exercises rename now stacks both decorators (NSKIP021 fires on standalone, NSKIP055 on hosted).

NSKIP054 covers the static-link build: `importlib.machinery.EXTENSION_SUFFIXES` is non-empty but no `.so` file exists on `sys.path`, so `util.EXTENSIONS.filename` stays `None` and the upstream `Requires dynamic loading support.` skip guard does not fire. Affects every test in `extension/test_loader.py` and `extension/test_finder.py`.

---

Refs: [NSKIP008](https://github.com/nanvix/cpython/issues/476), [NSKIP012](https://github.com/nanvix/cpython/issues/480), [NSKIP016](https://github.com/nanvix/cpython/issues/484), [NSKIP021](https://github.com/nanvix/cpython/issues/501), [NSKIP026](https://github.com/nanvix/cpython/issues/506), [NSKIP043](https://github.com/nanvix/cpython/issues/523), [#371](https://github.com/nanvix/cpython/issues/371), [#490](https://github.com/nanvix/cpython/issues/490)
Closes #491.

