### PR TITLE
Enable fcntl stdlib module

### DIFF
--- a/configure
+++ b/configure
@@ -28629,7 +28629,6 @@ case $ac_sys_system in #(
     py_cv_module__multiprocessing=n/a
     py_cv_module_audioop=n/a
     py_cv_module__posixshmem=n/a
-    py_cv_module_fcntl=n/a
     py_cv_module_grp=n/a
     py_cv_module_ossaudiodev=n/a
     py_cv_module_resource=n/a

--- a/configure.ac
+++ b/configure.ac
@@ -7302,7 +7302,8 @@ AS_CASE([$ac_sys_system],
       [_testimportmultiple],
       [_testmultiphase],
       [_testsinglephase],
-      [_testclinic])
+      [_testclinic],
+    )
   ],
   [Emscripten|WASI], [
     dnl subprocess and multiprocessing are not supported (no fork syscall).

--- a/configure.ac
+++ b/configure.ac
@@ -7271,7 +7271,6 @@ AS_CASE([$ac_sys_system],
       [_multiprocessing],
       [audioop],
       [_posixshmem],
-      [fcntl],
       [grp],
       [ossaudiodev],
       [resource],
@@ -7303,8 +7302,7 @@ AS_CASE([$ac_sys_system],
       [_testimportmultiple],
       [_testmultiphase],
       [_testsinglephase],
-      [_testclinic],
-    )
+      [_testclinic])
   ],
   [Emscripten|WASI], [
     dnl subprocess and multiprocessing are not supported (no fork syscall).


### PR DESCRIPTION
Closes #298.

Enables the `fcntl` C extension on Nanvix, exposing `fcntl.fcntl`,
`fcntl.ioctl`, `fcntl.flock`, and the constant surface (`F_GETFD`,
`F_SETFD`, `F_GETFL`, `F_SETFL`, `LOCK_*`, …). Unblocks the
`subprocess`/`multiprocessing`/`pty`/`mailbox` paths that import `fcntl`
lazily for `FD_CLOEXEC`, file locking, and TTY control.

## Changes

- `configure.ac:7275` — drop `[fcntl],` from the Nanvix arm of
  `PY_STDLIB_MOD_SET_NA(...)`.
- `configure.ac:7306` — normalise `[_testclinic],\n    )` →
  `[_testclinic])`. Pre-existing latent bug: the trailing comma made
  `m4_foreach` iterate over an empty element and emit a spurious
  `py_cv_module_=n/a` line on regen. Same shape exists in the
  Emscripten/WASI arms; left for a separate cleanup.
- `configure` regenerated via `autoconf -f` (autoconf 2.71); diff is the
  matching `py_cv_module_fcntl=n/a` deletion.

`Modules/fcntlmodule.c` needs no patches: every `HAVE_*` probe resolves
correctly against `libposix.a`. The Nanvix `PY_STDLIB_MOD_SET_NA` block
was force-overriding an otherwise-passing detection.

## Verification

`./z distclean && ./z clean && ./z --mode=$MODE setup && ./z test` for
each mode, plus an `import fcntl; print(fcntl.F_GETFD)` smoke:

| mode            | built-in modules | regrtest     | smoke |
|-----------------|-----------------:|--------------|------:|
| standalone      | **74** (was 73)  | 155/155 PASS | `1`   |
| single-process  | **74** (was 73)  | 162/162 PASS | `1`   |
| multi-process   | **74** (was 73)  | 162/162 PASS | `1`   |

`fcntl` drops out of the `n/a` set in every mode. No new kernel
`[ERROR]` classes; `vfs_fcntl ENOTSUP` count in standalone is unchanged.

## Process note

`autoreconf -ivf -Werror` (per `Makefile.pre.in:2637`) is broken on a
fresh environment — `aclocal --force` clobbers CPython's curated
`aclocal.m4`. `autoconf -f` is the working subset: regenerates
`configure` from `configure.ac` without touching `aclocal.m4`. Suggest
future stdlib-enablement cycles use it.

## Follow-ups (out of scope here)

- `NANVIX_TEST_LIST` expansion to actually exercise `test_fcntl`,
  `test_ioctl`, `test_pty`, etc. Expected new skips when added: `SIGIO`
  / `F_SETOWN` / `F_NOTIFY` (no signal proxy → silent hangs), `flock(2)`
  (not proxied at linuxd), record-lock mode-asymmetry between standalone
  and hosted modes.
- NSKIP048 bundles fcntl + ioctl C-extension N/A; only the fcntl half is
  resolved here. Ioctl gap lives at linuxd (`nanvix#351`). Split
  NSKIP048 before closing #528.
