### PR TITLE
Thread Docker flag through build pipeline

### DIFF
--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -95,6 +95,7 @@ def build(
     install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
     release: bool = False,
     run_fn=None,
+    docker: bool = False,
 ) -> None:
     """Cross-compile python.elf for Nanvix."""
     if config.IS_WINDOWS:
@@ -111,8 +112,10 @@ def build(
             install_destdir=install_cache,
         )
         return
+    effective_sysroot = config.DOCKER_SYSROOT_PATH if docker else sysroot
+    effective_toolchain = config.DOCKER_TOOLCHAIN_PATH if docker else toolchain
     args = make_args(
-        sysroot, toolchain, "build",
+        effective_sysroot, effective_toolchain, "build",
         platform=platform,
         process_mode=process_mode,
         memory_size=memory_size,
@@ -135,6 +138,7 @@ def install(
     release: bool = False,
     run_fn=None,
     extra_make_flags: list[str] | None = None,
+    docker: bool = False,
 ) -> None:
     """Install CPython into a staging directory."""
     if config.IS_WINDOWS:
@@ -147,6 +151,8 @@ def install(
             release=release,
         )
         return
+    effective_sysroot = config.DOCKER_SYSROOT_PATH if docker else sysroot
+    effective_toolchain = config.DOCKER_TOOLCHAIN_PATH if docker else toolchain
     # When running inside Docker, repo_root maps to /mnt/workspace.
     # Use a relative DESTDIR so it resolves correctly inside the container.
     try:
@@ -154,7 +160,7 @@ def install(
     except ValueError:
         rel_destdir = destdir
     args = make_args(
-        sysroot, toolchain,
+        effective_sysroot, effective_toolchain,
         *(extra_make_flags or []),
         "install", f"DESTDIR={rel_destdir}",
         platform=platform,

--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -46,6 +46,7 @@ def package(
     release: bool = True,
     run_fn=None,
     nanvix_home: str | Path | None = None,
+    docker: bool = False,
 ) -> None:
     """Package CPython release tarballs.
 
@@ -55,10 +56,7 @@ def package(
 
     Args:
         nanvix_home: Host-side path to the Nanvix sysroot for local
-            file operations (mkramfs, etc.).  When Docker is active
-            *sysroot* is a container-internal path; *nanvix_home*
-            should be the original host path so that
-            ``subprocess.run`` and ``Path.is_file`` work correctly.
+            file operations (mkramfs, etc.).  Defaults to *sysroot*.
     """
     nanvix_home = Path(nanvix_home) if nanvix_home else Path(sysroot)
     release_staging = repo_root / ".nanvix" / "release"
@@ -80,6 +78,7 @@ def package(
         install_prefix=install_prefix,
         release=True,
         run_fn=run_fn,
+        docker=docker,
     )
 
     # Install into staging.
@@ -91,6 +90,7 @@ def package(
         install_prefix=install_prefix,
         release=True,
         run_fn=run_fn,
+        docker=docker,
     )
 
     sysroot_installed = release_staging / "sysroot"

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -164,6 +164,7 @@ def stage(
     install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
     release: bool = False,
     run_fn=None,
+    docker: bool = False,
 ) -> Path:
     """Build, install, and stage CPython for testing.
 
@@ -232,6 +233,7 @@ def stage(
                 release=release,
                 run_fn=run_fn,
                 extra_make_flags=["-o", "build", "PYTHON_FOR_BUILD=:"],
+                docker=docker,
             )
         else:
             build_mod.build(
@@ -242,6 +244,7 @@ def stage(
                 install_prefix=install_prefix,
                 release=release,
                 run_fn=run_fn,
+                docker=docker,
             )
 
             build_mod.install(
@@ -252,6 +255,7 @@ def stage(
                 install_prefix=install_prefix,
                 release=release,
                 run_fn=run_fn,
+                docker=docker,
             )
 
     sysroot_dir = staging / "sysroot"
@@ -573,6 +577,7 @@ def run_all(
     test_list: list[str] | None = None,
     batch_size: int = config.DEFAULT_TEST_BATCH_SIZE,
     run_fn=None,
+    docker: bool = False,
 ) -> None:
     """Run the complete test pipeline: stage → hello → regrtest → cleanup."""
     nanvix_home = Path(sysroot)
@@ -587,6 +592,7 @@ def run_all(
         install_prefix=install_prefix,
         release=release,
         run_fn=run_fn,
+        docker=docker,
     )
 
     # Ramfs — only needed for standalone mode.  Multi-process and

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -208,8 +208,8 @@ class CPythonBuild(ZScript):
 
     # ---- Common helpers --------------------------------------------------
 
-    def _get_paths(self) -> tuple[str, str]:
-        """Return (sysroot, toolchain) paths from config."""
+    def _get_host_paths(self) -> tuple[str, str]:
+        """Return (sysroot, toolchain) raw host paths from config."""
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
             log.fatal(
@@ -218,9 +218,7 @@ class CPythonBuild(ZScript):
                 hint="Run `./z setup` first to download the sysroot.",
             )
         toolchain = self.config.get(CFG_TOOLCHAIN, config.TOOLCHAIN_DEFAULT_PATH)
-        sysroot_p = str(self.translate_path(Path(sysroot)))
-        toolchain_p = str(self.translate_path(Path(toolchain)))
-        return sysroot_p, toolchain_p
+        return sysroot, toolchain
 
     def _build_kwargs(self, release: bool = False) -> dict:
         """Return common keyword arguments for build/test/package modules."""
@@ -250,11 +248,13 @@ class CPythonBuild(ZScript):
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the make argument list for configure/build/install."""
-        sysroot, toolchain = self._get_paths()
+        sysroot, toolchain = self._get_host_paths()
         release = os.environ.get(_MAKE_VAR_RELEASE, "no")
 
         return build_mod.make_args(
-            sysroot, toolchain, *targets,
+            str(self.translate_path(Path(sysroot))),
+            str(self.translate_path(Path(toolchain))),
+            *targets,
             platform=self.config.machine,
             process_mode=self.config.deployment_mode,
             memory_size=self.config.memory_size,
@@ -311,43 +311,39 @@ class CPythonBuild(ZScript):
     def build(self) -> None:
         """Cross-compile python.elf and libpython.a for Nanvix."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_paths()
+        sysroot, toolchain = self._get_host_paths()
         release = os.environ.get(_MAKE_VAR_RELEASE, "no") == "yes"
         build_mod.build(
             sysroot, toolchain, self.repo_root,
             **self._build_kwargs(release=release),
             run_fn=lambda *args, **kw: self.run(*args, **kw),
+            docker=self.docker is not None,
         )
 
     def test(self) -> None:
         """Run the CPython test suite (hello + regrtest)."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_paths()
+        sysroot, toolchain = self._get_host_paths()
         kwargs = self._build_kwargs()
 
         test_mod.run_all(
             sysroot, toolchain, self.repo_root,
             **kwargs,
             run_fn=lambda *args, **kw: self.run(*args, **kw),
+            docker=self.docker is not None,
         )
 
     def release(self) -> None:
         """Package the CPython release tarballs and verify them."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_paths()
+        sysroot, toolchain = self._get_host_paths()
         kwargs = self._build_kwargs(release=True)
-
-        # Pass raw host sysroot path for local file operations (mkramfs,
-        # etc.).  _get_paths() translates to Docker-internal paths when
-        # Docker is active, but package.py needs host paths for
-        # subprocess.run() and Path.is_file() calls.
-        sysroot_host = self.config.get(CFG_SYSROOT, "")
 
         package_mod.package(
             sysroot, toolchain, self.repo_root,
             **kwargs,
             run_fn=lambda *args, **kw: self.run(*args, **kw),
-            nanvix_home=sysroot_host,
+            docker=self.docker is not None,
         )
         package_mod.verify(
             self.repo_root,


### PR DESCRIPTION
Move Docker path resolution from `z.py` into `build.py`/`install()` so that each function decides its own effective sysroot/toolchain based on a new `docker: bool` parameter, rather than having the caller pre-translate paths.

### Changes

- **build.py**: Add `docker` parameter to `build()` and `install()`. When set, use `config.DOCKER_SYSROOT_PATH` / `config.DOCKER_TOOLCHAIN_PATH` instead of the caller-supplied host paths.
- **package.py**: Forward `docker` to inner `build()`/`install()` calls. Simplify `nanvix_home` docstring now that sysroot is always a host path.
- **test.py**: Add `docker` parameter to `stage()` and `run_all()`, forwarding it to `build()`/`install()`.
- **z.py**: Rename `_get_paths()` to `_get_host_paths()` — it now returns raw host paths without `translate_path()`. Path translation is applied only in `_make_args()` (for direct make invocations) while `build()`, `test()`, and `release()` pass host paths and let the downstream modules handle Docker resolution via the new flag. Remove the `nanvix_home` workaround from `release()` since sysroot is no longer pre-translated.