### PR TITLE
[ci] Sync zutils v0.7.30

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.29"
+      zutil-version: "v0.7.33"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       matrix-exclude: '[{"platform":"hyperlight"}]'
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.29"
+      zutil-version: "v0.7.33"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       matrix-exclude: '[{"platform":"hyperlight"}]'

--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.33"
+      zutil-version: "v0.7.34"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       matrix-exclude: '[{"platform":"hyperlight"}]'
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0
     with:
-      zutil-version: "v0.7.33"
+      zutil-version: "v0.7.34"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
       matrix-exclude: '[{"platform":"hyperlight"}]'

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -65,7 +65,6 @@ def run_make(
     args: list[str],
     *,
     cwd: Path | None = None,
-    kvm: bool = False,
     run_fn: Any = None,
 ) -> None:
     """Execute a make command.
@@ -73,12 +72,11 @@ def run_make(
     Args:
         args: Full make argument list (from :func:`make_args`).
         cwd: Working directory.
-        kvm: Passed through to the run function (for VM execution).
         run_fn: Callable to execute the command. Defaults to
             ``subprocess.run`` with check=True.
     """
     if run_fn:
-        run_fn(*args, cwd=cwd, kvm=kvm)
+        run_fn(*args, cwd=cwd)
     else:
         subprocess.run(args, cwd=cwd, check=True)
 

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -232,7 +232,7 @@ class CPythonBuild(ZScript):
 
     # ---- Make invocation (for build/install only) ------------------------
 
-    def _run_make(self, make_args: list[str], *, kvm: bool = False) -> None:
+    def _run_make(self, make_args: list[str]) -> None:
         """Execute a make command directly (Linux/macOS only).
 
         On Windows, callers should use ``build_mod.build()`` or
@@ -244,7 +244,7 @@ class CPythonBuild(ZScript):
                 "_run_make() is not supported on Windows. "
                 "Use build_mod.build() / build_mod.install() instead."
             )
-        self.run(*make_args, cwd=self.repo_root, docker=False, kvm=kvm)
+        self.run(*make_args, cwd=self.repo_root, docker=False)
 
     def _make_args(self, *targets: str) -> list[str]:
         """Build the make argument list for configure/build/install."""

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.29"
+    "0.7.33"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.33"
+    "0.7.34"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.33"
+PINNED_VERSION="0.7.34"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.29"
+PINNED_VERSION="0.7.33"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
Automated sync with [`v0.7.30`](https://github.com/nanvix/zutils/releases/tag/v0.7.30):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.