### PR TITLE
ci: add format & lint job via workflows reusable workflow

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -23,6 +23,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format-and-lint:
+    uses: nanvix/workflows/.github/workflows/nanvix-format-lint.yml@v1.13.0
+    with:
+      zutil-version: "v0.7.41"
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.13.0


### PR DESCRIPTION
Adds a `format-and-lint` job that calls `nanvix/workflows/.github/workflows/nanvix-format-lint.yml` for Python, shell, and YAML checks.

Depends on: https://github.com/nanvix/workflows/pull/61