### PR TITLE
ci: bump nanvix/workflows to v1.14.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -75,7 +75,10 @@ jobs:
       github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ (needs.ci.outputs.package_version || needs.ci-scheduled.outputs.package_version) }}-nanvix-${{ (needs.ci.outputs.nanvix_version || needs.ci-scheduled.outputs.nanvix_version) }}
+      RELEASE_TAG: >-
+        ${{ (needs.ci.outputs.package_version || needs.ci-scheduled.outputs.package_version)
+        }}-nanvix-${{
+        (needs.ci.outputs.nanvix_version || needs.ci-scheduled.outputs.nanvix_version) }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Bumps `nanvix/workflows` from `v1.13.0` to `v1.14.0`, which adds format & lint checks (black, pyright, shfmt, shellcheck, yamllint) to the `nanvix-ci.yml` reusable workflow.

All consumers automatically gain these checks with no other changes needed.