### PR TITLE
Prevent distclean from blocking on locked venv on Windows

### DIFF
--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -236,9 +236,7 @@ def distclean(repo_root: Path) -> None:
     # error than git's interactive "Should I try again?" prompt.
     venv_dir = repo_root / ".nanvix" / "venv"
     if venv_dir.exists():
-        import shutil
-
-        shutil.rmtree(venv_dir, ignore_errors=True)
+        shutil.rmtree(venv_dir)
     cmd = ["git", "clean", "-fdx"]
     for exc in _DISTCLEAN_EXCLUDES:
         cmd.extend(["-e", exc])

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -218,6 +218,7 @@ _DISTCLEAN_EXCLUDES: list[str] = [
     ".nanvix/package.py",
     ".nanvix/run-regrtest.py",
     ".nanvix/run-tests.py",
+    ".nanvix/venv",
     "z",
     "z.sh",
     "z.ps1",
@@ -229,6 +230,15 @@ def distclean(repo_root: Path) -> None:
     clean(repo_root)
     if config.IS_WINDOWS:
         docker_mod.clean_volume(repo_root)
+    # Remove the venv separately — on Windows, git clean cannot delete
+    # python.exe while the current interpreter (running from the venv) holds
+    # a lock on it.  Use shutil which retries internally and gives a clearer
+    # error than git's interactive "Should I try again?" prompt.
+    venv_dir = repo_root / ".nanvix" / "venv"
+    if venv_dir.exists():
+        import shutil
+
+        shutil.rmtree(venv_dir, ignore_errors=True)
     cmd = ["git", "clean", "-fdx"]
     for exc in _DISTCLEAN_EXCLUDES:
         cmd.extend(["-e", exc])


### PR DESCRIPTION
On Windows, `./z distclean` hangs with an interactive prompt:

    Unlink of file '.nanvix/venv/Scripts/python.exe' failed.
    Should I try again? (y/n)

This happens because `git clean -fdx` tries to delete the venv's python.exe, which is locked by the currently running interpreter (z.py itself runs from that venv).

**Fix:**
- Add `.nanvix/venv` to the git-clean exclusion list so git skips it entirely.
- Explicitly remove the venv via `shutil.rmtree(ignore_errors=True)` before git clean runs. If the exe is still locked, it silently skips rather than prompting interactively.

The venv is recreated automatically on the next `./z` invocation.