### PR TITLE
Export xmlfile/htmlfile from etree shim

### DIFF
--- a/.nanvix/lxml.py
+++ b/.nanvix/lxml.py
@@ -58,4 +58,26 @@ def stage_lxml_runtime(repo_root: Path, sysroot: Path) -> None:
     if dst.exists():
         shutil.rmtree(dst)
     shutil.copytree(lxml_src, dst)
+
+    # Ensure the etree.py shim explicitly exports names that are not in
+    # lxml.etree.__all__ but are expected by downstream packages (e.g.
+    # openpyxl imports xmlfile).  The star-import only picks up names
+    # listed in __all__; xmlfile/htmlfile are cdef classes omitted from
+    # that list.
+    _write_etree_shim(dst / "etree.py")
+
     print(f"[lxml] Staged {lxml_src} -> {dst}")
+
+
+# The content of the etree.py shim that bridges the built-in _lxml_etree
+# C extension to the expected lxml.etree import path.
+_ETREE_SHIM = """\
+from _lxml_etree import *
+from _lxml_etree import _Element, _ElementTree, _Comment, _ProcessingInstruction, ElementBase, QName, _Attrib
+from _lxml_etree import xmlfile, htmlfile
+"""
+
+
+def _write_etree_shim(path: Path) -> None:
+    """Write (or overwrite) the lxml/etree.py shim with correct exports."""
+    path.write_text(_ETREE_SHIM, encoding="utf-8")

--- a/Lib/test/test_nanvix_lxml.py
+++ b/Lib/test/test_nanvix_lxml.py
@@ -37,6 +37,17 @@ class NanvixLxmlTests(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0].text, "1")
 
+    def test_xmlfile_available(self):
+        # xmlfile must be importable from lxml.etree for openpyxl compat.
+        from lxml.etree import xmlfile
+
+        self.assertTrue(callable(xmlfile))
+
+    def test_htmlfile_available(self):
+        from lxml.etree import htmlfile
+
+        self.assertTrue(callable(htmlfile))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The `nanvix-python` CI ([run 25356417542](https://github.com/nanvix/nanvix-python/actions/runs/25356417542)) fails on `test_029_et_xmlfile.py` with:

```
et-xmlfile: FAIL: cannot import name 'xmlfile' from 'lxml.etree' (/sysroot/lib/python3.12/lxml/etree.pyc)
```

## Root Cause

On Nanvix, `lxml.etree` is a Python shim (`etree.py`) that does `from _lxml_etree import *` to re-export names from the statically-linked C extension.

However, lxml's `etree.pyx` defines `__all__` which **excludes** `xmlfile` and `htmlfile` (they are `cdef class` types not listed in `__all__`). Python's star-import respects `__all__`, so these names are never brought into the shim namespace.

In standard (non-Nanvix) lxml installations, `lxml.etree` is loaded directly as a native `.so`, so named imports like `from lxml.etree import xmlfile` bypass `__all__` and succeed via direct attribute lookup. The Nanvix shim approach requires explicit imports for names outside `__all__`.

`openpyxl` (used by `et-xmlfile` test) does:
```python
from lxml.etree import xmlfile  # fails on Nanvix
```

## Fix

`stage_lxml_runtime()` in `.nanvix/lxml.py` now writes the `etree.py` shim with an explicit `from _lxml_etree import xmlfile, htmlfile` line, ensuring these names are available regardless of what the upstream lxml release artifact contains.

Also adds test coverage for `xmlfile`/`htmlfile` availability in `test_nanvix_lxml.py`.

## Reproduction (confirmed locally)

```python
import lxml.etree
namespace = {}
exec('from lxml.etree import *', namespace)
assert 'xmlfile' not in namespace  # star-import misses it
```