### PR TITLE
Enable NSKIP015-gated tests now passable with 128 MB heap (#483)

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1,6 +1,6 @@
 # NSKIP019 https://github.com/nanvix/cpython/issues/487
 # Module is excluded from standalone mode (32 MB heap too small).  Remaining
-# skips in non-standalone modes are NSKIP001 (pickle) and NSKIP015 (tee OOM).
+# skips in non-standalone modes are NSKIP001 (pickle).
 
 import doctest
 import unittest
@@ -1741,8 +1741,6 @@ class TestBasicOps(unittest.TestCase):
         script_helper.assert_python_ok("-c", script)
 
     # Issue 13454: Crash when deleting backward iterator from tee()
-    # NSKIP015 https://github.com/nanvix/cpython/issues/483
-    @unittest.skipIf(support.is_nanvix, "NSKIP015: OOM — test allocation exceeds available heap")
     def test_tee_del_backward(self):
         forward, backward = tee(repeat(None, 20000000))
         try:

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -68,9 +68,6 @@ class TestRecursion:
             self.fail("didn't raise ValueError on default recursion")
 
 
-    # NSKIP015 https://github.com/nanvix/cpython/issues/483
-    @unittest.skipIf(support.is_nanvix,
-                     "NSKIP015: OOM — test allocation exceeds available heap")
     def test_highly_nested_objects_decoding(self):
         # test that loading highly-nested objects doesn't segfault when C
         # accelerations are used. See #12017
@@ -84,9 +81,6 @@ class TestRecursion:
             with support.infinite_recursion():
                 self.loads('[' * 100000 + '1' + ']' * 100000)
 
-    # NSKIP015 https://github.com/nanvix/cpython/issues/483
-    @unittest.skipIf(support.is_nanvix,
-                     "NSKIP015: OOM — test allocation exceeds available heap")
     def test_highly_nested_objects_encoding(self):
         # See #12051
         l, d = [], {}
@@ -99,9 +93,6 @@ class TestRecursion:
             with support.infinite_recursion():
                 self.dumps(d)
 
-    # NSKIP015 https://github.com/nanvix/cpython/issues/483
-    @unittest.skipIf(support.is_nanvix,
-                     "NSKIP015: OOM — test allocation exceeds available heap")
     def test_endless_recursion(self):
         # See #12051
         class EndlessJSONEncoder(self.json.JSONEncoder):

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -910,9 +910,6 @@ class TestBinaryPlistlib(unittest.TestCase):
         b = plistlib.loads(plistlib.dumps(a, fmt=plistlib.FMT_BINARY))
         self.assertIs(b['x'], b)
 
-    # NSKIP015 https://github.com/nanvix/cpython/issues/483
-    @unittest.skipIf(support.is_nanvix,
-                     "NSKIP015: OOM — test allocation exceeds available heap")
     def test_deep_nesting(self):
         tests = [50, 100_000] if support.is_wasi else [50, 600, 100_000]
         for N in tests:


### PR DESCRIPTION
## Summary

Remove NSKIP015 skip guards from five test methods that now pass under the
256 MB standalone VM after the Nanvix OS heap capacity was raised from
`MEMORY_SIZE/4` (64 MB) to `MEMORY_SIZE/2` (128 MB).

## Tests enabled

| Test | Reason it now passes |
|------|---------------------|
| `test_itertools::TestBasicOps.test_tee_del_backward` | 20M-element `tee()` buffer fits in 128 MB heap (~98 MB footprint) |
| `test_plistlib::TestBinaryPlistlib.test_deep_nesting` | 100K nested nodes hit `RecursionError` before exhausting 128 MB heap |
| `test_json/test_recursion::test_highly_nested_objects_decoding` | 100K nested JSON triggers `RecursionError` within heap budget |
| `test_json/test_recursion::test_highly_nested_objects_encoding` | Same — recursion limit fires before OOM |
| `test_json/test_recursion::test_endless_recursion` | Same — recursion limit fires before OOM |

## Tests NOT enabled (still NSKIP015)

| Test | Reason |
|------|--------|
| `test_largefile` (module-level skip) | Requires >2 GB disk I/O — fundamentally exceeds the 256 MB VM physical memory |
| `test_zipfile64` (module-level skip) | Requires 4 GB+ ZIP entries — impossible in any deployment mode with ≤256 MB RAM |

These two tests exercise multi-gigabyte allocations that cannot fit in any
reasonable Nanvix VM configuration. They remain skipped regardless of heap ratio.

## OS-side change (prerequisite)

The Nanvix OS change (`USER_HEAP_CAPACITY: MEMORY_SIZE/4 → MEMORY_SIZE/2`) is in
a separate PR on [nanvix/nanvix](https://github.com/nanvix/nanvix). This CPython
PR depends on that OS change being merged and released.

## Verification

```
./z setup --with-nanvix /path/to/nanvix  # with heap patch
./z test
# PASS: all 157 modules passed
```

## Issues

- Closes #483 
- Opens #614 
- References #371