### PR TITLE
[ci] E: Pin nanvix to v0.12.521

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.12.511"
+nanvix-version = "0.12.521"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.12.521`](https://github.com/nanvix/nanvix/releases/tag/v0.12.521).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.