### PR TITLE
fix: align nightly schedule with tier5 (13:00 UTC)

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -5,7 +5,7 @@ name: Nanvix CI
 
 on:
   schedule:
-    - cron: "0 11 * * *"
+    - cron: "0 13 * * *"
   push:
     branches: ["nanvix/**"]
   pull_request:


### PR DESCRIPTION
Aligns the nightly CI cron with the new tier5 schedule (13:00 UTC) so it runs after tier4 dependencies are updated. See nanvix/workflows#76.