### PR TITLE
Decouple release packaging from compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,9 @@ Python/frozen_modules/MANIFEST
 # Ignore ./python binary on Unix but still look into ./Python/ directory.
 /python
 !/Python/
+
+# Nanvix build artifacts
+.nanvix-configured
+.nanvix/_build_output/
+.nanvix/_build_output.tmp/
+/python.elf

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -188,7 +188,14 @@ def clean(repo_root: Path) -> None:
             if p.is_file():
                 p.unlink()
                 print(f"Removed {name}")
-        for name in ("_test_staging", "staging", "_install_cache", "_ramfs_cache"):
+        for name in (
+            "_test_staging",
+            "staging",
+            "_install_cache",
+            "_ramfs_cache",
+            "_build_output",
+            "_build_output.tmp",
+        ):
             p = repo_root / ".nanvix" / name
             if p.is_dir():
                 shutil.rmtree(p)

--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -3,14 +3,20 @@
 
 """Release packaging and verification for Nanvix CPython.
 
-Replaces package-common.mk and verify-package.mk. Handles sysroot/buildroot
-tarball creation, ramfs image inclusion, and tarball verification.
+Provides:
+- ``stage_build_output()`` — called by ``./z build`` to produce persistent
+  release-ready sysroot, buildroot, binary, and ramfs image.
+- ``package()`` — called by ``./z release`` to archive the output from
+  ``./z build`` into tarballs (Linux) or zip files (Windows).
+- ``verify()`` — validates that release archives are well-formed.
 """
 
 from __future__ import annotations
 
+import json
 import shutil
 import tarfile
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -24,17 +30,32 @@ build_mod = load_sibling("build", __file__)
 lxml_mod = load_sibling("lxml", __file__)
 ramfs_mod = load_sibling("ramfs", __file__)
 
+# Persistent build output directory (produced by ./z build).
+BUILD_OUTPUT_DIR = "_build_output"
+_BUILD_OUTPUT_TMP = "_build_output.tmp"
+_MANIFEST_NAME = "manifest.json"
+
+
+def build_output_path(repo_root: Path) -> Path:
+    """Return the path to the persistent build output directory."""
+    return repo_root / ".nanvix" / BUILD_OUTPUT_DIR
+
 
 def _artifact_base(
     platform: str = config.DEFAULT_PLATFORM,
     process_mode: str = config.DEFAULT_PROCESS_MODE,
     memory_size: str = config.DEFAULT_MEMORY_SIZE,
 ) -> str:
-    """Return the base name for release tarballs."""
+    """Return the base name for release archives."""
     return f"cpython-{platform}-{process_mode}-{memory_size}"
 
 
-def package(
+# ---------------------------------------------------------------------------
+# Build output staging (called by ./z build)
+# ---------------------------------------------------------------------------
+
+
+def stage_build_output(
     sysroot: str | Path,
     toolchain: str | Path,
     repo_root: Path,
@@ -43,70 +64,70 @@ def package(
     process_mode: str = config.DEFAULT_PROCESS_MODE,
     memory_size: str = config.DEFAULT_MEMORY_SIZE,
     install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = True,
     run_fn: Any = None,
     nanvix_home: str | Path | None = None,
     docker: bool = False,
-) -> None:
-    """Package CPython release tarballs.
+) -> Path:
+    """Produce release-ready build output after compilation.
 
-    Creates two tarballs in ``dist/``:
-    - ``cpython-<platform>-<mode>-<memory>.tar.bz2`` — runtime sysroot + binary + ramfs
-    - ``cpython-<platform>-<mode>-<memory>-buildroot.tar.bz2`` — build dependencies
+    Installs CPython into a staging directory, splits into runtime sysroot
+    and buildroot, trims the runtime sysroot, builds the ramfs image
+    (without test files), and writes a manifest.
 
-    Args:
-        nanvix_home: Host-side path to the Nanvix sysroot for local
-            file operations (mkramfs, etc.).  Defaults to *sysroot*.
+    The output is written atomically: staging happens in a temporary
+    directory and is renamed to the final location only on success.
+
+    Returns the path to the build output directory.
     """
-    nanvix_home = Path(nanvix_home) if nanvix_home else Path(sysroot)
-    release_staging = repo_root / ".nanvix" / "release"
-    dist_dir = repo_root / "dist"
-    artifact = _artifact_base(platform, process_mode, memory_size)
+    nanvix_home_path = Path(nanvix_home) if nanvix_home else Path(sysroot)
+    output_dir = repo_root / ".nanvix" / BUILD_OUTPUT_DIR
+    tmp_dir = repo_root / ".nanvix" / _BUILD_OUTPUT_TMP
 
-    print("Packaging CPython release...")
+    print("Staging build output...")
 
-    # Clean previous staging.
-    if release_staging.exists():
-        shutil.rmtree(release_staging)
+    # Clean previous temporary staging.
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True)
 
-    # Build.
-    build_mod.build(
-        sysroot,
-        toolchain,
-        repo_root,
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=True,
-        run_fn=run_fn,
-        docker=docker,
-    )
+    # Install into a temporary install tree.
+    install_staging = tmp_dir / "_install"
+    install_staging.mkdir()
 
-    # Install into staging.
-    build_mod.install(
-        sysroot,
-        toolchain,
-        repo_root,
-        release_staging,
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=True,
-        run_fn=run_fn,
-        docker=docker,
-    )
+    if config.IS_WINDOWS:
+        # On Windows, the install cache from Docker is already available.
+        install_cache = repo_root / ".nanvix" / "_install_cache"
+        if install_cache.is_dir():
+            shutil.copytree(install_cache, install_staging, dirs_exist_ok=True)
+        else:
+            raise FileNotFoundError(
+                "Install cache not found. On Windows, ./z build should "
+                "produce _install_cache via Docker."
+            )
+    else:
+        build_mod.install(
+            sysroot,
+            toolchain,
+            repo_root,
+            install_staging,
+            platform=platform,
+            process_mode=process_mode,
+            memory_size=memory_size,
+            install_prefix=install_prefix,
+            release=True,
+            run_fn=run_fn,
+            docker=docker,
+        )
 
-    sysroot_installed = release_staging / "sysroot"
+    sysroot_installed = install_staging / "sysroot"
     if not sysroot_installed.is_dir():
         raise FileNotFoundError(f"Install did not produce {sysroot_installed}")
 
-    # Stage lxml Python package into the installed sysroot.
+    # Stage lxml runtime into the installed sysroot.
     lxml_mod.stage_lxml_runtime(repo_root, sysroot_installed)
 
-    # --- Buildroot: build dependencies ---
-    buildroot_pkg = release_staging / "buildroot-pkg"
+    # --- Buildroot: build/dev dependencies ---
+    buildroot_pkg = tmp_dir / "buildroot"
     buildroot_pkg.mkdir(parents=True)
     (buildroot_pkg / "lib").mkdir()
     (buildroot_pkg / "bin").mkdir()
@@ -157,57 +178,239 @@ def package(
     if share_src.is_dir():
         shutil.copytree(share_src, buildroot_pkg / "share")
 
-    # --- Sysroot: runtime stdlib (trimmed) ---
-    ramfs_staging = release_staging / "sysroot-pkg-wrap"
-    ramfs_sysroot = ramfs_staging / "sysroot" / "lib"
-    ramfs_sysroot.mkdir(parents=True)
+    # --- Sysroot: trimmed runtime stdlib (no tests) ---
+    sysroot_pkg = tmp_dir / "sysroot"
+    sysroot_lib = sysroot_pkg / "lib"
+    sysroot_lib.mkdir(parents=True)
 
     py_lib = sysroot_installed / "lib" / config.PYTHON_LIB_DIR
     if py_lib.is_dir():
-        shutil.copytree(py_lib, ramfs_sysroot / config.PYTHON_LIB_DIR)
+        shutil.copytree(py_lib, sysroot_lib / config.PYTHON_LIB_DIR)
 
-    ramfs_mod.trim_sysroot(ramfs_staging)
+    # Wrap in a staging dir for ramfs_mod.trim_sysroot (expects sysroot/ child).
+    trim_wrap = tmp_dir / "_trim_wrap"
+    trim_wrap.mkdir()
+    # Move sysroot_pkg into trim_wrap/sysroot for trimming.
+    sysroot_in_wrap = trim_wrap / "sysroot"
+    sysroot_pkg.rename(sysroot_in_wrap)
+    ramfs_mod.trim_sysroot(trim_wrap, keep_tests=False)
+    # Move back.
+    sysroot_in_wrap.rename(sysroot_pkg)
+    shutil.rmtree(trim_wrap)
 
     # --- Include python.elf binary ---
-    bin_dir = release_staging / "bin"
+    bin_dir = tmp_dir / "bin"
     python_elf = repo_root / f"python{config.EXE}"
     if python_elf.is_file():
         bin_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(python_elf, bin_dir / "python.elf")
         size = (bin_dir / "python.elf").stat().st_size
-        print(f"Included bin/python.elf ({size // 1024}K)")
+        print(f"  Included bin/python.elf ({size // 1024}K)")
     else:
-        print("Warning: python.elf not found — binary will not be included in release")
+        print(
+            "  Warning: python.elf not found — binary will not be "
+            "included in build output"
+        )
 
-    # --- Build ramfs image ---
-    ramfs_img = release_staging / "cpython-ramfs.img"
-    ramfs_mod.build_image(ramfs_staging, nanvix_home, ramfs_img)
+    # --- Build ramfs image (no tests) ---
+    ramfs_img = tmp_dir / "cpython-ramfs.img"
+    # ramfs_mod.build_image expects staging/sysroot — re-wrap temporarily.
+    ramfs_wrap = tmp_dir / "_ramfs_wrap"
+    ramfs_wrap.mkdir()
+    shutil.copytree(sysroot_pkg, ramfs_wrap / "sysroot")
+    # Ensure /tmp exists in ramfs for tempfile.gettempdir().
+    (ramfs_wrap / "sysroot" / "tmp").mkdir(exist_ok=True)
+    ramfs_mod.build_image(ramfs_wrap, nanvix_home_path, ramfs_img)
+    shutil.rmtree(ramfs_wrap)
 
-    # --- Create release tarballs ---
+    # --- Write manifest ---
+    manifest = {
+        "platform": platform,
+        "process_mode": process_mode,
+        "memory_size": memory_size,
+        "install_prefix": install_prefix,
+        "python_version": config.PYTHON_VERSION,
+        "release": True,
+    }
+    manifest_path = tmp_dir / _MANIFEST_NAME
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    # --- Remove temporary install tree (not part of output) ---
+    shutil.rmtree(install_staging)
+
+    # --- Atomic swap ---
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    shutil.move(str(tmp_dir), str(output_dir))
+
+    print("Build output ready:")
+    print(f"  {output_dir / 'sysroot'}")
+    print(f"  {output_dir / 'buildroot'}")
+    print(f"  {output_dir / 'bin' / 'python.elf'}")
+    print(f"  {output_dir / 'cpython-ramfs.img'}")
+
+    return output_dir
+
+
+# ---------------------------------------------------------------------------
+# Release packaging (called by ./z release)
+# ---------------------------------------------------------------------------
+
+
+def package(
+    repo_root: Path,
+    *,
+    platform: str = config.DEFAULT_PLATFORM,
+    process_mode: str = config.DEFAULT_PROCESS_MODE,
+    memory_size: str = config.DEFAULT_MEMORY_SIZE,
+) -> None:
+    """Package the build output into release archives.
+
+    Reads from the persistent build output directory produced by
+    ``./z build`` and creates:
+    - On Linux: ``.tar.bz2`` archives in ``dist/``
+    - On Windows: ``.zip`` archives in ``dist/``
+
+    Raises FileNotFoundError if ./z build has not been run.
+    Raises ValueError if the build output does not match the current config.
+    """
+    output_dir = build_output_path(repo_root)
+    dist_dir = repo_root / "dist"
+    artifact = _artifact_base(platform, process_mode, memory_size)
+
+    # Validate build output exists.
+    if not output_dir.is_dir():
+        raise FileNotFoundError(
+            f"Build output not found at {output_dir}. "
+            "Run `./z build` first to produce release-ready artifacts."
+        )
+
+    # Validate manifest matches current config.
+    manifest_path = output_dir / _MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"Manifest not found at {manifest_path}. "
+            "The build output may be corrupt. Run `./z build` again."
+        )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    _validate_manifest(manifest, platform, process_mode, memory_size)
+
+    # Validate expected contents.
+    sysroot_dir = output_dir / "sysroot"
+    buildroot_dir = output_dir / "buildroot"
+    bin_dir = output_dir / "bin"
+    ramfs_img = output_dir / "cpython-ramfs.img"
+
+    if not sysroot_dir.is_dir():
+        raise FileNotFoundError(f"Sysroot directory missing: {sysroot_dir}")
+    if not buildroot_dir.is_dir():
+        raise FileNotFoundError(f"Buildroot directory missing: {buildroot_dir}")
+
+    print("Packaging CPython release...")
+
     dist_dir.mkdir(parents=True, exist_ok=True)
 
+    if config.IS_WINDOWS:
+        _package_zip(dist_dir, artifact, sysroot_dir, buildroot_dir, bin_dir, ramfs_img)
+    else:
+        _package_tar(dist_dir, artifact, sysroot_dir, buildroot_dir, bin_dir, ramfs_img)
+
+    print("Release archives created in dist/")
+    for f in sorted(dist_dir.iterdir()):
+        if f.name.startswith(artifact):
+            size = f.stat().st_size
+            print(f"  {f.name} ({size // 1024}K)")
+
+
+def _validate_manifest(
+    manifest: dict[str, object],
+    platform: str,
+    process_mode: str,
+    memory_size: str,
+) -> None:
+    """Raise ValueError if manifest does not match the requested config."""
+    mismatches: list[str] = []
+    if manifest.get("platform") != platform:
+        mismatches.append(
+            f"platform: got '{manifest.get('platform')}', expected '{platform}'"
+        )
+    if manifest.get("process_mode") != process_mode:
+        mismatches.append(
+            f"process_mode: got '{manifest.get('process_mode')}', "
+            f"expected '{process_mode}'"
+        )
+    if manifest.get("memory_size") != memory_size:
+        mismatches.append(
+            f"memory_size: got '{manifest.get('memory_size')}', "
+            f"expected '{memory_size}'"
+        )
+    if mismatches:
+        raise ValueError(
+            "Build output does not match current configuration. "
+            "Run `./z build` again.\n  " + "\n  ".join(mismatches)
+        )
+
+
+def _package_tar(
+    dist_dir: Path,
+    artifact: str,
+    sysroot_dir: Path,
+    buildroot_dir: Path,
+    bin_dir: Path,
+    ramfs_img: Path,
+) -> None:
+    """Create .tar.bz2 release archives."""
     # Sysroot tarball.
     sysroot_tar = dist_dir / f"{artifact}.tar.bz2"
-    sysroot_runtime = ramfs_staging / "sysroot"
     with tarfile.open(str(sysroot_tar), "w:bz2") as tf:
-        tf.add(str(sysroot_runtime), arcname="sysroot")
+        tf.add(str(sysroot_dir), arcname="sysroot")
         if bin_dir.is_dir():
             tf.add(str(bin_dir), arcname="bin")
         if ramfs_img.is_file():
             tf.add(str(ramfs_img), arcname="cpython-ramfs.img")
 
-    # Buildroot tarball.
+    # Buildroot tarball (arcname="sysroot" for backward compatibility).
     buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.bz2"
     with tarfile.open(str(buildroot_tar), "w:bz2") as tf:
-        tf.add(str(buildroot_pkg), arcname="sysroot")
+        tf.add(str(buildroot_dir), arcname="sysroot")
 
-    # Cleanup staging.
-    shutil.rmtree(release_staging)
 
-    print("Release tarballs created in dist/")
-    for f in sorted(dist_dir.glob(f"{artifact}*.tar.bz2")):
-        size = f.stat().st_size
-        print(f"  {f.name} ({size // 1024}K)")
+def _package_zip(
+    dist_dir: Path,
+    artifact: str,
+    sysroot_dir: Path,
+    buildroot_dir: Path,
+    bin_dir: Path,
+    ramfs_img: Path,
+) -> None:
+    """Create .zip release archives."""
+    # Sysroot zip.
+    sysroot_zip_path = dist_dir / f"{artifact}.zip"
+    with zipfile.ZipFile(str(sysroot_zip_path), "w", zipfile.ZIP_DEFLATED) as zf:
+        _add_dir_to_zip(zf, sysroot_dir, "sysroot")
+        if bin_dir.is_dir():
+            _add_dir_to_zip(zf, bin_dir, "bin")
+        if ramfs_img.is_file():
+            zf.write(str(ramfs_img), "cpython-ramfs.img")
+
+    # Buildroot zip (arcname prefix "sysroot" for backward compatibility).
+    buildroot_zip_path = dist_dir / f"{artifact}-buildroot.zip"
+    with zipfile.ZipFile(str(buildroot_zip_path), "w", zipfile.ZIP_DEFLATED) as zf:
+        _add_dir_to_zip(zf, buildroot_dir, "sysroot")
+
+
+def _add_dir_to_zip(zf: zipfile.ZipFile, src_dir: Path, arcname: str) -> None:
+    """Recursively add a directory to a zip file."""
+    for file_path in sorted(src_dir.rglob("*")):
+        if file_path.is_file():
+            rel = file_path.relative_to(src_dir)
+            zf.write(str(file_path), f"{arcname}/{rel}")
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
 
 
 def verify(
@@ -217,32 +420,44 @@ def verify(
     process_mode: str = config.DEFAULT_PROCESS_MODE,
     memory_size: str = config.DEFAULT_MEMORY_SIZE,
 ) -> None:
-    """Verify release tarballs.
+    """Verify release archives.
 
-    Checks that tarballs exist, are not corrupt, and contain the
-    expected contents.
+    Checks that archives exist, are not corrupt, and contain the
+    expected contents. Supports both .tar.bz2 and .zip formats.
     """
     artifact = _artifact_base(platform, process_mode, memory_size)
     dist_dir = repo_root / "dist"
 
-    print("Verifying release tarballs...")
+    print("Verifying release archives...")
 
+    # Determine format.
     sysroot_tar = dist_dir / f"{artifact}.tar.bz2"
+    sysroot_zip = dist_dir / f"{artifact}.zip"
     buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.bz2"
+    buildroot_zip = dist_dir / f"{artifact}-buildroot.zip"
 
-    if not sysroot_tar.is_file():
-        raise FileNotFoundError(f"Sysroot tarball not found: {sysroot_tar}")
-    if not buildroot_tar.is_file():
-        raise FileNotFoundError(f"Buildroot tarball not found: {buildroot_tar}")
+    if sysroot_tar.is_file():
+        with tarfile.open(str(sysroot_tar), "r:bz2") as tf:
+            members = tf.getnames()
+        if not buildroot_tar.is_file():
+            raise FileNotFoundError(f"Buildroot tarball not found: {buildroot_tar}")
+        with tarfile.open(str(buildroot_tar), "r:bz2") as tf:
+            _ = tf.getnames()
+    elif sysroot_zip.is_file():
+        with zipfile.ZipFile(str(sysroot_zip), "r") as zf:
+            members = zf.namelist()
+        if not buildroot_zip.is_file():
+            raise FileNotFoundError(f"Buildroot zip not found: {buildroot_zip}")
+        with zipfile.ZipFile(str(buildroot_zip), "r") as zf:
+            _ = zf.namelist()
+    else:
+        raise FileNotFoundError(
+            f"No release archive found for '{artifact}' in {dist_dir}. "
+            "Expected .tar.bz2 or .zip files."
+        )
 
-    # Verify integrity.
-    with tarfile.open(str(sysroot_tar), "r:bz2") as tf:
-        members = tf.getnames()
-    with tarfile.open(str(buildroot_tar), "r:bz2") as tf:
-        _ = tf.getnames()
-
-    # Verify python.elf is present (exact path match).
+    # Verify python.elf is present.
     if "bin/python.elf" not in members:
-        raise ValueError("Sysroot tarball missing bin/python.elf")
+        raise ValueError("Release archive missing bin/python.elf")
 
     print("\t\t*** Package verification PASSED ***")

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -428,7 +428,7 @@ def stage(
         shutil.copy2(regrtest_runner, sysroot_dir / "run-regrtest.py")
 
     # Invalidate stale ramfs image and cache from previous runs.
-    stale_ramfs = repo_root / ".nanvix" / "cpython-rootfs.img"
+    stale_ramfs = repo_root / ".nanvix" / "cpython_test-ramfs.img"
     if stale_ramfs.is_file():
         stale_ramfs.unlink()
     stale_cache = repo_root / ".nanvix" / "_ramfs_cache"
@@ -456,7 +456,7 @@ def stage_ramfs(
     Returns the path to the ramfs image.
     """
     if ramfs_img is None:
-        ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
+        ramfs_img = repo_root / ".nanvix" / "cpython_test-ramfs.img"
 
     ramfs_cache = repo_root / ".nanvix" / "_ramfs_cache"
 
@@ -646,7 +646,7 @@ def run_regrtest(
     if standalone:
         # Standalone: ramfs + semicolon env syntax.
         if ramfs_img is None:
-            ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
+            ramfs_img = repo_root / ".nanvix" / "cpython_test-ramfs.img"
         extra_str = f"-bin-dir ./bin -ramfs {ramfs_img}"
         if resolved_nanvixd_extra:
             extra_str += " " + " ".join(resolved_nanvixd_extra)
@@ -680,6 +680,13 @@ def cleanup(repo_root: Path) -> None:
     staging = repo_root / ".nanvix" / "_test_staging"
     if staging.is_dir():
         shutil.rmtree(staging)
+    # Remove test ramfs image.
+    test_ramfs = repo_root / ".nanvix" / "cpython_test-ramfs.img"
+    if test_ramfs.is_file():
+        test_ramfs.unlink()
+    ramfs_cache = repo_root / ".nanvix" / "_ramfs_cache"
+    if ramfs_cache.is_dir():
+        shutil.rmtree(ramfs_cache)
     for name in [
         "cpython_test.log",
         "cpython_regrtest.log",
@@ -688,17 +695,6 @@ def cleanup(repo_root: Path) -> None:
         p = repo_root / ".nanvix" / name
         if p.is_file():
             p.unlink()
-
-
-def deep_cleanup(repo_root: Path) -> None:
-    """Deep clean: remove cached ramfs template."""
-    cleanup(repo_root)
-    ramfs_cache = repo_root / ".nanvix" / "_ramfs_cache"
-    if ramfs_cache.is_dir():
-        shutil.rmtree(ramfs_cache)
-    ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
-    if ramfs_img.is_file():
-        ramfs_img.unlink()
 
 
 # ---------------------------------------------------------------------------

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -5,9 +5,9 @@
 
 Usage:
     ./z setup      # Download Nanvix sysroot and dependencies
-    ./z build      # Cross-compile python.elf and libpython.a
-    ./z test       # Run test suite (hello-world on nanvixd.elf)
-    ./z release    # Package release tarballs (sysroot + buildroot)
+    ./z build      # Cross-compile + produce release-ready sysroot/buildroot/ramfs
+    ./z test       # Build test sysroot, run test suite
+    ./z release    # Package build output into archives (tar.bz2 or zip)
     ./z clean      # Remove build artifacts
     ./z distclean  # Deep clean (build artifacts + untracked files)
 
@@ -314,17 +314,33 @@ class CPythonBuild(ZScript):
         return used_fallback
 
     def build(self) -> None:
-        """Cross-compile python.elf and libpython.a for Nanvix."""
+        """Cross-compile python.elf and libpython.a, then stage build output."""
         self._overlay_local_nanvix()
         sysroot, toolchain = self._get_host_paths()
         release = os.environ.get(_MAKE_VAR_RELEASE, "no") == "yes"
+        docker = self.docker is not None
+
+        # Compile.
         build_mod.build(
             sysroot,
             toolchain,
             self.repo_root,
             **self._build_kwargs(release=release),
             run_fn=lambda *args, **kw: self.run(*args, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
+            docker=docker,
+        )
+
+        # Produce persistent release-ready output (sysroot, buildroot, ramfs).
+        stage_kwargs = self._build_kwargs(release=True)
+        stage_kwargs.pop("release", None)
+        package_mod.stage_build_output(
+            sysroot,
+            toolchain,
+            self.repo_root,
+            **stage_kwargs,
+            run_fn=lambda *args, **kw: self.run(*args, **kw),  # type: ignore[arg-type]
+            nanvix_home=sysroot,
+            docker=docker,
         )
 
     def test(self) -> None:
@@ -343,18 +359,15 @@ class CPythonBuild(ZScript):
         )
 
     def release(self) -> None:
-        """Package the CPython release tarballs and verify them."""
+        """Package the build output into release archives and verify them."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_host_paths()
         kwargs = self._build_kwargs(release=True)
 
         package_mod.package(
-            sysroot,
-            toolchain,
             self.repo_root,
-            **kwargs,
-            run_fn=lambda *args, **kw: self.run(*args, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
+            platform=kwargs["platform"],
+            process_mode=kwargs["process_mode"],
+            memory_size=kwargs["memory_size"],
         )
         package_mod.verify(
             self.repo_root,

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -55,13 +55,13 @@ pip install nanvix-zutil
 # 2. Setup (downloads Nanvix sysroot and all dependencies automatically)
 ./z setup
 
-# 3. Build
+# 3. Build (compiles + produces release-ready sysroot, buildroot, and ramfs)
 ./z build
 
-# 4. Test
+# 4. Test (builds test sysroot with test files and runs tests)
 ./z test
 
-# 5. Package release tarballs
+# 5. Package release archives (tarballs on Linux, zip on Windows)
 ./z release
 ```
 
@@ -193,12 +193,20 @@ make -f Makefile.nanvix CONFIG_NANVIX=y all
 
 ### Build Outputs
 
-After a successful build, you will have:
+After a successful `./z build`, you will have:
 
 | File | Description |
 |------|-------------|
-| `python.elf` | Python interpreter executable |
-| `libpython3.12.a` | Python static library |
+| `python.elf` | Python interpreter executable (in repo root) |
+| `libpython3.12.a` | Python static library (in repo root) |
+| `.nanvix/_build_output/sysroot/` | Trimmed runtime stdlib (no tests) |
+| `.nanvix/_build_output/buildroot/` | Build dependencies (headers, .a, pkgconfig) |
+| `.nanvix/_build_output/bin/python.elf` | Stripped interpreter binary |
+| `.nanvix/_build_output/cpython-ramfs.img` | RAM filesystem image (no tests) |
+| `.nanvix/_build_output/manifest.json` | Build metadata for release validation |
+
+The build output directory is persistent and is consumed by `./z release`
+to produce distributable archives.
 
 ---
 
@@ -220,6 +228,10 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix test
 > created by `make test` and removed automatically at the end of a successful
 > run. To use the interactive or individual-module commands below, run
 > `make test` first (or interrupt it after the staging step completes).
+>
+> Alternatively, after `./z build`, you can use the persistent build output
+> directly with the ramfs image at `.nanvix/_build_output/cpython-ramfs.img`
+> (which does not include test files).
 
 ### Running Interactively
 
@@ -227,7 +239,7 @@ To start an interactive CPython session on Nanvix (standalone/microvm):
 
 ```bash
 cd .nanvix/_test_staging/sysroot && \
-  ./bin/nanvixd.elf -bin-dir ./bin -ramfs ../../cpython-rootfs.img \
+  ./bin/nanvixd.elf -bin-dir ./bin -ramfs ../../cpython_test-ramfs.img \
     -- ./bin/python3.12 \
     "-i;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1 _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata__nanvix_"
 ```
@@ -251,7 +263,7 @@ To run a one-shot script instead of the REPL:
 
 ```bash
 cd .nanvix/_test_staging/sysroot && \
-  ./bin/nanvixd.elf -bin-dir ./bin -ramfs ../../cpython-rootfs.img \
+  ./bin/nanvixd.elf -bin-dir ./bin -ramfs ../../cpython_test-ramfs.img \
     -- ./bin/python3.12 \
     "-B ./test_hello.py;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1 _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata__nanvix_"
 ```
@@ -262,7 +274,7 @@ To run a single test module inside the Nanvix VM:
 
 ```bash
 cd .nanvix/_test_staging/sysroot && \
-  ./bin/nanvixd.elf -bin-dir ./bin -ramfs ../../cpython-rootfs.img \
+  ./bin/nanvixd.elf -bin-dir ./bin -ramfs ../../cpython_test-ramfs.img \
     -- ./bin/python3.12 \
     "-B -m test --verbose test_int;PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1 NANVIX_STANDALONE=1 _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata__nanvix_"
 ```


### PR DESCRIPTION
Split the monolithic `package()` function into a two-phase workflow:

1. `./z build` now calls `stage_build_output()` which produces persistent release-ready artifacts in `.nanvix/_build_output/` (sysroot, buildroot, bin/python.elf, cpython-ramfs.img, and manifest.json).

2. `./z release` now calls a simplified `package()` that reads from the pre-built output directory and creates distributable archives (.tar.bz2 on Linux, .zip on Windows).

This eliminates the need for `./z release` to trigger a full rebuild, enables incremental workflows, and adds Windows zip archive support.

### Additional changes

- Add `manifest.json` for build output validation (platform, mode, memory size) so `./z release` rejects stale or mismatched artifacts.
- Use atomic directory swap (`_build_output.tmp` → `_build_output`) for crash safety during staging.
- Rename test ramfs image from `cpython-rootfs.img` to `cpython_test-ramfs.img` to avoid confusion with build output ramfs.
- Consolidate test cleanup: merge `deep_cleanup()` into `cleanup()` and remove the now-unused function.
- Clean `_build_output` and `_build_output.tmp` directories in `./z clean`.
- Update NANVIX.md with new build outputs table and corrected commands.