### PR TITLE
ci: enable hyperlight platform in build matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,10 +28,12 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.44"
-      platforms: '["microvm"]'
+      platforms: '["hyperlight","microvm"]'
       memory-sizes: '["256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight"}]'
-      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+         {"platform":"hyperlight","process-mode":"single-process"}]
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
@@ -49,10 +51,12 @@ jobs:
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.14.0
     with:
       zutil-version: "v0.7.44"
-      platforms: '["microvm"]'
+      platforms: '["hyperlight","microvm"]'
       memory-sizes: '["256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight"}]'
-      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
+      matrix-exclude: >-
+        [{"platform":"hyperlight","process-mode":"multi-process"},
+         {"platform":"hyperlight","process-mode":"single-process"}]
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -5,7 +5,7 @@ nanvix-version = "0.12.529"
 
 [builds]
 [builds.matrix]
-platforms = ["microvm"]
+platforms = ["hyperlight", "microvm"]
 modes = ["multi-process", "single-process", "standalone"]
 memory = ["256mb"]
 


### PR DESCRIPTION
## Summary
- Add `hyperlight` to the platform list in `nanvix.toml` and `nanvix-ci.yml`
- Only enable standalone mode (exclude multi-process and single-process for hyperlight)
- Enable Windows test matrix for hyperlight

Mirrors the same change already landed in zlib, sqlite, libxml2, libxslt, lxml, and nanvix-python.