### PR TITLE
ci: remove hyperlight from CI matrix

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -30,8 +30,7 @@ jobs:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight"}]'
-      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: ${{ github.event_name }}
       windows-test: true
@@ -51,8 +50,7 @@ jobs:
       zutil-version: "v0.7.48"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
-      matrix-exclude: '[{"platform":"hyperlight"}]'
-      windows-matrix-exclude: '[{"platform":"hyperlight"}]'
+      windows-matrix-exclude: '[]'
       skip-full-test-modes: '[]'
       caller-event-name: 'schedule'
       windows-test: true


### PR DESCRIPTION
Remove hyperlight platform from CI matrix configuration. This removes hyperlight from `platforms`, cleans up `matrix-exclude` and `windows-matrix-exclude` entries that were only needed for hyperlight.