### PR TITLE
[ci] Sync zutils v0.7.48

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.12.536"
+nanvix-version = "0.12.538"
 
 [builds]
 [builds.matrix]


### PR DESCRIPTION
Automated sync with [`v0.7.48`](https://github.com/nanvix/zutils/releases/tag/v0.7.48):
- Bumps `zutil-version` in caller workflows.
- Copies bootstrapper templates (`z`, `z.sh`, `z.ps1`) from release assets.
- Pins `nanvix-version` to `0.12.538` in `.nanvix/nanvix.toml`.

Generated by the [Update Zutils](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-zutils.yml) workflow.