### PR TITLE
feat: ship toolchain-python Docker image for cross-compilation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
     labels:
       - "skip issue"
       - "skip news"
+  - package-ecosystem: "docker"
+    directory: "/.nanvix/docker"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "skip issue"
+      - "skip news"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,59 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: Docker Image
+
+on:
+  push:
+    branches: ["nanvix/**"]
+    paths:
+      - ".nanvix/docker/Dockerfile"
+      - ".github/workflows/docker-image.yml"
+  pull_request:
+    branches: ["nanvix/**"]
+    paths:
+      - ".nanvix/docker/Dockerfile"
+      - ".github/workflows/docker-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nanvix/toolchain-python
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .nanvix/docker
+          file: .nanvix/docker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -16,7 +16,7 @@ from pathlib import Path
 # Platform defaults
 # ---------------------------------------------------------------------------
 
-DOCKER_IMAGE = "nanvix/toolchain:latest-minimal"
+DOCKER_IMAGE = "ghcr.io/nanvix/toolchain-python:latest"
 DEFAULT_PLATFORM = "microvm"
 DEFAULT_PROCESS_MODE = "standalone"
 DEFAULT_MEMORY_SIZE = "256mb"

--- a/.nanvix/docker/Dockerfile
+++ b/.nanvix/docker/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# toolchain-python — Nanvix GCC toolchain + host Python 3 for CPython
+# cross-compilation.  Published as ghcr.io/nanvix/toolchain-python.
+
+FROM ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /opt/nanvix/bin/python3

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -69,7 +69,7 @@ pip install nanvix-zutil
 
 ```bash
 # 1. Pull the Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-python:latest
 
 # 2. Download Nanvix sysroot
 curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh | bash -s -- nanvix-artifacts
@@ -150,7 +150,7 @@ The Makefile supports automatic Docker fallback when the native toolchain is not
 
 ```bash
 # Pull the Nanvix toolchain Docker image
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-python:latest
 
 # Build (Docker is used automatically if native toolchain is not found)
 make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debug
@@ -164,7 +164,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`; recommended: `ghcr.io/nanvix/toolchain-python:latest`)
 
 ### Building on Windows
 
@@ -173,7 +173,7 @@ On Windows, cross-compilation is performed entirely inside Docker:
 ```powershell
 # Prerequisites: Python 3, Make, and Docker Desktop must be installed and running.
 # Avoid GnuWin32 Make 3.81; prefer ezwinports Make 4.4.1 (winget install ezwinports.make).
-docker pull nanvix/toolchain:latest-minimal
+docker pull ghcr.io/nanvix/toolchain-python:latest
 
 .\z.ps1 setup
 .\z.ps1 build


### PR DESCRIPTION
## Summary

Ship a derived Docker image (`ghcr.io/nanvix/toolchain-python`) that layers Python 3 on top of `ghcr.io/nanvix/toolchain-gcc:sha-34a3641`, providing the host Python 3 interpreter required for CPython cross-compilation (`--with-build-python`).

## Changes

| File | Change |
|------|--------|
| `.nanvix/docker/Dockerfile` | New — derived image from `toolchain-gcc` + `python3` + `python3-dev` |
| `.github/workflows/docker-image.yml` | New — CI to build & publish to GHCR on push |
| `Makefile.nanvix` | Update `NANVIX_DOCKER_IMAGE` to `ghcr.io/nanvix/toolchain-python:latest`; `BUILD_PYTHON` to `/usr/bin/python3` |
| `.nanvix/config.py` | Update `DOCKER_IMAGE` constant and `build_python` path |
| `NANVIX.md` | Update `docker pull` instructions |

## Validation

- Built image locally and ran full CPython cross-compilation successfully
- `python3` available at `/usr/bin/python3` (Python 3.12.3)
- GCC toolchain intact at `/opt/nanvix/`
- 77 built-in modules compiled, `python.elf` produced (15M stripped)

Closes #612