### PR TITLE
fix: update docker image reference

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -19,7 +19,7 @@
 #   - liblzma (liblzma.a in NANVIX_HOME/lib)
 
 # Nanvix Docker image for cross-compilation
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+NANVIX_DOCKER_IMAGE ?= ghcr.io/nanvix/toolchain-gcc:latest
 
 # Platform and deployment configuration
 PLATFORM ?= microvm


### PR DESCRIPTION
## Summary

Update stale Docker image reference in Makefile.nanvix.

### Changes
- Update Docker image from `nanvix/toolchain:latest-minimal` to `ghcr.io/nanvix/toolchain-gcc:latest`

### Background
The Docker image was migrated from Docker Hub to GitHub Container Registry. This updates the stale reference.