### PR TITLE
ci: bump workflows to v2.0.0 and zutils to v0.8.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,9 +25,9 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
@@ -46,9 +46,9 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v1.15.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
     with:
-      zutil-version: "v0.7.48"
+      zutil-version: "v0.8.1"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
@@ -62,7 +62,7 @@ jobs:
 
   # -------------------------------------------------------------------
   # Create a Windows zip release asset for MXC consumption.
-  # The reusable workflow creates a GitHub release with .tar.bz2 assets.
+  # The reusable workflow creates a GitHub release with .tar.gz assets.
   # This job downloads the standalone tarball from that release, extracts
   # python.elf + cpython-ramfs.img, packs them into a flat .zip, and
   # uploads it to the same release.
@@ -94,7 +94,7 @@ jobs:
           sleep 5
 
           # Download standalone tarballs (exclude buildroot variant)
-          gh release download "$RELEASE_TAG" --pattern "*standalone*.tar.bz2" --dir release-download || true
+          gh release download "$RELEASE_TAG" --pattern "*standalone*.tar.gz" --dir release-download || true
           ls -la release-download/
 
       - name: Create Windows zip
@@ -104,7 +104,7 @@ jobs:
           set -euo pipefail
 
           # Find the main standalone tarball (not buildroot)
-          TARBALL=$(find release-download -name "*standalone*.tar.bz2" ! -name "*buildroot*" | head -1)
+          TARBALL=$(find release-download -name "*standalone*.tar.gz" ! -name "*buildroot*" | head -1)
           if [[ -z "$TARBALL" ]]; then
             echo "::warning::No standalone tarball found (excluding buildroot)"
             ls release-download/ 2>/dev/null || true
@@ -113,7 +113,7 @@ jobs:
           echo "Using tarball: $TARBALL"
 
           mkdir -p extract windows-zip
-          tar -xjf "$TARBALL" -C extract
+          tar -xzf "$TARBALL" -C extract
 
           # Find the python binary — it's at bin/python.elf
           PYTHON_ELF=$(find extract -name "python.elf" -type f | head -1)
@@ -153,10 +153,10 @@ jobs:
             curl -fsSL https://raw.githubusercontent.com/nanvix/nanvix/refs/heads/dev/scripts/get-nanvix.sh \
               | bash -s -- --force nanvix-dl
             MKRAMFS=""
-            NVX_TAR=$(find nanvix-dl -name "nanvix-microvm-standalone-*.tar.bz2" | head -1)
+            NVX_TAR=$(find nanvix-dl -name "nanvix-microvm-standalone-*.tar.gz" | head -1)
             if [[ -n "$NVX_TAR" ]]; then
               mkdir -p nanvix-extract
-              tar -xjf "$NVX_TAR" -C nanvix-extract
+              tar -xzf "$NVX_TAR" -C nanvix-extract
               MKRAMFS=$(find nanvix-extract -name "mkramfs.elf" -type f | head -1)
             fi
 

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.12.538"
+nanvix-version = "0.12.547"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -276,13 +276,38 @@ class CPythonBuild(ZScript):
         if local_nanvix:
             local_nanvix = os.path.abspath(os.path.expanduser(local_nanvix))
 
+        # Dependencies are now shipped as .tar.gz; override the default
+        # artifact_pattern (which still targets .tar.bz2 in zutil <=0.8.1).
+        _gz = "{name}-{machine}-{mode}-{mem}.tar.gz"
+        for dep in self.manifest.dependencies:  # type: ignore[attr-defined]
+            dep.artifact_pattern = _gz  # type: ignore[attr-defined]
+
         used_fallback = False
         if local_nanvix and os.path.isdir(local_nanvix):
             self._setup_from_local_nanvix(local_nanvix)
         else:
-            # Base class handles: download sysroot, download Windows
-            # binaries (if on Windows), verify required files.
-            used_fallback = super().setup()
+            # Monkey-patch tarfile.open to auto-detect compression so that
+            # buildroot.install_dep (which hardcodes "r:bz2") can extract
+            # .tar.gz archives produced by newer dependency releases.
+            _orig_tarfile_open = tarfile.open
+
+            def _tarfile_open_auto(
+                name: object = None,
+                mode: str = "r",
+                *args: object,
+                **kwargs: object,
+            ) -> tarfile.TarFile:
+                if mode == "r:bz2":
+                    mode = "r:*"
+                return _orig_tarfile_open(name, mode, *args, **kwargs)  # type: ignore[arg-type]
+
+            tarfile.open = _tarfile_open_auto  # type: ignore[assignment]
+            try:
+                # Base class handles: download sysroot, download Windows
+                # binaries (if on Windows), verify required files.
+                used_fallback = super().setup()
+            finally:
+                tarfile.open = _orig_tarfile_open  # type: ignore[assignment]
 
         self._install_missing_deps()
 

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.7.48"
+    "0.8.1"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.7.48"
+PINNED_VERSION="0.8.1"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"


### PR DESCRIPTION
## Summary

Adapt caller workflow to breaking changes introduced by:

- `nanvix/workflows` v2.0.0 — `docker-image` is now a required input (no default).
- `nanvix/zutils` v0.8.0 — `setup --with-docker` requires an explicit image argument.

### Changes

- Bump `nanvix/workflows` from `v1.15.0` → `v2.0.0`
- Bump `zutil-version` from `v0.7.48` → `v0.8.1`
- Add required `docker-image` input to both `ci` and `ci-scheduled` jobs
- Update `z.sh` and `z.ps1` pinned versions to `0.8.1`
- Bump `nanvix-version` to `0.12.547` in `nanvix.toml`
- Override dependency artifact_pattern to `.tar.gz` and monkey-patch tarfile.open for bz2→gz compat
- Update windows-zip job to handle `.tar.gz` release assets

Supersedes: #630, #628