### PR TITLE
fix: migrate release tarballs from .tar.bz2 to .tar.gz

### DIFF
--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -51,8 +51,8 @@ def package(
     """Package CPython release tarballs.
 
     Creates two tarballs in ``dist/``:
-    - ``cpython-<platform>-<mode>-<memory>.tar.bz2`` — runtime sysroot + binary + ramfs
-    - ``cpython-<platform>-<mode>-<memory>-buildroot.tar.bz2`` — build dependencies
+    - ``cpython-<platform>-<mode>-<memory>.tar.gz`` — runtime sysroot + binary + ramfs
+    - ``cpython-<platform>-<mode>-<memory>-buildroot.tar.gz`` — build dependencies
 
     Args:
         nanvix_home: Host-side path to the Nanvix sysroot for local
@@ -187,9 +187,9 @@ def package(
     dist_dir.mkdir(parents=True, exist_ok=True)
 
     # Sysroot tarball.
-    sysroot_tar = dist_dir / f"{artifact}.tar.bz2"
+    sysroot_tar = dist_dir / f"{artifact}.tar.gz"
     sysroot_runtime = ramfs_staging / "sysroot"
-    with tarfile.open(str(sysroot_tar), "w:bz2") as tf:
+    with tarfile.open(str(sysroot_tar), "w:gz") as tf:
         tf.add(str(sysroot_runtime), arcname="sysroot")
         if bin_dir.is_dir():
             tf.add(str(bin_dir), arcname="bin")
@@ -197,15 +197,15 @@ def package(
             tf.add(str(ramfs_img), arcname="cpython-ramfs.img")
 
     # Buildroot tarball.
-    buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.bz2"
-    with tarfile.open(str(buildroot_tar), "w:bz2") as tf:
+    buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.gz"
+    with tarfile.open(str(buildroot_tar), "w:gz") as tf:
         tf.add(str(buildroot_pkg), arcname="sysroot")
 
     # Cleanup staging.
     shutil.rmtree(release_staging)
 
     print("Release tarballs created in dist/")
-    for f in sorted(dist_dir.glob(f"{artifact}*.tar.bz2")):
+    for f in sorted(dist_dir.glob(f"{artifact}*.tar.gz")):
         size = f.stat().st_size
         print(f"  {f.name} ({size // 1024}K)")
 
@@ -227,8 +227,8 @@ def verify(
 
     print("Verifying release tarballs...")
 
-    sysroot_tar = dist_dir / f"{artifact}.tar.bz2"
-    buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.bz2"
+    sysroot_tar = dist_dir / f"{artifact}.tar.gz"
+    buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.gz"
 
     if not sysroot_tar.is_file():
         raise FileNotFoundError(f"Sysroot tarball not found: {sysroot_tar}")
@@ -236,9 +236,9 @@ def verify(
         raise FileNotFoundError(f"Buildroot tarball not found: {buildroot_tar}")
 
     # Verify integrity.
-    with tarfile.open(str(sysroot_tar), "r:bz2") as tf:
+    with tarfile.open(str(sysroot_tar), "r:gz") as tf:
         members = tf.getnames()
-    with tarfile.open(str(buildroot_tar), "r:bz2") as tf:
+    with tarfile.open(str(buildroot_tar), "r:gz") as tf:
         _ = tf.getnames()
 
     # Verify python.elf is present (exact path match).

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -71,24 +71,27 @@ def _download_release_as_cache(
     tag = release["tag_name"]
     print(f"  Resolved cpython release: {tag}")
 
-    # Find a standalone tarball asset.
+    # Find a standalone tarball asset (.tar.gz preferred, .tar.bz2 fallback).
     asset_prefix = f"cpython-{platform}-{process_mode}-{memory_size}"
     asset_url = None
     asset_name = None
-    for a in release.get("assets", []):
-        name = a.get("name", "")
-        if (
-            name.startswith(asset_prefix)
-            and name.endswith(".tar.bz2")
-            and "buildroot" not in name
-        ):
-            asset_url = a["browser_download_url"]
-            asset_name = name
+    for ext in (".tar.gz", ".tar.bz2"):
+        for a in release.get("assets", []):
+            name = a.get("name", "")
+            if (
+                name.startswith(asset_prefix)
+                and name.endswith(ext)
+                and "buildroot" not in name
+            ):
+                asset_url = a["browser_download_url"]
+                asset_name = name
+                break
+        if asset_url:
             break
 
     if not asset_url:
         raise FileNotFoundError(
-            f"No cpython release asset matching '{asset_prefix}*.tar.bz2' "
+            f"No cpython release asset matching '{asset_prefix}*.tar.gz' or '*.tar.bz2' "
             f"in release {tag}. Available assets: "
             + ", ".join(a["name"] for a in release.get("assets", []))
         )
@@ -104,7 +107,7 @@ def _download_release_as_cache(
 
     # Extract into _install_cache with path-traversal protection.
     print(f"  Extracting to {cache_dir}...")
-    with tarfile.open(tarball, "r:bz2") as tf:
+    with tarfile.open(tarball, "r:*") as tf:
         base = cache_dir.resolve()
         for member in tf.getmembers():
             if member.issym() or member.islnk():


### PR DESCRIPTION
The `windows-zip` CI job (updated in the v2.0.0 workflow bump) expects `.tar.gz` standalone tarballs, but `package.py` was still producing `.tar.bz2`. This mismatch caused the Windows `.zip` release to silently stop being created.

This PR switches all tarball creation and verification in `package.py` from bzip2 to gzip compression to align with the CI workflow expectations.