### PR TITLE
build: migrate Docker image to ghcr.io/nanvix/toolchain-python

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -19,7 +19,7 @@
 #   - liblzma (liblzma.a in NANVIX_HOME/lib)
 
 # Nanvix Docker image for cross-compilation
-NANVIX_DOCKER_IMAGE ?= nanvix/toolchain:latest-minimal
+NANVIX_DOCKER_IMAGE ?= ghcr.io/nanvix/toolchain-python:latest
 
 # Platform and deployment configuration
 PLATFORM ?= microvm

--- a/NANVIX.md
+++ b/NANVIX.md
@@ -164,7 +164,7 @@ make -f Makefile.nanvix CONFIG_NANVIX=y NANVIX_HOME=/path/to/nanvix/sysroot-debu
 - If `NANVIX_TOOLCHAIN` points to a valid toolchain, it uses the native compiler
 - If the native toolchain is not found, it automatically uses Docker if available
 - Use `CONFIG_NANVIX_DOCKER=y` to force Docker usage even when native toolchain exists
-- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `nanvix/toolchain:latest-minimal`; recommended: `ghcr.io/nanvix/toolchain-python:latest`)
+- Use `NANVIX_DOCKER_IMAGE` to specify a custom Docker image (default: `ghcr.io/nanvix/toolchain-python:latest`)
 
 ### Building on Windows
 


### PR DESCRIPTION
## Summary

Migrate Docker image references from the legacy `nanvix/toolchain:latest-minimal` (Docker Hub) to `ghcr.io/nanvix/toolchain-python:latest` (GitHub Container Registry).

## Changes

- **Makefile.nanvix**: Updated `NANVIX_DOCKER_IMAGE` default
- **NANVIX.md**: Updated default image documentation