### PR TITLE
[ci] E: Update nanvix workflow refs to v2.0.1

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
       zutil-version: "v0.8.2"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
@@ -46,7 +46,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: write
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
       zutil-version: "v0.8.2"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.0.1`](https://github.com/nanvix/workflows/releases/tag/v2.0.1).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.