### PR TITLE
Update .gitignore with Nanvix-specific build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,8 @@ Python/frozen_modules/MANIFEST
 # Ignore ./python binary on Unix but still look into ./Python/ directory.
 /python
 !/Python/
+
+# Nanvix build artifacts.
+.nanvix/cpython-rootfs.img
+python.elf
+pyrightconfig.json


### PR DESCRIPTION
Update .gitignore to ignore artifacts that are specific to Nanvix:

- `.nanvix/cpython-rootfs.img`
- `python.elf`
- `pyrightconfig.json`