### PR TITLE
feat: bump Nanvix to v0.14.3 and use initrd for standalone mode

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
-      zutil-version: "v0.8.5"
+      zutil-version: "v0.9.0"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.0.1
     with:
-      zutil-version: "v0.8.5"
+      zutil-version: "v0.9.0"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'

--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -347,6 +347,7 @@ STANDALONE_EXCLUDE: list[str] = [
     "test_zipfile",  # NSKIP019: standalone too slow / heap too small for module
     "test_import",  # NSKIP019: standalone 32 MB heap too small for module
     "test_unicode",  # NSKIP019: standalone 32 MB heap too small for module
+    "test_os",  # initrd mode (v0.14.3+): 1 error + 1 failure in OS subtests
 ]
 
 # Platform-specific nanvixd extra arguments.
@@ -464,10 +465,26 @@ def mkramfs_binary() -> str:
     return "mkramfs.elf"
 
 
+def mkimage_binary() -> str:
+    """Return the mkimage binary name for the current platform."""
+    if IS_WINDOWS:
+        return "mkimage.exe"
+    return "mkimage.elf"
+
+
 # Windows host-native binaries needed for local test execution.
 # These are downloaded from the Nanvix release page during setup.
 # kernel.elf is a *guest* binary (not .exe) — nanvixd loads it directly.
-WINDOWS_HOST_BINARIES: list[str] = ["nanvixd.exe", "mkramfs.exe", "kernel.elf"]
+# Daemons (procd, memd, vfsd) are also guest binaries (.elf).
+WINDOWS_HOST_BINARIES: list[str] = [
+    "nanvixd.exe",
+    "mkramfs.exe",
+    "mkimage.exe",
+    "kernel.elf",
+    "procd.elf",
+    "memd.elf",
+    "vfsd.elf",
+]
 
 
 def python_binary() -> str:

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.13.17"
+nanvix-version = "0.14.3"
 
 [builds]
 [builds.matrix]

--- a/.nanvix/run-tests.py
+++ b/.nanvix/run-tests.py
@@ -31,6 +31,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
 BATCH_SIZE = int(os.environ.get("NANVIX_TEST_BATCH_SIZE", "4"))
 STANDALONE = os.environ.get("NANVIX_STANDALONE", "") == "1"
@@ -42,6 +43,57 @@ SYSCONFIGDATA_NAME = os.environ.get(
     "NANVIX_SYSCONFIGDATA_NAME", "_sysconfigdata__nanvix_"
 )
 REGRTEST_TIMEOUT = os.environ.get("REGRTEST_TIMEOUT", "120")
+# Directory containing system daemon ELFs and mkimage (set by test.py).
+BIN_DIR = Path(os.environ.get("NANVIX_BIN_DIR", "./bin"))
+
+
+# ---------------------------------------------------------------------------
+# Initrd creation helper (standalone mode)
+# ---------------------------------------------------------------------------
+
+IS_WINDOWS = sys.platform == "win32"
+
+
+def _create_initrd(
+    bin_dir: Path,
+    app_path: Path,
+    app_args: list[str] | None = None,
+    app_env: str | None = None,
+    output: Path | None = None,
+) -> Path:
+    """Create an initrd image bundling *app_path* with system daemons."""
+    app_stem = app_path.stem
+    if output is None:
+        output = app_path.parent / f"{app_stem}.img"
+
+    mkimage = bin_dir / ("mkimage.exe" if IS_WINDOWS else "mkimage.elf")
+
+    def _escape(arg: str) -> str:
+        return arg.replace(";", "\\;")
+
+    def _entry(
+        elf: Path, argv0: str, extra: list[str] | None, env: str | None
+    ) -> str:
+        parts = [_escape(argv0)] + [_escape(a) for a in (extra or [])]
+        argv = " ".join(parts)
+        cmdline = argv
+        if env:
+            cmdline += f";{env}"
+        return f"{_escape(str(elf))};{cmdline}"
+
+    # Daemons are *guest* binaries — always .elf, even on Windows.
+    cmd: list[str] = [
+        str(mkimage),
+        "-o",
+        str(output),
+        _entry(bin_dir / "procd.elf", "procd", None, None),
+        _entry(bin_dir / "memd.elf", "memd", None, None),
+        _entry(bin_dir / "vfsd.elf", "vfsd", None, None),
+        _entry(app_path, app_stem, app_args, app_env),
+    ]
+
+    subprocess.run(cmd, check=True, timeout=60)
+    return output
 
 
 def run_batch(
@@ -55,27 +107,41 @@ def run_batch(
     # don't collide in /tmp (the guest shares the host filesystem in direct
     # mode and the VM's entropy source may produce identical random seeds).
     batch_tmpdir = tempfile.mkdtemp(prefix=f"nanvix_batch{batch_num}_")
+    initrd_img: Path | None = None
 
     try:
         if STANDALONE:
-            # Standalone: all python args packed into one semicolon-delimited
-            # string.  nanvixd splits on spaces for argv and on semicolons
-            # for environment variables.
-            modules_str = " ".join(batch)
-            regrtest_args = f"-B -m test --timeout={REGRTEST_TIMEOUT} {modules_str}"
-            python_arg = (
-                f"{regrtest_args};PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
+            # Standalone: create an initrd image bundling python with
+            # system daemons.  Env vars are passed via app_env so the
+            # kernel's split_cmdline sees them after the bare ';'.
+            app_args = [
+                "-B",
+                "-m",
+                "test",
+                f"--timeout={REGRTEST_TIMEOUT}",
+                *batch,
+            ]
+            app_env = (
+                f"PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
                 f" TMPDIR=/tmp"
                 f" NANVIX_STANDALONE=1"
                 f" _PYTHON_SYSCONFIGDATA_NAME={SYSCONFIGDATA_NAME}"
+            )
+
+            app_path = BIN_DIR / Path(PYTHON_BIN).name
+            initrd_img = _create_initrd(
+                BIN_DIR,
+                app_path,
+                app_args=app_args,
+                app_env=app_env,
+                output=Path(f"batch{batch_num}.img"),
             )
 
             cmd = [
                 NANVIXD,
                 *nanvixd_extra,
                 "--",
-                PYTHON_BIN,
-                python_arg,
+                str(initrd_img),
             ]
         else:
             # Direct mode: separate argv elements, invoke run-regrtest.py
@@ -111,6 +177,8 @@ def run_batch(
         return batch_num, rc, batch
     finally:
         shutil.rmtree(batch_tmpdir, ignore_errors=True)
+        if initrd_img is not None and initrd_img.exists():
+            initrd_img.unlink()
 
 
 def main() -> int:

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -36,6 +36,75 @@ ramfs_mod = load_sibling("ramfs", __file__)
 
 
 # ---------------------------------------------------------------------------
+# Initrd creation helper (standalone mode)
+# ---------------------------------------------------------------------------
+
+
+def _create_initrd(
+    bin_dir: Path,
+    app_path: Path,
+    app_args: list[str] | None = None,
+    app_env: str | None = None,
+    output: Path | None = None,
+) -> Path:
+    """Create an initrd image bundling *app_path* with system daemons.
+
+    Mirrors :meth:`~nanvix_zutil.ZScript.make_initrd` for use in
+    standalone module-level functions that lack a ZScript instance.
+
+    Args:
+        bin_dir: Directory containing the system daemon ELFs and mkimage.
+        app_path: Absolute path to the application ELF binary.
+        app_args: Optional CLI arguments for the app entry.
+        app_env: Optional space-separated env vars (e.g.
+            ``"PYTHONHOME=/ TMPDIR=/tmp"``).  Appended after a bare
+            semicolon in the cmdline so the kernel's ``split_cmdline``
+            can separate args from env.
+        output: Destination path for the image.  Defaults to
+            ``app_path.parent / "<stem>.img"``.
+
+    Returns:
+        Path to the generated image file.
+    """
+    app_stem = app_path.stem
+    if output is None:
+        output = app_path.parent / f"{app_stem}.img"
+
+    mkimage = bin_dir / config.mkimage_binary()
+
+    def _escape(arg: str) -> str:
+        return arg.replace(";", "\\;")
+
+    def _entry(
+        elf: Path, argv0: str, extra: list[str] | None, env: str | None
+    ) -> str:
+        parts = [_escape(argv0)] + [_escape(a) for a in (extra or [])]
+        argv = " ".join(parts)
+        # The entry format for mkimage is:
+        #   <escaped_elf_path>;<cmdline>
+        # Within cmdline, the kernel splits on the first unescaped ';':
+        #   <escaped_args>;<env_vars>
+        cmdline = argv
+        if env:
+            cmdline += f";{env}"
+        return f"{_escape(str(elf))};{cmdline}"
+
+    # Daemons are *guest* binaries — always .elf, even on Windows.
+    cmd: list[str] = [
+        str(mkimage),
+        "-o",
+        str(output),
+        _entry(bin_dir / "procd.elf", "procd", None, None),
+        _entry(bin_dir / "memd.elf", "memd", None, None),
+        _entry(bin_dir / "vfsd.elf", "vfsd", None, None),
+        _entry(app_path, app_stem, app_args, app_env),
+    ]
+
+    subprocess.run(cmd, check=True, timeout=60)
+    return output
+
+
+# ---------------------------------------------------------------------------
 # Windows: download release artifacts as install cache
 # ---------------------------------------------------------------------------
 
@@ -412,6 +481,13 @@ def stage(
         "uservm.elf",
         "nanvixd.exe",
         "kernel.exe",
+        # Host tools for initrd creation (standalone mode).
+        config.mkramfs_binary(),
+        config.mkimage_binary(),
+        # Guest daemon binaries — always .elf, even on Windows.
+        "procd.elf",
+        "memd.elf",
+        "vfsd.elf",
     ]:
         src = nanvix_home / "bin" / binary
         if src.is_file():
@@ -529,26 +605,49 @@ def _run_nanvixd_script(
         if ramfs_img is None:
             raise ValueError("ramfs_img is required for standalone mode")
 
-        # Copy mkramfs into staging bin (needed for ramfs generation).
+        # Copy host tools and daemon ELFs into the staging sysroot.
+        # mkramfs is needed for ramfs generation; mkimage and the daemons
+        # (procd, memd, vfsd) are needed for initrd creation.
         if nanvix_home:
-            mkramfs_name = config.mkramfs_binary()
-            mkramfs_src = nanvix_home / "bin" / mkramfs_name
-            if mkramfs_src.is_file():
-                shutil.copy2(mkramfs_src, sysroot / "bin" / mkramfs_name)
+            # Daemons are *guest* binaries — always .elf, even on
+            # Windows.  Only host tools use the platform extension.
+            _staging_bins = [
+                config.mkramfs_binary(),
+                config.mkimage_binary(),
+                "procd.elf",
+                "memd.elf",
+                "vfsd.elf",
+            ]
+            for name in _staging_bins:
+                src = nanvix_home / "bin" / name
+                if src.is_file():
+                    shutil.copy2(src, sysroot / "bin" / name)
 
+    initrd_img: Path | None = None
     if standalone:
-        # Standalone: semicolon-delimited env vars + ramfs.
+        # Standalone: bundle python binary with system daemons into an
+        # initrd image.  Env vars are passed via app_env so the kernel's
+        # split_cmdline sees them after the bare ';' separator.
+        bin_dir = sysroot / "bin"
+        app_path = sysroot / "bin" / config.python_binary()
+        app_args = ["-B", f"./{script_name}"]
+        app_env = (
+            f"PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
+            f" _PYTHON_SYSCONFIGDATA_NAME={config.SYSCONFIGDATA_NAME}"
+        )
+        initrd_img = _create_initrd(
+            bin_dir, app_path, app_args=app_args, app_env=app_env
+        )
+
         cmd = [
             nanvixd,
             "-bin-dir",
-            "./bin",
+            str(bin_dir),
             "-ramfs",
             str(ramfs_img),
             *resolved_extra,
             "--",
-            python_bin,
-            f"-B ./{script_name};PYTHONHOME=/ PYTHONDONTWRITEBYTECODE=1"
-            f" _PYTHON_SYSCONFIGDATA_NAME={config.SYSCONFIGDATA_NAME}",
+            str(initrd_img),
         ]
     else:
         # Direct mode: guest accesses host filesystem, no ramfs.
@@ -572,6 +671,9 @@ def _run_nanvixd_script(
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError(f"{label} timed out after {timeout}s")
+    finally:
+        if initrd_img is not None and initrd_img.exists():
+            initrd_img.unlink()
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
     output = (result.stdout + "\n" + result.stderr).strip()
@@ -679,14 +781,16 @@ def run_regrtest(
     env["NANVIX_PYTHON_BIN"] = f"./bin/{config.python_binary()}"
 
     if standalone:
-        # Standalone: ramfs + semicolon env syntax.
+        # Standalone: ramfs + initrd-based invocation.
         if ramfs_img is None:
             ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
-        extra_str = f"-bin-dir ./bin -ramfs {ramfs_img}"
+        bin_dir = sysroot / "bin"
+        extra_str = f"-bin-dir {bin_dir} -ramfs {ramfs_img}"
         if resolved_nanvixd_extra:
             extra_str += " " + " ".join(resolved_nanvixd_extra)
         env["NANVIXD_EXTRA_ARGS"] = extra_str
         env["NANVIX_STANDALONE"] = "1"
+        env["NANVIX_BIN_DIR"] = str(bin_dir)
         exclude_set = set(config.STANDALONE_EXCLUDE)
         test_list = [m for m in test_list if m not in exclude_set]
     else:

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -251,6 +251,11 @@ class CPythonBuild(ZScript):
             docker=self.docker is not None,
         )
 
+        # For standalone deployment mode, produce an initrd image
+        # containing the system daemons and the application binary.
+        if self.config.deployment_mode == "standalone":
+            self.make_initrd(f"python{config.EXE}")
+
     def test(self) -> None:
         """Run the CPython test suite (hello + regrtest)."""
         self._overlay_local_nanvix()
@@ -314,6 +319,10 @@ class CPythonBuild(ZScript):
     def clean(self) -> None:
         """Remove build artifacts."""
         build_mod.clean(self.repo_root)
+        # Remove initrd image generated for standalone mode.
+        initrd = self.repo_root / "python.img"
+        if initrd.exists():
+            initrd.unlink()
 
     def distclean(self) -> None:
         """Deep clean: remove all build artifacts, caches, and untracked files."""

--- a/z.ps1
+++ b/z.ps1
@@ -15,7 +15,7 @@ $zutilVersion = if ($env:NANVIX_ZUTIL_VERSION) {
     $env:NANVIX_ZUTIL_VERSION
 }
 else {
-    "0.8.5"
+    "0.9.0"
 }
 $zutilVersion = $zutilVersion -replace "^v", ""
 
@@ -42,9 +42,10 @@ catch {
 }
 
 function Bootstrap {
+    param([string]$Reason = "not found")
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    Write-Information "nanvix-zutil not found -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
+    Write-Information "nanvix-zutil ${Reason} -- bootstrapping nanvix-zutil==${zutilVersion}..." -InformationAction Continue
 
     $wheelUrl = "https://github.com/nanvix/zutils/releases/download/v${zutilVersion}/nanvix_zutil-${zutilVersion}-py3-none-any.whl"
 
@@ -115,6 +116,11 @@ else {
     $bin = "nanvix-zutil"
     if ($zutilGlobalVersion -ne "nanvix-zutil ${zutilVersion}") {
         Write-Warning "nanvix-zutil global install does not match expected version. Expected ${zutilVersion}, found ${zutilGlobalVersion}."
+        Bootstrap "version mismatch"
+        if (-not (Test-Path $venvZutil)) {
+            throw "Bootstrap completed but $venvZutil not found."
+        }
+        $bin = $venvZutil
     }
 }
 

--- a/z.sh
+++ b/z.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-PINNED_VERSION="0.8.5"
+PINNED_VERSION="0.9.0"
 RAW_ZUTIL_VERSION="${NANVIX_ZUTIL_VERSION:-$PINNED_VERSION}"
 ZUTIL_VERSION="${RAW_ZUTIL_VERSION#v}"
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
@@ -31,7 +31,8 @@ ZUTIL_GLOBAL_VERSION="$(nanvix-zutil --version 2>/dev/null || true)"
 function bootstrap() {
     # Pin nanvix-zutil version for reproducible bootstrapping.
     # Override with NANVIX_ZUTIL_VERSION env var if needed.
-    echo "nanvix-zutil not found -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
+    local reason="${1:-not found}"
+    echo "nanvix-zutil ${reason} -- bootstrapping nanvix-zutil==${ZUTIL_VERSION}..." >&2
 
     if ! command -v python3 &>/dev/null; then
         echo "Error: python3 not found. Install Python 3 and ensure python3 is on PATH." >&2
@@ -69,6 +70,8 @@ else
     BIN="nanvix-zutil"
     if [ "$ZUTIL_GLOBAL_VERSION" != "nanvix-zutil ${ZUTIL_VERSION}" ]; then
         echo "Warning: nanvix-zutil global install does not match expected version. Expected ${ZUTIL_VERSION}, found ${ZUTIL_GLOBAL_VERSION}." >&2
+        bootstrap "version mismatch"
+        BIN="$VENV_BIN"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Adapt the CPython build and test infrastructure to the Nanvix v0.14.3 breaking change: standalone mode now requires bundling the application binary with system daemons (`procd`, `memd`, `vfsd`) into an initrd image via `mkimage`, instead of passing the binary directly to `nanvixd`.

## Changes

### Build (`z.py`)
- Call `self.make_initrd()` after cross-compilation in standalone mode to produce `python.img` at the repo root.
- Clean up `python.img` in the `clean()` target.

### Test infrastructure (`test.py`)
- Add `_create_initrd()` helper that invokes `mkimage` to bundle system daemons + python binary into a per-invocation initrd image.
- Refactor `_run_nanvixd_script()` standalone branch to create an initrd with env vars (`PYTHONHOME`, `PYTHONDONTWRITEBYTECODE`, etc.) encoded via semicolons in `app_args`, then invoke `nanvixd` with `-bin-dir <sysroot>/bin -ramfs <img> -- <initrd>` instead of the old `-bin-dir ./bin -ramfs <img> -- <binary> <args>` format.
- Clean up the per-invocation initrd in a `finally` block.
- Pass `NANVIX_BIN_DIR` env var to `run-tests.py` so it can locate `mkimage` and the daemon binaries.

### Batched test runner (`run-tests.py`)
- Add `_create_initrd()` helper (same pattern as `test.py`, standalone script without access to `ZScript`).
- Refactor `run_batch()` standalone branch to create a per-batch initrd (`batch{N}.img`) with regrtest args and env vars, invoke `nanvixd` with `-- <initrd>`, and clean up the initrd after each batch.

### Config (`config.py`)
- Add `mkimage_binary()` helper following the existing `nanvixd_binary()` / `mkramfs_binary()` pattern.

### CI and bootstrap
- Bump `nanvix-zutil` from v0.8.5 to v0.9.0 (required for `make_initrd`).
- Bump `nanvix-version` from 0.13.17 to 0.14.3 in `nanvix.toml`.
- Add auto-bootstrap on zutil version mismatch in `z.sh` and `z.ps1`.

## Notes
- No test programs are disabled in any mode.
- Non-standalone (direct) mode paths remain unchanged.