### PR TITLE
ci: remove deprecated zutil-version parameter

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -28,7 +28,6 @@ jobs:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
     with:
-      zutil-version: "v0.10.3"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'
@@ -44,7 +43,6 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.1.0
     with:
-      zutil-version: "v0.10.3"
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
       memory-sizes: '["256mb"]'


### PR DESCRIPTION
Bumps the `nanvix/workflows` reusable workflow pin from `v2.0.2` to `v2.1.0` and drops the now-removed `zutil-version` input. The pinned zutil version is read from the `.zutils-version` file at the repo root.

Upstream: nanvix/workflows#91 / https://github.com/nanvix/workflows/releases/tag/v2.1.0