### PR TITLE
[nanvix] E: Add cc-wrapper for -shared vs exe link mode

### DIFF
--- a/.nanvix/docker/Dockerfile
+++ b/.nanvix/docker/Dockerfile
@@ -12,3 +12,32 @@ RUN apt-get update \
         python3-dev \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/python3 /opt/nanvix/bin/python3
+
+# Install the cc-wrapper.  This wrapper sits in front of the real
+# `i686-nanvix-gcc` / `i686-nanvix-g++` driver binaries and detects
+# whether the invocation is producing an executable or a shared library.
+# For shared-library links (-shared) it strips exe-only LDFLAGS that
+# would otherwise be inherited from cpython's single `LDFLAGS` env var
+# and cause `.so` builds to fail when the linker treats the output as
+# an executable.  See cc-wrapper.sh's header for the full rationale.
+#
+# Install pattern: rename the real driver to `<name>.real`, install the
+# wrapper script at `<name>`, and symlink for both gcc and g++.
+COPY cc-wrapper.sh /opt/nanvix/bin/i686-nanvix-cc-wrapper.sh
+RUN sed -i 's/\r$//' /opt/nanvix/bin/i686-nanvix-cc-wrapper.sh \
+    && chmod +x /opt/nanvix/bin/i686-nanvix-cc-wrapper.sh \
+    && for tool in i686-nanvix-gcc i686-nanvix-g++; do \
+         if [ -L "/opt/nanvix/bin/$tool" ]; then \
+             # Pre-existing wrapper symlink: require the matching .real to
+             # already exist (set up by a prior wrapper install) before we
+             # replace the symlink, so we never strand the toolchain.
+             if [ ! -f "/opt/nanvix/bin/$tool.real" ]; then \
+                 echo "cc-wrapper install: $tool is a symlink but $tool.real is missing; aborting" >&2; \
+                 exit 1; \
+             fi; \
+             rm /opt/nanvix/bin/$tool; \
+         elif [ ! -f "/opt/nanvix/bin/$tool.real" ]; then \
+             mv /opt/nanvix/bin/$tool /opt/nanvix/bin/$tool.real; \
+         fi; \
+         ln -sf i686-nanvix-cc-wrapper.sh /opt/nanvix/bin/$tool; \
+       done

--- a/.nanvix/docker/cc-wrapper.sh
+++ b/.nanvix/docker/cc-wrapper.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# i686-nanvix-gcc / i686-nanvix-g++ cc-wrapper.
+#
+# Detects whether the invocation is producing an executable or a shared
+# library, and routes to the real compiler driver with the correct linker
+# flags for each case.
+#
+# Why this exists:
+#
+#   The Nanvix build of CPython sets a single `LDFLAGS` env var on
+#   `./configure` that contains executable-specific flags (the linker
+#   script `user.ld`, `-no-pie`, `-Wl,--no-dynamic-linker`,
+#   `-Wl,--export-dynamic`).  cpython's build system propagates that same
+#   `LDFLAGS` to BOTH the main `python.elf` link and to every extension
+#   module `.so` link.  For `.so` outputs those exe-only flags are wrong:
+#
+#     - `-T user.ld`            tells `ld` to use an executable layout.
+#                               When applied to a `-shared` link, `ld`
+#                               treats the output as an exe and rejects
+#                               any undefined symbol -- even those that
+#                               should resolve at dlopen() time against
+#                               the main exe's `.dynsym` (the C API
+#                               symbols every Python extension references).
+#     - `-no-pie`               PIE-disable.  Shared libraries must be PIC.
+#     - `-Wl,--no-dynamic-linker`  meaningless for `.so`.
+#     - `-Wl,--export-dynamic`  exe-only.
+#
+#   This wrapper makes the build system's single `LDFLAGS` value
+#   "do the right thing" for both modes, without forcing each Makefile
+#   that consumes the toolchain to know the difference.
+#
+# Behaviour:
+#
+#   - If the invocation is compile-only (any of `-c` / `-S` / `-E`):
+#         forward unchanged to the real compiler.
+#   - If the invocation does NOT contain `-shared`:
+#         executable link (or pure compile in the rare case
+#         of no `-c`/`-S`/`-E` and no `-shared`).  Forward unchanged.
+#   - If the invocation contains `-shared`:
+#         shared-library link.  Strip the exe-only flags listed above
+#         and ensure `-fPIC` is present.  Forward.
+#
+# The wrapper is invoked by symlink: i686-nanvix-gcc -> cc-wrapper.sh
+# and i686-nanvix-g++ -> cc-wrapper.sh.  The wrapper picks the right
+# real binary based on its own argv[0] (i.e. how it was invoked).
+#
+# Each real binary is preserved as `.real` alongside the wrapper:
+#   i686-nanvix-gcc.real, i686-nanvix-g++.real.
+#
+# See nanvix-todo/c-extension-compiler-wrapper.md for the design note.
+
+set -e
+
+# Find the real binary by appending `.real` to argv[0]'s basename.
+self_dir="$(dirname "$0")"
+self_name="$(basename "$0")"
+real_bin="${self_dir}/${self_name}.real"
+
+if [ ! -x "$real_bin" ]; then
+    echo "cc-wrapper: real binary not found at $real_bin" >&2
+    exit 1
+fi
+
+# Detect mode: compile-only, exe link, or shared link.
+shared=0
+compile_only=0
+for arg in "$@"; do
+    case "$arg" in
+        -shared)        shared=1 ;;
+        -c|-S|-E)       compile_only=1 ;;
+    esac
+done
+
+if [ "$compile_only" = "1" ] || [ "$shared" = "0" ]; then
+    # Compile-only or exe link: forward unchanged.
+    exec "$real_bin" "$@"
+fi
+
+# Shared-library link: strip exe-only flags and ensure -fPIC.
+filtered=()
+skip_next=0
+have_fpic=0
+for arg in "$@"; do
+    if [ "$skip_next" = "1" ]; then
+        skip_next=0
+        continue
+    fi
+    case "$arg" in
+        -T)                                 skip_next=1 ;;
+        -T*)                                ;;
+        -no-pie)                            ;;
+        -Wl,--no-dynamic-linker)            ;;
+        -Wl,--export-dynamic)               ;;
+        -Wl,-T,*)                           ;;
+        *.ld)                               ;;
+        -fPIC)
+                                            have_fpic=1
+                                            filtered+=("$arg")
+                                            ;;
+        *)                                  filtered+=("$arg") ;;
+    esac
+done
+
+if [ "$have_fpic" = "0" ]; then
+    filtered=(-fPIC "${filtered[@]}")
+fi
+
+exec "$real_bin" "${filtered[@]}"


### PR DESCRIPTION
[nanvix] E: Add cc-wrapper for -shared vs exe link mode

Adds a small bash wrapper that sits in front of the real `i686-nanvix-gcc` and `i686-nanvix-g++` driver binaries in the toolchain-python docker image. The wrapper detects whether the invocation is producing an executable or a shared library and applies the correct linker flags for each case.

This mirrors the well-established `emcc` pattern used by emscripten and Pyodide, where the compiler-driver wrapper is what knows the difference between main-module and side-module builds, so consumers (cpython's Makefile.nanvix, future numpy / scipy / lxml meson builds, etc.) can use a single `LDFLAGS` env var without needing to encode the exe-vs-shared distinction themselves.

## Why this exists

`Makefile.nanvix` sets a single `LDFLAGS` on `./configure` that contains executable-specific linker flags:

- `-T <sysroot>/lib/user.ld` — executable layout script.
- `-no-pie` — disable PIE for executables.
- `-Wl,--no-dynamic-linker` — executable-only marker.
- `-Wl,--export-dynamic` — populate the main executable's `.dynsym`.

cpython propagates that same `LDFLAGS` to BOTH the main `python.elf` link AND every extension-module `.so` link via `PY_LDFLAGS`. For `.so` outputs these exe-only flags are wrong:

- `-T user.ld` tells `ld` to use an executable layout. When applied to a `-shared` link, `ld` treats the output as an exe and rejects undefined symbols, even those that should resolve at `dlopen()` time against the main exe's `.dynsym` (the Python C API symbols every extension references).
- `-no-pie` is incompatible with `-shared` (shared libraries must be PIC).
- `-Wl,--no-dynamic-linker` is meaningless for `.so`.
- `-Wl,--export-dynamic` is exe-only.

There is no clean place in cpython 3.12's `Modules/Setup` system to express "use this LDFLAGS for the exe link and that LDFLAGS for shared modules". cpython expects a single `LDFLAGS` shared between both.

The cleanest fix is to install a compiler-driver wrapper that does the split transparently: forwards exe builds unchanged, and strips exe-only flags + adds `-fPIC` for shared builds. That way `LDFLAGS` stays the same for everyone and the wrapper does the right thing per-invocation.

## What changed in `.nanvix/docker/`

- **New file `cc-wrapper.sh`** (~110 lines bash). Detects compile-only mode (`-c` / `-S` / `-E`), exe-link mode (no `-shared`), or shared-link mode (`-shared` present). Compile-only and exe modes forward to the real binary unchanged via `exec "$real_bin" "$@"`. Shared mode iterates the args and:
  - Strips `-T <script>` (both `-T <script>` and `-T<script>` forms), `-no-pie`, `-Wl,--no-dynamic-linker`, `-Wl,--export-dynamic`, `-Wl,-T,<script>`, and bare `*.ld` argument files.
  - Adds `-fPIC` if not already present.
  - Uses a bash `filtered=()` array (not a string) so argv boundaries and quoting are preserved across the rewrite — `exec "$real_bin" "${filtered[@]}"` is argv-preserving for arguments containing spaces, empty strings, or glob metacharacters.
- **Dockerfile updated** to install the wrapper. The script is copied to `/opt/nanvix/bin/i686-nanvix-cc-wrapper.sh`, made executable, and the real `i686-nanvix-gcc` / `i686-nanvix-g++` binaries are renamed to `<name>.real`. Symlinks `<name>` -> `i686-nanvix-cc-wrapper.sh` are then installed. The wrapper picks the right `.real` binary based on `argv[0]`.

The install pattern is defensive: if the upstream base image already has a wrapper symlinked (some local-build flavours of `toolchain-python` carry an earlier wrapper), the symlink is removed and replaced — but only after asserting that the matching `<name>.real` file already exists, so a missing `.real` aborts the install rather than stranding the toolchain. If the real binary has not yet been renamed, it is moved to `<name>.real` in the same step.

## Validation

Built the image locally with the additions and smoke-tested all three wrapper modes against a trivial `int main(){return 0;}`:

- **Test 1 (exe link, no `-shared`):** wrapper transparent; real gcc handles normally.
- **Test 2 (simple `-shared`):** wrapper detects shared mode, adds `-fPIC`, link succeeds.
- **Test 3 (`-shared` plus the toxic exe-only flags `-T <script>` `-no-pie` `-Wl,--no-dynamic-linker`):** wrapper strips the toxic flags and the link succeeds with no spurious "cannot create executables" error.

Build-side end-to-end smoke test with cpython: applied a Phase-0-style change to `Modules/Setup.local` adding `*shared*\narray arraymodule.c`. With the wrapper in place, `array.cpython-312-i686-nanvix.so` (~190 KB) is produced and installed at the canonical `lib/python3.12/lib-dynload/` location; `PyInit_array` no longer appears in `python.elf`. Full `./z build` succeeds.

## What this unblocks

This wrapper is the foundational prerequisite for the broader `.a` -> `.so` migration documented in `nanvix-todo/cpython-static-to-shared-migration.md`. Every subsequent phase of that plan (peeling stdlib extension modules off `python.elf` and shipping them as `.so` files loaded via dlopen, exactly as upstream CPython works) depends on this wrapper being in place. Without it, every per-module conversion would need a per-call LDFLAGS hack.

## Backward compatibility

This change is purely additive at the image level — it adds the wrapper script and rewrites the gcc/g++ entry points to point at it. Existing build paths that don't pass `-shared` see no behavioural change (the wrapper falls through to the real binary unchanged). Existing `.so` build paths that DID work before (e.g., when LDFLAGS happened not to include `-T user.ld`) continue to work because the wrapper's strip-then-add-fPIC produces a strict superset of what bare `gcc -shared` would have done.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
