### PR TITLE
Remove def release()

### DIFF
--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -32,7 +32,6 @@ def _artifact_base(
 def package(
     sysroot: str | Path,
     toolchain: str | Path,
-    repo_root: Path,
     *,
     platform: str = config.DEFAULT_PLATFORM,
     process_mode: str = config.DEFAULT_PROCESS_MODE,
@@ -54,7 +53,7 @@ def package(
             file operations (mkramfs, etc.).  Defaults to *sysroot*.
     """
     nanvix_home = Path(nanvix_home) if nanvix_home else Path(sysroot)
-    release_staging = repo_root / ".nanvix" / "release"
+    release_staging = paths.nanvix_root() / "release"
     dist_dir = paths.dist_dir()
     artifact = _artifact_base(platform, process_mode, memory_size)
 
@@ -68,7 +67,7 @@ def package(
     build_mod.build(
         sysroot,
         toolchain,
-        repo_root,
+        paths.repo_root(),
         platform=platform,
         process_mode=process_mode,
         memory_size=memory_size,
@@ -82,7 +81,7 @@ def package(
     build_mod.install(
         sysroot,
         toolchain,
-        repo_root,
+        paths.repo_root(),
         release_staging,
         platform=platform,
         process_mode=process_mode,
@@ -93,12 +92,11 @@ def package(
         docker=docker,
     )
 
+    # Stage lxml Python package into the installed sysroot.
     sysroot_installed = release_staging / "sysroot"
     if not sysroot_installed.is_dir():
         raise FileNotFoundError(f"Install did not produce {sysroot_installed}")
-
-    # Stage lxml Python package into the installed sysroot.
-    lxml_mod.stage_lxml_runtime(repo_root, sysroot_installed)
+    lxml_mod.stage_lxml_runtime(paths.repo_root(), sysroot_installed)
 
     # --- Buildroot: build dependencies ---
     buildroot_pkg = release_staging / "buildroot-pkg"
@@ -165,7 +163,7 @@ def package(
 
     # --- Include python.elf binary ---
     bin_dir = release_staging / "bin"
-    python_elf = repo_root / f"python{config.EXE}"
+    python_elf = paths.repo_root() / f"python{config.EXE}"
     if python_elf.is_file():
         bin_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(python_elf, bin_dir / "python.elf")
@@ -206,8 +204,6 @@ def package(
 
 
 def verify(
-    repo_root: Path,
-    *,
     platform: str = config.DEFAULT_PLATFORM,
     process_mode: str = config.DEFAULT_PROCESS_MODE,
     memory_size: str = config.DEFAULT_MEMORY_SIZE,

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -235,19 +235,34 @@ class CPythonBuild(ZScript):
         return used_fallback
 
     def build(self) -> None:
-        """Cross-compile python.elf and libpython.a for Nanvix."""
+        """
+        Cross-compile python.elf and libpython.a for Nanvix.
+        Builds for release mode.
+        """
         self._overlay_local_nanvix()
         sysroot, toolchain = self._get_host_paths()
         release = os.environ.get(_MAKE_VAR_RELEASE, "no") == "yes"
+        kwargs = self._build_kwargs(release=release)
         build_mod.build(
             sysroot,
             toolchain,
             repo_root(),
-            **self._build_kwargs(
-                release=release
-            ),  # pyright: ignore[reportArgumentType]
+            **kwargs,  # pyright: ignore[reportArgumentType]
             run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
             docker=self.docker is not None,
+        )
+
+        package_mod.package(
+            sysroot,
+            toolchain,
+            **kwargs,  # pyright: ignore[reportArgumentType]
+            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
+            docker=self.docker is not None,
+        )
+        package_mod.verify(
+            kwargs["platform"],  # pyright: ignore[reportArgumentType]
+            kwargs["process_mode"],  # pyright: ignore[reportArgumentType]
+            kwargs["memory_size"],  # pyright: ignore[reportArgumentType]
         )
 
         # For standalone deployment mode, produce an initrd image
@@ -292,27 +307,6 @@ class CPythonBuild(ZScript):
             nanvixd_extra=nanvixd_extra,
             run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
             docker=self.docker is not None,
-        )
-
-    def release(self) -> None:
-        """Package the CPython release tarballs and verify them."""
-        self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_host_paths()
-        kwargs = self._build_kwargs(release=True)
-
-        package_mod.package(
-            sysroot,
-            toolchain,
-            repo_root(),
-            **kwargs,  # pyright: ignore[reportArgumentType]
-            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
-        )
-        package_mod.verify(
-            repo_root(),
-            platform=kwargs["platform"],  # pyright: ignore[reportArgumentType]
-            process_mode=kwargs["process_mode"],  # pyright: ignore[reportArgumentType]
-            memory_size=kwargs["memory_size"],  # pyright: ignore[reportArgumentType]
         )
 
     def clean(self) -> None:


### PR DESCRIPTION
Moves release builds to `def build()`, removes `def release()`.

Removes redundant build.

Towards https://github.com/nanvix/zutils/issues/191
STACKED ON #705 
Future work: #710 