### PR TITLE
Update toolchain-python base image to latest toolchain-gcc

### DIFF
--- a/.nanvix/docker/Dockerfile
+++ b/.nanvix/docker/Dockerfile
@@ -4,7 +4,7 @@
 # toolchain-python — Nanvix GCC toolchain + host Python 3 for CPython
 # cross-compilation.  Published as ghcr.io/nanvix/toolchain-python.
 
-FROM ghcr.io/nanvix/toolchain-gcc:sha-34a3641
+FROM ghcr.io/nanvix/toolchain-gcc:sha-3892efb
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Updates the `toolchain-python` Docker base image to the latest published version of `toolchain-gcc`.

- `.nanvix/docker/Dockerfile`: bump `ghcr.io/nanvix/toolchain-gcc` from `sha-34a3641` to `sha-3892efb`

`sha-3892efb` is the commit that the `latest` tag currently points to on GHCR (verified by matching manifest digests: `sha256:6b8450a9…`).