### PR TITLE
[ci] E: Pin nanvix to v0.16.32

### DIFF
--- a/.nanvix/config.py
+++ b/.nanvix/config.py
@@ -67,6 +67,7 @@ def toolchain_paths(
         "libc": tc / f"{TOOLCHAIN_TRIPLET}" / "lib" / "libc.a",
         "libm": tc / f"{TOOLCHAIN_TRIPLET}" / "lib" / "libm.a",
         "libposix": sr / "lib" / "libposix.a",
+        "libcrt0": sr / "lib" / "libnvx_crt0.a",
         "libz": sr / "lib" / "libz.a",
         "libsqlite3": sr / "lib" / "libsqlite3.a",
         "libssl": sr / "lib" / "libssl.a",
@@ -96,7 +97,7 @@ def configure_env(toolchain: str | Path, sysroot: str | Path) -> dict[str, str]:
             f"-Wl,--export-dynamic -Wl,--no-dynamic-linker"
         ),
         "LIBS": (
-            f"-Wl,--start-group {tp['libposix']} {tp['libc']} {tp['libm']} "
+            f"-Wl,--start-group {tp['libcrt0']} {tp['libposix']} {tp['libc']} {tp['libm']} "
             f"-lsqlite3 -lssl -lcrypto -lz -lbz2 -llzma -lffi -Wl,--end-group"
         ),
         "LIBSQLITE3_LIBS": f"-L{sr}/lib -lsqlite3",

--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.16.17"
+nanvix-version = "0.16.32"
 
 [builds]
 [builds.matrix]

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -87,6 +87,7 @@ ifdef CONFIG_NANVIX
     LIBC := $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libc.a
     LIBM := $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libm.a
     LIBPOSIX := $(DOCKER_SYSROOT_PATH)/lib/libposix.a
+    LIBCRT0 := $(DOCKER_SYSROOT_PATH)/lib/libnvx_crt0.a
     LIBZ := $(DOCKER_SYSROOT_PATH)/lib/libz.a
     LIBSQLITE3 := $(DOCKER_SYSROOT_PATH)/lib/libsqlite3.a
     LIBSSL := $(DOCKER_SYSROOT_PATH)/lib/libssl.a
@@ -98,6 +99,7 @@ ifdef CONFIG_NANVIX
     LIBC := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
     LIBM := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a
     LIBPOSIX := $(abspath $(NANVIX_HOME))/lib/libposix.a
+    LIBCRT0 := $(abspath $(NANVIX_HOME))/lib/libnvx_crt0.a
     LIBZ := $(abspath $(NANVIX_HOME))/lib/libz.a
     LIBSQLITE3 := $(abspath $(NANVIX_HOME))/lib/libsqlite3.a
     LIBSSL := $(abspath $(NANVIX_HOME))/lib/libssl.a
@@ -123,7 +125,7 @@ CONFIGURE_ENV = \
 	CFLAGS="-O3 -fomit-frame-pointer -fno-unwind-tables -fno-asynchronous-unwind-tables -I$(SYSROOT_PATH)/include" \
 	CFLAGS_NODIST="-fno-semantic-interposition" \
 	LDFLAGS="-L$(SYSROOT_PATH)/lib -T$(SYSROOT_PATH)/lib/user.ld -Wl,--allow-multiple-definition -no-pie -Wl,--export-dynamic -Wl,--no-dynamic-linker" \
-	LIBS="-Wl,--start-group $(LIBPOSIX) $(LIBC) $(LIBM) -lsqlite3 -lssl -lcrypto -lz -lbz2 -llzma -lffi -Wl,--end-group" \
+	LIBS="-Wl,--start-group $(LIBCRT0) $(LIBPOSIX) $(LIBC) $(LIBM) -lsqlite3 -lssl -lcrypto -lz -lbz2 -llzma -lffi -Wl,--end-group" \
 	LIBSQLITE3_LIBS="-L$(SYSROOT_PATH)/lib -lsqlite3" \
 	LIBSQLITE3_CFLAGS="-I$(SYSROOT_PATH)/include" \
 	ZLIB_LIBS="-L$(SYSROOT_PATH)/lib -lz" \


### PR DESCRIPTION
## Summary

Bump pinned Nanvix version `0.16.17` → `0.16.32` in `.nanvix/nanvix.toml`.

This repo's per-config `release()` fix is already on the default branch, and all dependency releases at `-nanvix-0.16.32` now publish correct per-configuration assets, so dependency resolution and release packaging both work at the new version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
