### PR TITLE
Makefile.nanvix: Protect .nanivx dir from clean recipe

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -238,11 +238,18 @@ else
 	$(MAKE) install DESTDIR="$(DESTDIR)"
 endif
 
+
 # Clean target
 clean:
-	-$(MAKE) clean 2>/dev/null || true
+	set -e; \
+	TEMPDIR=$$(mktemp -d); \
+	mv .nanvix/ "$$TEMPDIR"; \
+	$(MAKE) clean 2>/dev/null || true; \
+	mv "$$TEMPDIR/.nanvix" ./; \
+	rm -rf "$$TEMPDIR"
 	rm -f $(CONFIGURED_MARKER)
 	rm -f python$(EXE)
+
 
 # Distclean target
 distclean: clean


### PR DESCRIPTION
Upstream's `clean-retain-profile` (via `make clean`) runs `find . -name '*.[oa]' ...` from the repo root, which walks into `.nanvix/sysroot/lib/` and deletes libposix.a, libnvx_crt0.a, libcrypto.a, libbz2.a, etc. 

Move the .nanvix directory temporarily during cleanup to avoid accidental removals.

Note: `distclean` has the same defect (both via `$(MAKE) distclean` and `git clean -fdx`) but is being removed entirely in a follow-up PR, so it is left as-is here.