### PR TITLE
[ci] E: Pin nanvix to v0.16.42

### DIFF
--- a/.nanvix/nanvix.toml
+++ b/.nanvix/nanvix.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cpython"
 version = "3.12.3"
-nanvix-version = "0.16.32"
+nanvix-version = "0.16.42"
 
 [builds]
 [builds.matrix]

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -177,7 +177,9 @@ CONFIGURE_OPTS = \
 	ac_cv_func_getsockname=yes \
 	ac_cv_func_inet_aton=no \
 	ac_cv_func_inet_ntoa=yes \
-	ac_cv_func_inet_pton=no
+	ac_cv_func_inet_pton=no \
+	ac_cv_func_statvfs=no \
+	ac_cv_func_fstatvfs=no
 
 # Marker file to track if configure has been run
 CONFIGURED_MARKER = .nanvix-configured

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -179,7 +179,8 @@ CONFIGURE_OPTS = \
 	ac_cv_func_inet_ntoa=yes \
 	ac_cv_func_inet_pton=no \
 	ac_cv_func_statvfs=no \
-	ac_cv_func_fstatvfs=no
+	ac_cv_func_fstatvfs=no \
+	ac_cv_func_fdopendir=no
 
 # Marker file to track if configure has been run
 CONFIGURED_MARKER = .nanvix-configured

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4324,7 +4324,7 @@ _posix_listdir(path_t *path, PyObject *list)
 exit:
     if (dirp != NULL) {
         Py_BEGIN_ALLOW_THREADS
-#ifdef HAVE_FDOPENDIR
+#if defined(HAVE_FDOPENDIR) && defined(HAVE_REWINDDIR)
         if (fd > -1)
             rewinddir(dirp);
 #endif
@@ -15262,7 +15262,7 @@ ScandirIterator_closedir(ScandirIterator *iterator)
 
     iterator->dirp = NULL;
     Py_BEGIN_ALLOW_THREADS
-#ifdef HAVE_FDOPENDIR
+#if defined(HAVE_FDOPENDIR) && defined(HAVE_REWINDDIR)
     if (iterator->path.fd != -1)
         rewinddir(dirp);
 #endif

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12356,7 +12356,7 @@ os_WSTOPSIG_impl(PyObject *module, int status)
 #endif /* HAVE_SYS_WAIT_H */
 
 
-#if defined(HAVE_FSTATVFS) && defined(HAVE_SYS_STATVFS_H)
+#if (defined(HAVE_FSTATVFS) || defined(HAVE_STATVFS)) && defined(HAVE_SYS_STATVFS_H)
 #ifdef _SCO_DS
 /* SCO OpenServer 5.0 and later requires _SVID3 before it reveals the
    needed definitions in sys/statvfs.h */
@@ -12420,6 +12420,7 @@ _pystatvfs_fromstructstatvfs(PyObject *module, struct statvfs st) {
 }
 
 
+#ifdef HAVE_FSTATVFS
 /*[clinic input]
 os.fstatvfs
     fd: int
@@ -12449,7 +12450,8 @@ os_fstatvfs_impl(PyObject *module, int fd)
 
     return _pystatvfs_fromstructstatvfs(module, st);
 }
-#endif /* defined(HAVE_FSTATVFS) && defined(HAVE_SYS_STATVFS_H) */
+#endif /* HAVE_FSTATVFS */
+#endif /* (defined(HAVE_FSTATVFS) || defined(HAVE_STATVFS)) && defined(HAVE_SYS_STATVFS_H) */
 
 
 #if defined(HAVE_STATVFS) && defined(HAVE_SYS_STATVFS_H)

--- a/configure
+++ b/configure
@@ -18235,6 +18235,12 @@ then :
   printf "%s\n" "#define HAVE_RENAMEAT 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "rewinddir" "ac_cv_func_rewinddir"
+if test "x$ac_cv_func_rewinddir" = xyes
+then :
+  printf "%s\n" "#define HAVE_REWINDDIR 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "rtpSpawn" "ac_cv_func_rtpSpawn"
 if test "x$ac_cv_func_rtpSpawn" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -4914,6 +4914,7 @@ AC_CHECK_FUNCS([ \
   pipe2 plock poll posix_fadvise posix_fallocate posix_spawn posix_spawnp \
   pread preadv preadv2 pthread_condattr_setclock pthread_init pthread_kill \
   pwrite pwritev pwritev2 readlink readlinkat readv realpath renameat \
+  rewinddir \
   rtpSpawn sched_get_priority_max sched_rr_get_interval sched_setaffinity \
   sched_setparam sched_setscheduler sem_clockwait sem_getvalue sem_open \
   sem_timedwait sem_unlink sendfile setegid seteuid setgid sethostname \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -998,6 +998,9 @@
 /* Define to 1 if you have the `renameat' function. */
 #undef HAVE_RENAMEAT
 
+/* Define to 1 if you have the `rewinddir' function. */
+#undef HAVE_REWINDDIR
+
 /* Define if readline supports append_history */
 #undef HAVE_RL_APPEND_HISTORY
 


### PR DESCRIPTION
Automated bump of `nanvix-version` to [`v0.16.42`](https://github.com/nanvix/nanvix/releases/tag/v0.16.42).

Generated by the [Nanvix CI](https://github.com/nanvix/workflows/blob/main/.github/workflows/nanvix-ci.yml) reusable workflow.