### PR TITLE
Build cleanup

### DIFF
--- a/.nanvix/_docker.py
+++ b/.nanvix/_docker.py
@@ -41,7 +41,7 @@ def _docker_mount_source(path: Path) -> str:
     Windows, ``Path`` renders drive-letter paths like ``C:\\Users\\foo``,
     whose colon is misread as a field separator -- producing errors such
     as ``invalid mode: /mnt/host-workspace``.  Translate drive-letter
-    paths to the ``//c/Users/foo`` form that Docker accepts and which
+    paths to the ``/c/Users/foo`` form that Docker accepts and which
     contains no colon.  POSIX paths are returned unchanged.
     """
     resolved = path.resolve()
@@ -50,7 +50,7 @@ def _docker_mount_source(path: Path) -> str:
     if len(drive) == 2 and drive[1] == ":":
         letter = drive[0].lower()
         rest = str(resolved)[len(drive) :].replace("\\", "/").lstrip("/")
-        return f"//{letter}/{rest}"
+        return f"/{letter}/{rest}"
     return str(resolved)
 
 
@@ -212,52 +212,6 @@ def docker_build(
         )
     else:
         shell_cmd += f"; rc=$?; {copy_back}; exit $rc"
-
-    subprocess.run(
-        [*base, "sh", "-c", shell_cmd],
-        check=True,
-    )
-
-
-def docker_install(
-    workspace: Path,
-    destdir: Path,
-    args: build_mod.MakeArgs,
-) -> None:
-    """Run make install inside Docker (Windows host mode)."""
-    targets = [
-        "install",
-        f"DESTDIR={config.DOCKER_WORKSPACE_PATH}/_install_staging",
-    ]
-    _args = dataclasses.replace(args, docker=True, targets=targets)
-    base = _docker_run_base(workspace, _args)
-    sync = sync_sources(workspace)
-
-    # Compute relative path so nested destdirs (e.g. .nanvix/_test_staging)
-    # are preserved correctly on the host.
-    try:
-        rel_dest = destdir.relative_to(workspace).as_posix()
-    except ValueError:
-        rel_dest = destdir.name
-
-    # Copy install staging back to host, stripping the binary first.
-    strip_bin = f"{config.DOCKER_TOOLCHAIN_PATH}/bin/{config.TOOLCHAIN_TRIPLET}-strip"
-    install_bin = (
-        f"{config.DOCKER_WORKSPACE_PATH}/_install_staging"
-        f"{_args.install_prefix}/bin/{config.python_binary()}"
-    )
-    strip_cmd = (
-        f'[ -x "{strip_bin}" ] && [ -f "{install_bin}" ] && '
-        f'"{strip_bin}" --strip-all "{install_bin}" || true'
-    )
-    shell_cmd = (
-        f"{sync} && cd {config.DOCKER_WORKSPACE_PATH} && {_args.to_string()}; rc=$?; "
-        f"{strip_cmd}; "
-        f"if [ -d {config.DOCKER_WORKSPACE_PATH}/_install_staging ]; then "
-        f"mkdir -p /mnt/host-workspace/{rel_dest} && "
-        f"cp -a {config.DOCKER_WORKSPACE_PATH}/_install_staging/* /mnt/host-workspace/{rel_dest}/; fi; "
-        f"exit $rc"
-    )
 
     subprocess.run(
         [*base, "sh", "-c", shell_cmd],

--- a/.nanvix/_test.py
+++ b/.nanvix/_test.py
@@ -35,6 +35,14 @@ import ramfs as ramfs_mod
 # ---------------------------------------------------------------------------
 
 
+def install_cache() -> Path:
+    """
+    Cpython installation cache used on Windows.
+    Allows tests to run without building first.
+    """
+    return paths.nanvix_root() / "_install_cache"
+
+
 def _create_initrd(
     bin_dir: Path,
     app_path: Path,
@@ -109,7 +117,7 @@ def _download_release_as_cache(args: build_mod.MakeArgs) -> Path:
     (which requires Docker). The release tarball contains the same
     sysroot tree that ``./z build`` would produce.
     """
-    cache_dir = paths.nanvix_root() / "_install_cache"
+    cache_dir = paths.test_out()
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -218,146 +226,32 @@ def _download_release_as_cache(args: build_mod.MakeArgs) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def _manual_install(
-    staging: Path,
-    args: build_mod.MakeArgs,
-) -> None:
-    """Create a minimal install tree without invoking make.
-
-    Used when the Makefile was configured inside Docker and cannot be
-    used natively.  Copies the Python binary and standard library from
-    the source/build tree into the staging directory.
-    """
-    # install_prefix is e.g. "/sysroot" — strip leading slash for relative path.
-    prefix_rel = args.install_prefix.lstrip("/")
-    sysroot_dir = staging / prefix_rel
-    bin_dir = sysroot_dir / "bin"
-    lib_dir = sysroot_dir / "lib" / config.PYTHON_LIB_DIR
-
-    bin_dir.mkdir(parents=True, exist_ok=True)
-    lib_dir.mkdir(parents=True, exist_ok=True)
-
-    # Copy the built python binary.
-    python_bin = paths.repo_root() / f"python{config.EXE}"
-    if python_bin.is_file():
-        shutil.copy2(python_bin, bin_dir / config.python_binary())
-
-    # Copy the standard library from Lib/.
-    lib_src = paths.repo_root() / "Lib"
-    if lib_src.is_dir():
-        shutil.copytree(lib_src, lib_dir, dirs_exist_ok=True)
-
-    # Copy sysconfigdata from the build directory.
-    scdata_name = f"{config.SYSCONFIGDATA_NAME}.py"
-    pybuilddir_file = paths.repo_root() / "pybuilddir.txt"
-    if pybuilddir_file.is_file():
-        bdir = paths.repo_root() / pybuilddir_file.read_text().strip()
-        scdata_src = bdir / scdata_name
-        if scdata_src.is_file():
-            shutil.copy2(scdata_src, lib_dir / scdata_name)
-
-    # Copy libpython archive (needed by some install validation).
-    libpython = paths.repo_root() / f"libpython{config.PYTHON_VERSION}.a"
-    lib_parent = sysroot_dir / "lib"
-    if libpython.is_file():
-        shutil.copy2(libpython, lib_parent / libpython.name)
-
-    print(f"  Manual install complete ({sysroot_dir})")
-
-
 def stage(
     args: build_mod.MakeArgs,
 ) -> Path:
-    """Build, install, and stage CPython for testing.
-
+    """Stage CPython for testing.
+    Assumes that build() has already run.
     Returns the test staging directory.
     """
-    staging = paths.nanvix_root() / "_test_staging"
+    staging = paths.test_out()
 
     print("Running CPython tests on Nanvix...")
-    if staging.exists():
-        shutil.rmtree(staging)
-
     if config.IS_WINDOWS:
-        # On Windows, use the cached install tree produced by ``./z build``
-        # so that no Docker invocation is needed during testing.
-        install_cache = paths.nanvix_root() / "_install_cache"
-        if install_cache.is_dir():
-            shutil.copytree(install_cache, staging)
-            print("  Using cached install from ./z build")
-        else:
-            # Fallback: download the release tarball and use it as the
-            # install cache. This lets ``./z test`` work on Windows
-            # without a prior ``./z build`` (which requires Docker).
-            print("  Install cache not found — downloading release artifacts...")
+        # Fallback: download the release tarball and use it as the
+        # install cache. This lets ``./z test`` work on Windows
+        # without a prior ``./z build`` (which requires Docker).
+        if not paths.test_out().is_dir():
+            print("  Install cache not found. Downloading release artifacts...")
             install_cache = _download_release_as_cache(args)
             shutil.copytree(install_cache, staging)
             print("  Using downloaded release as install cache")
-    else:
-        # Linux: build and install directly.
-        # Only skip the rebuild when the previously built binary exists,
-        # the build tree is properly configured, and the host cannot use
-        # BUILD_PYTHON (e.g. after a prior Docker build where that tool
-        # is unavailable outside the container).
-        python_binary = paths.repo_root() / f"python{config.EXE}"
-        configured_marker = paths.repo_root() / ".nanvix-configured"
-        pybuilddir = paths.repo_root() / "pybuilddir.txt"
-
-        # Determine whether BUILD_PYTHON is usable on the host.
-        build_python_path = Path(args.toolchain_path) / "bin" / "python3"
-        build_python_available = (
-            build_python_path.is_file()
-            or shutil.which(str(build_python_path)) is not None
-        )
-
-        # Detect if ./configure was run inside Docker (paths like
-        # /mnt/sysroot baked into Makefile).  A native rebuild would
-        # fail because those paths don't exist on the host.
-        docker_configured = False
-        makefile = paths.repo_root() / "Makefile"
-        if makefile.is_file() and not args.docker:
-            try:
-                header = makefile.read_text(encoding="utf-8", errors="replace")[:8192]
-                docker_configured = config.DOCKER_SYSROOT_PATH in header
-            except OSError:
-                pass
-
-        can_skip_rebuild = (
-            python_binary.is_file()
-            and configured_marker.is_file()
-            and pybuilddir.is_file()
-            and (not build_python_available or docker_configured)
-        )
-
-        if can_skip_rebuild:
-            skip_reason = (
-                "Docker-configured Makefile (native rebuild would fail)"
-                if docker_configured and build_python_available
-                else "BUILD_PYTHON is unavailable"
-            )
-            print(
-                f"  Skipping rebuild ({python_binary.name} already exists"
-                f" — {skip_reason})"
-            )
-            if docker_configured and build_python_available:
-                # Cannot run make install natively when configure used
-                # Docker paths and the native toolchain would trigger a
-                # rebuild — do a manual install instead.
-                _manual_install(staging, args)
-            else:
-                # Install into staging, skipping the outer build prereq
-                # and stubbing PYTHON_FOR_BUILD for the inner make.
-                build_mod.install(
-                    staging,
-                    args,
-                    extra_make_flags=["-o", "build", "PYTHON_FOR_BUILD=:"],
-                )
-        else:
-            build_mod.build(args)
-            build_mod.install(staging, args)
 
     sysroot_dir = staging / "sysroot"
-
+    if not sysroot_dir.is_dir():
+        raise FileNotFoundError(
+            f"Test install tree not found at {sysroot_dir}. "
+            "Run `./z build` first to populate it."
+        )
     # Ensure _sysconfigdata module is present in the installed sysroot.
     # make install should copy it from build/<pybuilddir>/ but this can
     # silently fail when PYTHON_FOR_BUILD is not available or when the
@@ -439,13 +333,21 @@ def stage(
         if src.is_file():
             shutil.copy2(src, bin_dir / binary)
 
-    # Replace unstripped python binary with stripped python.elf.
-    stripped = paths.repo_root() / f"python{config.EXE}"
-    if stripped.is_file():
-        target = bin_dir / config.python_binary()
-        shutil.copy2(stripped, target)
-        size = target.stat().st_size
-        print(f"  Installed stripped python.elf into staging ({size // 1024}K)")
+    # NOTE: do not copy from paths.repo_root()/python.elf here.  By the
+    # time `./z test` runs, the release build in z.py::build() has
+    # overwritten that file with a --without-doc-strings binary, which
+    # breaks any regrtest module that depends on docstrings.  The
+    # correct stripped test binary was already installed into
+    # test_out/sysroot/bin by z.py::build() immediately after the test
+    # install, while python.elf still reflected the test build.
+    target = bin_dir / config.python_binary()
+    if not target.is_file():
+        raise FileNotFoundError(
+            f"Staged python binary not found at {target}. "
+            "Run `./z build` first to populate the test install tree."
+        )
+    size = target.stat().st_size
+    print(f"  Using staged python binary ({size // 1024}K)")
 
     # Copy guest-side test runner.
     regrtest_runner = paths.nanvix_root() / "run-regrtest.py"

--- a/.nanvix/_test.py
+++ b/.nanvix/_test.py
@@ -35,14 +35,6 @@ import ramfs as ramfs_mod
 # ---------------------------------------------------------------------------
 
 
-def install_cache() -> Path:
-    """
-    Cpython installation cache used on Windows.
-    Allows tests to run without building first.
-    """
-    return paths.nanvix_root() / "_install_cache"
-
-
 def _create_initrd(
     bin_dir: Path,
     app_path: Path,

--- a/.nanvix/_test.py
+++ b/.nanvix/_test.py
@@ -240,11 +240,10 @@ def stage(
         # Fallback: download the release tarball and use it as the
         # install cache. This lets ``./z test`` work on Windows
         # without a prior ``./z build`` (which requires Docker).
-        if not paths.test_out().is_dir():
+        if not staging.is_dir():
             print("  Install cache not found. Downloading release artifacts...")
-            install_cache = _download_release_as_cache(args)
-            shutil.copytree(install_cache, staging)
-            print("  Using downloaded release as install cache")
+            _download_release_as_cache(args)
+            print("  Using downloaded release as install tree")
 
     sysroot_dir = staging / "sysroot"
     if not sysroot_dir.is_dir():

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -85,22 +85,18 @@ class MakeArgs:
         return f"cpython-{self.platform}-{self.process_mode}-{self.memory_size}"
 
 
-def build(
-    args: MakeArgs,
-) -> None:
-    """Cross-compile python.elf for Nanvix."""
+def build(args: MakeArgs, out: Path) -> None:
+    """
+    Cross-compile python.elf for Nanvix.
+    Always runs in Docker.
+    """
     _args = dataclasses.replace(args, targets=["build"])
     if config.IS_WINDOWS:
-        # Build and install in one Docker invocation so the install tree
-        # is cached for later use by ``./z test`` (no Docker during tests).
-        install_cache = paths.nanvix_root() / "_install_cache"
-        docker_mod.docker_build(paths.repo_root(), args, install_destdir=install_cache)
+        docker_mod.docker_build(paths.repo_root(), args, install_destdir=out)
         return
-    sysroot_for_setup = (
-        Path(config.DOCKER_SYSROOT_PATH) if _args.docker else args.sysroot
-    )
-    lxml_mod.generate_setup_local(paths.repo_root(), sysroot_for_setup)
+    lxml_mod.generate_setup_local(paths.repo_root(), Path(config.DOCKER_SYSROOT_PATH))
     _args.run(cwd=paths.repo_root())
+    install(out, args)
 
 
 def install(
@@ -109,19 +105,41 @@ def install(
     *,
     extra_make_flags: list[str] | None = None,
 ) -> None:
-    """Install CPython into a staging directory."""
-    if config.IS_WINDOWS:
-        docker_mod.docker_install(paths.repo_root(), destdir, args)
-        return
+    """Install CPython into a staging directory under ``paths.out_dir()``."""
+    # Safety: destdir is caller-supplied and we're about to rmtree it.
+    # Refuse anything outside the Nanvix work area.
+    resolved_destdir = destdir.resolve()
+    out_root = paths.out_dir().resolve()
+    try:
+        resolved_destdir.relative_to(out_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"install() refuses to wipe {destdir!s}: not under {out_root!s}"
+        ) from exc
     # When running inside Docker, repo_root maps to /mnt/workspace.
     # Use a relative DESTDIR so it resolves correctly inside the container.
+    if destdir.exists():
+        shutil.rmtree(destdir)
     try:
-        rel_destdir = destdir.resolve().relative_to(paths.repo_root())
+        rel_destdir = resolved_destdir.relative_to(paths.repo_root())
     except ValueError:
         rel_destdir = destdir
     targets = [*(extra_make_flags or []), "install", f"DESTDIR={rel_destdir}"]
     _args = dataclasses.replace(args, targets=targets)
     _args.run(cwd=paths.repo_root())
+
+    if not args.release:
+        sysroot = destdir / args.install_prefix.lstrip("/")
+        shutil.copytree(
+            paths.repo_root() / "Lib" / "test",
+            sysroot / "lib" / config.PYTHON_LIB_DIR / "test",
+            dirs_exist_ok=True,
+        )
+        stripped = paths.repo_root() / f"python{config.EXE}"
+        if stripped.is_file():
+            bin_dir = sysroot / "bin"
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(stripped, bin_dir / config.python_binary())
 
 
 def clean() -> None:

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -130,17 +130,15 @@ def install(
 
     if not args.release:
         sysroot = destdir / args.install_prefix.lstrip("/")
-        shutil.copytree(
-            paths.repo_root() / "Lib" / "test",
-            sysroot / "lib" / config.PYTHON_LIB_DIR / "test",
-            dirs_exist_ok=True,
-        )
+        test_src = paths.repo_root() / "Lib" / "test"
+        test_dst = sysroot / "lib" / config.PYTHON_LIB_DIR / "test"
+        if test_src.is_dir() and not test_dst.is_dir():
+            shutil.copytree(test_src, test_dst)
         stripped = paths.repo_root() / f"python{config.EXE}"
         if stripped.is_file():
             bin_dir = sysroot / "bin"
             bin_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy2(stripped, bin_dir / config.python_binary())
-
 
 def clean() -> None:
     """Remove build artifacts."""

--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -27,25 +27,31 @@ def package(
     - ``cpython-<platform>-<mode>-<memory>.tar.gz`` — runtime sysroot + binary + ramfs
     - ``cpython-<platform>-<mode>-<memory>-buildroot.tar.gz`` — build dependencies
     """
-    release_staging = paths.nanvix_root() / "release"
+    release_staging = paths.release_dir()
     dist_dir = paths.dist_dir()
     artifact = args.asset_prefix()
 
     print("Packaging CPython release...")
 
-    # Clean previous staging.
-    if release_staging.exists():
-        shutil.rmtree(release_staging)
-
-    # Build.
-    build_mod.build(args)
-
-    # Install into staging.
-    build_mod.install(release_staging, args)
-
     sysroot_installed = release_staging / "sysroot"
     if not sysroot_installed.is_dir():
-        raise FileNotFoundError(f"Install did not produce {sysroot_installed}")
+        raise FileNotFoundError(
+            f"Release install tree not found at {sysroot_installed}. "
+            "Run `./z build` first to populate it."
+        )
+
+    # Clean previous packaging scratch (but NEVER the installed sysroot,
+    # which is produced by `./z build` and is the input to this step).
+    for scratch in (
+        release_staging / "buildroot-pkg",
+        release_staging / "sysroot-pkg-wrap",
+        release_staging / "bin",
+        release_staging / "cpython-ramfs.img",
+    ):
+        if scratch.is_dir():
+            shutil.rmtree(scratch)
+        elif scratch.is_file():
+            scratch.unlink()
 
     # Stage lxml Python package into the installed sysroot.
     lxml_mod.stage_lxml_runtime(sysroot_installed)
@@ -145,9 +151,6 @@ def package(
     buildroot_tar = dist_dir / f"{artifact}-buildroot.tar.gz"
     with tarfile.open(str(buildroot_tar), "w:gz") as tf:
         tf.add(str(buildroot_pkg), arcname="sysroot")
-
-    # Cleanup staging.
-    shutil.rmtree(release_staging)
 
     print("Release tarballs created in dist/")
     for f in sorted(dist_dir.glob(f"{artifact}*.tar.gz")):

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -62,7 +62,6 @@ _MAKE_VAR_PLATFORM = "PLATFORM"
 _MAKE_VAR_PROCESS_MODE = "PROCESS_MODE"
 _MAKE_VAR_MEMORY_SIZE = "MEMORY_SIZE"
 _MAKE_VAR_INSTALL_PREFIX = "INSTALL_PREFIX"
-_MAKE_VAR_RELEASE = "NANVIX_RELEASE"
 
 # CPython embeds --prefix into the binary (sys.prefix, sys.path).
 _DEFAULT_INSTALL_PREFIX = config.DEFAULT_INSTALL_PREFIX
@@ -205,16 +204,43 @@ class CPythonBuild(ZScript):
         return used_fallback
 
     def build(self) -> None:
-        """Cross-compile python.elf and libpython.a for Nanvix."""
-        self._overlay_local_nanvix()
-        release = os.environ.get(_MAKE_VAR_RELEASE, "no") == "yes"
-        args = self._make_args(release=release)
-        build_mod.build(args)
+        """Cross-compile python.elf and libpython.a for Nanvix.
 
-        # For standalone deployment mode, produce an initrd image
-        # containing the system daemons and the application binary.
+        Runs entirely inside Docker so that build and install share a
+        consistent set of sysroot/toolchain paths.  Produces two install
+        trees up front:
+
+          * ``paths.test_out()``   — test build (with docstrings,
+            test modules, and ``Lib/test``); consumed by ``./z test``.
+          * ``paths.release_dir()`` — release build
+            (``--without-doc-strings``, ``--disable-test-modules``);
+            consumed by ``./z release``.
+        """
+        if self.docker is None:
+            raise RuntimeError(
+                "`./z build` requires Docker; rerun `./z setup --with-docker=<image>`"
+            )
+        self._overlay_local_nanvix()
+
+        # Ensure a clean configure state: a prior `./z build` may have
+        # left .nanvix-configured (and the Makefile) in release mode,
+        # which would silently carry --without-doc-strings and
+        # --disable-test-modules into the test build below and break
+        # regrtest (any module that introspects docstrings).
+        self._make_args("clean", release=False).run(cwd=paths.repo_root())
+
+        # build for tests
+        args = self._make_args(release=False)
+        build_mod.build(args, paths.test_out())
         if self.config.deployment_mode == "standalone":
-            make_initrd(self, f"python{config.EXE}", test=False)
+            make_initrd(self, f"python{config.EXE}", test=True)
+
+        # clean debug build artifacts
+        self._make_args("clean", release=False).run(cwd=paths.repo_root())
+
+        # build for release
+        args = self._make_args(release=True)
+        build_mod.build(args, paths.release_dir())
 
     def test(self) -> None:
         """Run the CPython test suite (hello + regrtest)."""

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -227,7 +227,10 @@ class CPythonBuild(ZScript):
         # which would silently carry --without-doc-strings and
         # --disable-test-modules into the test build below and break
         # regrtest (any module that introspects docstrings).
-        self._make_args("clean", release=False).run(cwd=paths.repo_root())
+        if config.IS_WINDOWS:
+            build_mod.docker_mod.clean_volume(paths.repo_root())
+        else:
+            self._make_args("clean", release=False).run(cwd=paths.repo_root())
 
         # build for tests
         args = self._make_args(release=False)

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -239,7 +239,10 @@ class CPythonBuild(ZScript):
             make_initrd(self, f"python{config.EXE}", test=True)
 
         # clean debug build artifacts
-        self._make_args("clean", release=False).run(cwd=paths.repo_root())
+        if config.IS_WINDOWS:
+            build_mod.docker_mod.clean_volume(paths.repo_root())
+        else:
+            self._make_args("clean", release=False).run(cwd=paths.repo_root())
 
         # build for release
         args = self._make_args(release=True)


### PR DESCRIPTION
 Build test and release artifacts up front; make `test`/`release` pure consumers

 `./z test` was rebuilding CPython on every run and racing with `./z release`:
 the release pass overwrote `python.elf` with a `--without-doc-strings` /
 `--disable-test-modules` binary, which `test` then copied into the staging
 tree, breaking any regrtest module that introspects docstrings.

 `./z build` now does both passes up front:

   1. test build    -> installed into `paths.test_out()` (with `Lib/test/` and
                       the stripped `python.elf` copied in before it gets
                       clobbered).
   2. `make clean`
   3. release build -> installed into `paths.release_dir()`.

 `./z test` and `./z release` (`package.py`) become pure consumers of those
 staged trees -- no build, no install, no rebuild-detection heuristics.

 Drops `NANVIX_RELEASE`, `_manual_install()`, and the ~130 lines of
 "is BUILD_PYTHON usable / was configure run in Docker / can we skip the
 rebuild" logic in `_test.stage()`. `build.install()` owns wiping its destdir
 and staging the test binary/stdlib.

 Net -89 lines; full lifecycle (setup/lint/build/test/release) passes.

STACKED ON https://github.com/nanvix/cpython/pull/719
Closes #710 