### PR TITLE
.nanvix: consolidate make invocations behind MakeArgs dataclass

### DIFF
--- a/.nanvix/_docker.py
+++ b/.nanvix/_docker.py
@@ -10,10 +10,15 @@ invocation for configure/build/install only.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import os
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import build as build_mod
 
 import config
 
@@ -31,7 +36,7 @@ def _volume_name(workspace: Path) -> str:
 
 def _docker_run_base(
     workspace: Path,
-    nanvix_home: Path,
+    args: build_mod.MakeArgs,
     image: str = config.DOCKER_IMAGE,
 ) -> list[str]:
     """Build the common ``docker run`` prefix."""
@@ -49,7 +54,7 @@ def _docker_run_base(
         "-v",
         f"{workspace}:/mnt/host-workspace",
         "-v",
-        f"{nanvix_home.resolve()}:{config.DOCKER_SYSROOT_PATH}:ro",
+        f"{args.sysroot.resolve()}:{config.DOCKER_SYSROOT_PATH}:ro",
         "-w",
         config.DOCKER_WORKSPACE_PATH,
         "-e",
@@ -93,13 +98,8 @@ def sync_sources(
 
 def docker_build(
     workspace: Path,
-    nanvix_home: Path,
+    args: build_mod.MakeArgs,
     *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
     install_destdir: Path | None = None,
 ) -> None:
     """Run cross-compilation inside Docker (Windows host mode).
@@ -111,17 +111,10 @@ def docker_build(
     the same container and copies the install tree to the host.  This
     avoids a second Docker invocation during testing.
     """
-    base = _docker_run_base(workspace, nanvix_home)
+    _args = dataclasses.replace(args, docker=True, targets=["build"])
+    base = _docker_run_base(workspace, _args)
     sync = sync_sources(workspace)
-    inner_make = _inner_make_cmd(
-        "build",
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=release,
-    )
-    copy_back = _copy_outputs_cmd(workspace)
+    copy_back = _copy_outputs_cmd()
 
     # Explicit strip command — ensure binaries are fully stripped even if
     # the Makefile's strip step is skipped (e.g. toolchain detection fails
@@ -162,18 +155,15 @@ def docker_build(
         f"{sync} && cd {config.DOCKER_WORKSPACE_PATH} && "
         f"{sysroot_check} && "
         f"{_generate_setup_local_cmd()} && "
-        f"{inner_make} && {strip_build}"
+        f"{_args.to_string()} && {strip_build}"
     )
 
     if install_destdir is not None:
-        install_make = _inner_make_cmd(
-            f"install DESTDIR={config.DOCKER_WORKSPACE_PATH}/_install_staging",
-            platform=platform,
-            process_mode=process_mode,
-            memory_size=memory_size,
-            install_prefix=install_prefix,
-            release=release,
-        )
+        targets = [
+            "install",
+            f"DESTDIR={config.DOCKER_WORKSPACE_PATH}/_install_staging",
+        ]
+        _args = dataclasses.replace(_args, targets=targets)
         try:
             rel_dest = install_destdir.relative_to(workspace).as_posix()
         except ValueError:
@@ -182,7 +172,7 @@ def docker_build(
         # Strip the installed binary too so the install cache is lean.
         install_bin = (
             f"{config.DOCKER_WORKSPACE_PATH}/_install_staging"
-            f"{install_prefix}/bin/{config.python_binary()}"
+            f"{_args.install_prefix}/bin/{config.python_binary()}"
         )
         strip_install = (
             f'[ -x "{strip_bin}" ] && [ -f "{install_bin}" ] && '
@@ -197,7 +187,7 @@ def docker_build(
             f"/mnt/host-workspace/{rel_dest}/"
         )
         shell_cmd += (
-            f" && {install_make} && {strip_install}; rc=$?; "
+            f" && {_args.to_string()} && {strip_install}; rc=$?; "
             f"{copy_back}; {install_copy}; exit $rc"
         )
     else:
@@ -211,26 +201,17 @@ def docker_build(
 
 def docker_install(
     workspace: Path,
-    nanvix_home: Path,
     destdir: Path,
-    *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
+    args: build_mod.MakeArgs,
 ) -> None:
     """Run make install inside Docker (Windows host mode)."""
-    base = _docker_run_base(workspace, nanvix_home)
+    targets = [
+        "install",
+        f"DESTDIR={config.DOCKER_WORKSPACE_PATH}/_install_staging",
+    ]
+    _args = dataclasses.replace(args, docker=True, targets=targets)
+    base = _docker_run_base(workspace, _args)
     sync = sync_sources(workspace)
-    inner_make = _inner_make_cmd(
-        f"install DESTDIR={config.DOCKER_WORKSPACE_PATH}/_install_staging",
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=release,
-    )
 
     # Compute relative path so nested destdirs (e.g. .nanvix/_test_staging)
     # are preserved correctly on the host.
@@ -243,14 +224,14 @@ def docker_install(
     strip_bin = f"{config.DOCKER_TOOLCHAIN_PATH}/bin/{config.TOOLCHAIN_TRIPLET}-strip"
     install_bin = (
         f"{config.DOCKER_WORKSPACE_PATH}/_install_staging"
-        f"{install_prefix}/bin/{config.python_binary()}"
+        f"{_args.install_prefix}/bin/{config.python_binary()}"
     )
     strip_cmd = (
         f'[ -x "{strip_bin}" ] && [ -f "{install_bin}" ] && '
         f'"{strip_bin}" --strip-all "{install_bin}" || true'
     )
     shell_cmd = (
-        f"{sync} && cd {config.DOCKER_WORKSPACE_PATH} && {inner_make}; rc=$?; "
+        f"{sync} && cd {config.DOCKER_WORKSPACE_PATH} && {_args.to_string()}; rc=$?; "
         f"{strip_cmd}; "
         f"if [ -d {config.DOCKER_WORKSPACE_PATH}/_install_staging ]; then "
         f"mkdir -p /mnt/host-workspace/{rel_dest} && "
@@ -291,32 +272,7 @@ def _generate_setup_local_cmd() -> str:
     )
 
 
-def _inner_make_cmd(
-    targets: str,
-    *,
-    platform: str,
-    process_mode: str,
-    memory_size: str,
-    install_prefix: str,
-    release: bool,
-) -> str:
-    """Build the inner make command string for execution inside Docker."""
-    release_str = "yes" if release else "no"
-    return (
-        f"make -f Makefile.nanvix "
-        f"CONFIG_NANVIX=y "
-        f"NANVIX_HOME={config.DOCKER_SYSROOT_PATH} "
-        f"NANVIX_TOOLCHAIN={config.DOCKER_TOOLCHAIN_PATH} "
-        f"PLATFORM={platform} "
-        f"PROCESS_MODE={process_mode} "
-        f"MEMORY_SIZE={memory_size} "
-        f"INSTALL_PREFIX={install_prefix} "
-        f"NANVIX_RELEASE={release_str} "
-        f"{targets}"
-    )
-
-
-def _copy_outputs_cmd(workspace: Path) -> str:
+def _copy_outputs_cmd() -> str:
     """Build shell command to copy build outputs back to host workspace."""
     copies: list[str] = []
     for f in config.DOCKER_OUTPUT_FILES:

--- a/.nanvix/_test.py
+++ b/.nanvix/_test.py
@@ -22,7 +22,8 @@ import tarfile
 import time
 import urllib.request
 from pathlib import Path
-from typing import Any
+
+from nanvix_zutil import paths
 
 import build as build_mod
 import config
@@ -101,19 +102,14 @@ def _create_initrd(
 # ---------------------------------------------------------------------------
 
 
-def _download_release_as_cache(
-    repo_root: Path,
-    platform: str,
-    process_mode: str,
-    memory_size: str,
-) -> Path:
+def _download_release_as_cache(args: build_mod.MakeArgs) -> Path:
     """Download the latest cpython release tarball and extract it as _install_cache.
 
     This lets ``./z test`` work on Windows without a prior ``./z build``
     (which requires Docker). The release tarball contains the same
     sysroot tree that ``./z build`` would produce.
     """
-    cache_dir = repo_root / ".nanvix" / "_install_cache"
+    cache_dir = paths.nanvix_root() / "_install_cache"
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -133,14 +129,13 @@ def _download_release_as_cache(
     print(f"  Resolved cpython release: {tag}")
 
     # Find a standalone tarball asset (.tar.gz preferred, .tar.bz2 fallback).
-    asset_prefix = f"cpython-{platform}-{process_mode}-{memory_size}"
     asset_url = None
     asset_name = None
     for ext in (".tar.gz", ".tar.bz2"):
         for a in release.get("assets", []):
             name = a.get("name", "")
             if (
-                name.startswith(asset_prefix)
+                name.startswith(args.asset_prefix())
                 and name.endswith(ext)
                 and "buildroot" not in name
             ):
@@ -152,13 +147,13 @@ def _download_release_as_cache(
 
     if not asset_url:
         raise FileNotFoundError(
-            f"No cpython release asset matching '{asset_prefix}*.tar.gz' or '*.tar.bz2' "
+            f"No cpython release asset matching '{args.asset_prefix()}*.tar.gz' or '*.tar.bz2' "
             f"in release {tag}. Available assets: "
             + ", ".join(a["name"] for a in release.get("assets", []))
         )
 
     # Download.
-    dl_dir = repo_root / ".nanvix" / "cache"
+    dl_dir = paths.nanvix_root() / "cache"
     dl_dir.mkdir(parents=True, exist_ok=True)
     assert asset_name is not None
     tarball = dl_dir / asset_name
@@ -208,7 +203,7 @@ def _download_release_as_cache(
     # needs it. The source checkout has the full Lib/test/.
     pylib_dir = sysroot / "lib" / config.PYTHON_LIB_DIR
     test_dst = pylib_dir / "test"
-    test_src = repo_root / "Lib" / "test"
+    test_src = paths.repo_root() / "Lib" / "test"
     if test_src.is_dir() and not test_dst.is_dir():
         shutil.copytree(test_src, test_dst)
         test_count = sum(1 for _ in test_dst.rglob("*.py"))
@@ -224,9 +219,8 @@ def _download_release_as_cache(
 
 
 def _manual_install(
-    repo_root: Path,
     staging: Path,
-    install_prefix: str,
+    args: build_mod.MakeArgs,
 ) -> None:
     """Create a minimal install tree without invoking make.
 
@@ -235,7 +229,7 @@ def _manual_install(
     the source/build tree into the staging directory.
     """
     # install_prefix is e.g. "/sysroot" — strip leading slash for relative path.
-    prefix_rel = install_prefix.lstrip("/")
+    prefix_rel = args.install_prefix.lstrip("/")
     sysroot_dir = staging / prefix_rel
     bin_dir = sysroot_dir / "bin"
     lib_dir = sysroot_dir / "lib" / config.PYTHON_LIB_DIR
@@ -244,26 +238,26 @@ def _manual_install(
     lib_dir.mkdir(parents=True, exist_ok=True)
 
     # Copy the built python binary.
-    python_bin = repo_root / f"python{config.EXE}"
+    python_bin = paths.repo_root() / f"python{config.EXE}"
     if python_bin.is_file():
         shutil.copy2(python_bin, bin_dir / config.python_binary())
 
     # Copy the standard library from Lib/.
-    lib_src = repo_root / "Lib"
+    lib_src = paths.repo_root() / "Lib"
     if lib_src.is_dir():
         shutil.copytree(lib_src, lib_dir, dirs_exist_ok=True)
 
     # Copy sysconfigdata from the build directory.
     scdata_name = f"{config.SYSCONFIGDATA_NAME}.py"
-    pybuilddir_file = repo_root / "pybuilddir.txt"
+    pybuilddir_file = paths.repo_root() / "pybuilddir.txt"
     if pybuilddir_file.is_file():
-        bdir = repo_root / pybuilddir_file.read_text().strip()
+        bdir = paths.repo_root() / pybuilddir_file.read_text().strip()
         scdata_src = bdir / scdata_name
         if scdata_src.is_file():
             shutil.copy2(scdata_src, lib_dir / scdata_name)
 
     # Copy libpython archive (needed by some install validation).
-    libpython = repo_root / f"libpython{config.PYTHON_VERSION}.a"
+    libpython = paths.repo_root() / f"libpython{config.PYTHON_VERSION}.a"
     lib_parent = sysroot_dir / "lib"
     if libpython.is_file():
         shutil.copy2(libpython, lib_parent / libpython.name)
@@ -272,23 +266,13 @@ def _manual_install(
 
 
 def stage(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
-    *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
-    run_fn: Any = None,
-    docker: bool = False,
+    args: build_mod.MakeArgs,
 ) -> Path:
     """Build, install, and stage CPython for testing.
 
     Returns the test staging directory.
     """
-    staging = repo_root / ".nanvix" / "_test_staging"
+    staging = paths.nanvix_root() / "_test_staging"
 
     print("Running CPython tests on Nanvix...")
     if staging.exists():
@@ -297,7 +281,7 @@ def stage(
     if config.IS_WINDOWS:
         # On Windows, use the cached install tree produced by ``./z build``
         # so that no Docker invocation is needed during testing.
-        install_cache = repo_root / ".nanvix" / "_install_cache"
+        install_cache = paths.nanvix_root() / "_install_cache"
         if install_cache.is_dir():
             shutil.copytree(install_cache, staging)
             print("  Using cached install from ./z build")
@@ -306,12 +290,7 @@ def stage(
             # install cache. This lets ``./z test`` work on Windows
             # without a prior ``./z build`` (which requires Docker).
             print("  Install cache not found — downloading release artifacts...")
-            install_cache = _download_release_as_cache(
-                repo_root,
-                platform,
-                process_mode,
-                memory_size,
-            )
+            install_cache = _download_release_as_cache(args)
             shutil.copytree(install_cache, staging)
             print("  Using downloaded release as install cache")
     else:
@@ -320,12 +299,12 @@ def stage(
         # the build tree is properly configured, and the host cannot use
         # BUILD_PYTHON (e.g. after a prior Docker build where that tool
         # is unavailable outside the container).
-        python_binary = repo_root / f"python{config.EXE}"
-        configured_marker = repo_root / ".nanvix-configured"
-        pybuilddir = repo_root / "pybuilddir.txt"
+        python_binary = paths.repo_root() / f"python{config.EXE}"
+        configured_marker = paths.repo_root() / ".nanvix-configured"
+        pybuilddir = paths.repo_root() / "pybuilddir.txt"
 
         # Determine whether BUILD_PYTHON is usable on the host.
-        build_python_path = Path(toolchain) / "bin" / "python3"
+        build_python_path = Path(args.toolchain_path) / "bin" / "python3"
         build_python_available = (
             build_python_path.is_file()
             or shutil.which(str(build_python_path)) is not None
@@ -335,8 +314,8 @@ def stage(
         # /mnt/sysroot baked into Makefile).  A native rebuild would
         # fail because those paths don't exist on the host.
         docker_configured = False
-        makefile = repo_root / "Makefile"
-        if makefile.is_file() and not docker:
+        makefile = paths.repo_root() / "Makefile"
+        if makefile.is_file() and not args.docker:
             try:
                 header = makefile.read_text(encoding="utf-8", errors="replace")[:8192]
                 docker_configured = config.DOCKER_SYSROOT_PATH in header
@@ -364,51 +343,18 @@ def stage(
                 # Cannot run make install natively when configure used
                 # Docker paths and the native toolchain would trigger a
                 # rebuild — do a manual install instead.
-                _manual_install(repo_root, staging, install_prefix)
+                _manual_install(staging, args)
             else:
                 # Install into staging, skipping the outer build prereq
                 # and stubbing PYTHON_FOR_BUILD for the inner make.
                 build_mod.install(
-                    sysroot,
-                    toolchain,
-                    repo_root,
                     staging,
-                    platform=platform,
-                    process_mode=process_mode,
-                    memory_size=memory_size,
-                    install_prefix=install_prefix,
-                    release=release,
-                    run_fn=run_fn,
+                    args,
                     extra_make_flags=["-o", "build", "PYTHON_FOR_BUILD=:"],
-                    docker=docker,
                 )
         else:
-            build_mod.build(
-                sysroot,
-                toolchain,
-                repo_root,
-                platform=platform,
-                process_mode=process_mode,
-                memory_size=memory_size,
-                install_prefix=install_prefix,
-                release=release,
-                run_fn=run_fn,
-                docker=docker,
-            )
-
-            build_mod.install(
-                sysroot,
-                toolchain,
-                repo_root,
-                staging,
-                platform=platform,
-                process_mode=process_mode,
-                memory_size=memory_size,
-                install_prefix=install_prefix,
-                release=release,
-                run_fn=run_fn,
-                docker=docker,
-            )
+            build_mod.build(args)
+            build_mod.install(staging, args)
 
     sysroot_dir = staging / "sysroot"
 
@@ -420,9 +366,9 @@ def stage(
     scdata_name = f"{config.SYSCONFIGDATA_NAME}.py"
     scdata_dst = sysroot_dir / "lib" / config.PYTHON_LIB_DIR / scdata_name
     if not scdata_dst.is_file():
-        pybuilddir = repo_root / "pybuilddir.txt"
+        pybuilddir = paths.repo_root() / "pybuilddir.txt"
         if pybuilddir.is_file():
-            bdir = repo_root / pybuilddir.read_text().strip()
+            bdir = paths.repo_root() / pybuilddir.read_text().strip()
             scdata_src = bdir / scdata_name
             if scdata_src.is_file():
                 shutil.copy2(scdata_src, scdata_dst)
@@ -441,7 +387,7 @@ def stage(
     # xmlInitParser() hangs in multi-process/single-process modes where
     # filesystem I/O goes through nanvixd's virtualized host-FS layer.
     hello_script = sysroot_dir / "test_hello.py"
-    standalone = process_mode == "standalone"
+    standalone = args.process_mode == "standalone"
     lxml_snippet = (
         "try:\n"
         "    import lxml.etree\n"
@@ -467,14 +413,13 @@ def stage(
     # stage_ramfs().  Standalone mode mounts the ramfs as /, so the
     # script must already be present at this point — copying it later
     # (e.g. from run_smoke_httpserver) is too late.
-    httpserver_src = repo_root / "httpserver.py"
+    httpserver_src = paths.repo_root() / "httpserver.py"
     if httpserver_src.is_file():
         shutil.copy2(httpserver_src, sysroot_dir / "httpserver.py")
 
     # Copy Nanvix runtime binaries.
     bin_dir = sysroot_dir / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
-    nanvix_home = Path(sysroot)
     for binary in [
         "nanvixd.elf",
         "kernel.elf",
@@ -490,12 +435,12 @@ def stage(
         "memd.elf",
         "vfsd.elf",
     ]:
-        src = nanvix_home / "bin" / binary
+        src = args.sysroot / "bin" / binary
         if src.is_file():
             shutil.copy2(src, bin_dir / binary)
 
     # Replace unstripped python binary with stripped python.elf.
-    stripped = repo_root / f"python{config.EXE}"
+    stripped = paths.repo_root() / f"python{config.EXE}"
     if stripped.is_file():
         target = bin_dir / config.python_binary()
         shutil.copy2(stripped, target)
@@ -503,15 +448,15 @@ def stage(
         print(f"  Installed stripped python.elf into staging ({size // 1024}K)")
 
     # Copy guest-side test runner.
-    regrtest_runner = repo_root / ".nanvix" / "run-regrtest.py"
+    regrtest_runner = paths.nanvix_root() / "run-regrtest.py"
     if regrtest_runner.is_file():
         shutil.copy2(regrtest_runner, sysroot_dir / "run-regrtest.py")
 
     # Invalidate stale ramfs image and cache from previous runs.
-    stale_ramfs = repo_root / ".nanvix" / "cpython-rootfs.img"
+    stale_ramfs = paths.nanvix_root() / "cpython-rootfs.img"
     if stale_ramfs.is_file():
         stale_ramfs.unlink()
-    stale_cache = repo_root / ".nanvix" / "_ramfs_cache"
+    stale_cache = paths.nanvix_root() / "_ramfs_cache"
     if stale_cache.is_dir():
         shutil.rmtree(stale_cache)
 
@@ -525,8 +470,7 @@ def stage(
 
 def stage_ramfs(
     staging: Path,
-    nanvix_home: Path,
-    repo_root: Path,
+    args: build_mod.MakeArgs,
     ramfs_img: Path | None = None,
 ) -> Path:
     """Build a ramfs image for standalone mode testing.
@@ -536,9 +480,9 @@ def stage_ramfs(
     Returns the path to the ramfs image.
     """
     if ramfs_img is None:
-        ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
+        ramfs_img = paths.nanvix_root() / "cpython-rootfs.img"
 
-    ramfs_cache = repo_root / ".nanvix" / "_ramfs_cache"
+    ramfs_cache = paths.nanvix_root() / "_ramfs_cache"
 
     if ramfs_img.is_file() and (ramfs_cache / "sysroot").is_dir():
         print(f"  Using cached ramfs: {ramfs_img}")
@@ -560,7 +504,7 @@ def stage_ramfs(
     # Trim and build ramfs image (keep tests for test pipeline).
     ramfs_mod.trim_and_build(
         ramfs_cache,
-        nanvix_home,
+        args.sysroot,
         ramfs_img,
         keep_tests=True,
     )
@@ -576,12 +520,10 @@ def stage_ramfs(
 def _run_nanvixd_script(
     staging: Path,
     script_name: str,
+    args: build_mod.MakeArgs,
     *,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    platform: str = config.DEFAULT_PLATFORM,
     nanvixd_extra: list[str] | None = None,
     ramfs_img: Path | None = None,
-    nanvix_home: Path | None = None,
     timeout: int = 120,
     label: str = "script",
 ) -> tuple[int, str, int]:
@@ -594,13 +536,13 @@ def _run_nanvixd_script(
     resolved_extra: list[str] = (
         nanvixd_extra
         if nanvixd_extra is not None
-        else config.PLATFORM_NANVIXD_ARGS.get(platform, [])
+        else config.PLATFORM_NANVIXD_ARGS.get(args.platform, [])
     )
     # On Windows, CreateProcess searches for the executable relative to the
     # *parent's* CWD, not the child's cwd. Use an absolute path to avoid this.
     nanvixd = str((sysroot / "bin" / config.nanvixd_binary()).resolve())
     python_bin = f"./bin/{config.python_binary()}"
-    standalone = process_mode == "standalone"
+    standalone = args.process_mode == "standalone"
 
     if standalone:
         if ramfs_img is None:
@@ -609,20 +551,19 @@ def _run_nanvixd_script(
         # Copy host tools and daemon ELFs into the staging sysroot.
         # mkramfs is needed for ramfs generation; mkimage and the daemons
         # (procd, memd, vfsd) are needed for initrd creation.
-        if nanvix_home:
-            # Daemons are *guest* binaries — always .elf, even on
-            # Windows.  Only host tools use the platform extension.
-            _staging_bins = [
-                config.mkramfs_binary(),
-                config.mkimage_binary(),
-                "procd.elf",
-                "memd.elf",
-                "vfsd.elf",
-            ]
-            for name in _staging_bins:
-                src = nanvix_home / "bin" / name
-                if src.is_file():
-                    shutil.copy2(src, sysroot / "bin" / name)
+        # Daemons are *guest* binaries — always .elf, even on
+        # Windows.  Only host tools use the platform extension.
+        _staging_bins = [
+            config.mkramfs_binary(),
+            config.mkimage_binary(),
+            "procd.elf",
+            "memd.elf",
+            "vfsd.elf",
+        ]
+        for name in _staging_bins:
+            src = args.sysroot / "bin" / name
+            if src.is_file():
+                shutil.copy2(src, sysroot / "bin" / name)
 
     initrd_img: Path | None = None
     if standalone:
@@ -683,12 +624,9 @@ def _run_nanvixd_script(
 
 def run_hello(
     staging: Path,
-    *,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    platform: str = config.DEFAULT_PLATFORM,
+    args: build_mod.MakeArgs,
     nanvixd_extra: list[str] | None = None,
     ramfs_img: Path | None = None,
-    nanvix_home: Path | None = None,
 ) -> None:
     """Run the hello-world test via nanvixd.
 
@@ -696,18 +634,16 @@ def run_hello(
     environment variable syntax.  Multi-process and single-process modes
     use direct host-filesystem access (no ramfs).
     """
-    standalone = process_mode == "standalone"
+    standalone = args.process_mode == "standalone"
 
-    print(f"Test: Hello world ({process_mode})...")
+    print(f"Test: Hello world ({args.process_mode})...")
 
     returncode, output, elapsed_ms = _run_nanvixd_script(
         staging,
         "test_hello.py",
-        process_mode=process_mode,
-        platform=platform,
+        args,
         nanvixd_extra=nanvixd_extra,
         ramfs_img=ramfs_img,
-        nanvix_home=nanvix_home,
         label="Hello test",
     )
     print(f"  Execution time: {elapsed_ms} ms")
@@ -749,13 +685,10 @@ def run_hello(
 
 def run_smoke_httpserver(
     staging: Path,
-    repo_root: Path,
+    args: build_mod.MakeArgs,
     *,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    platform: str = config.DEFAULT_PLATFORM,
     nanvixd_extra: list[str] | None = None,
     ramfs_img: Path | None = None,
-    nanvix_home: Path | None = None,
     host: str = "127.0.0.1",
     port: int = 9999,
     boot_timeout: float = 60.0,
@@ -779,10 +712,10 @@ def run_smoke_httpserver(
     import socket as _socket
     import tempfile
 
-    standalone = process_mode == "standalone"
+    standalone = args.process_mode == "standalone"
     if not standalone:
         print(
-            f"Test: HTTP server smoke ({process_mode})... "
+            f"Test: HTTP server smoke ({args.process_mode})... "
             "SKIP (networking only available in standalone mode)"
         )
         return
@@ -798,23 +731,23 @@ def run_smoke_httpserver(
     resolved_extra: list[str] = (
         nanvixd_extra
         if nanvixd_extra is not None
-        else config.PLATFORM_NANVIXD_ARGS.get(platform, [])
+        else config.PLATFORM_NANVIXD_ARGS.get(args.platform, [])
     )
     nanvixd = str((sysroot / "bin" / config.nanvixd_binary()).resolve())
 
     if ramfs_img is None:
         raise ValueError("ramfs_img is required for standalone mode")
-    if nanvix_home is not None:
-        for name in (
-            config.mkramfs_binary(),
-            config.mkimage_binary(),
-            "procd.elf",
-            "memd.elf",
-            "vfsd.elf",
-        ):
-            hp = nanvix_home / "bin" / name
-            if hp.is_file():
-                shutil.copy2(hp, sysroot / "bin" / name)
+
+    for name in (
+        config.mkramfs_binary(),
+        config.mkimage_binary(),
+        "procd.elf",
+        "memd.elf",
+        "vfsd.elf",
+    ):
+        hp = args.sysroot / "bin" / name
+        if hp.is_file():
+            shutil.copy2(hp, sysroot / "bin" / name)
 
     bin_dir = sysroot / "bin"
     app_path = sysroot / "bin" / config.python_binary()
@@ -835,7 +768,7 @@ def run_smoke_httpserver(
         str(initrd_img),
     ]
 
-    print(f"Test: HTTP server smoke ({process_mode}) on {host}:{port}...")
+    print(f"Test: HTTP server smoke ({args.process_mode}) on {host}:{port}...")
 
     # Capture stdout/stderr to a file so we can both poll for the
     # "listening" marker without risking PIPE deadlock and include the
@@ -935,18 +868,15 @@ def run_smoke_httpserver(
 
 def run_regrtest(
     staging: Path,
-    repo_root: Path,
+    args: build_mod.MakeArgs,
     *,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    platform: str = config.DEFAULT_PLATFORM,
     test_list: list[str] | None = None,
     batch_size: int = config.DEFAULT_TEST_BATCH_SIZE,
     nanvixd_extra: list[str] | None = None,
     ramfs_img: Path | None = None,
-    release: bool = False,
 ) -> None:
     """Run stdlib regression tests via run-tests.py."""
-    if release:
+    if args.release:
         print("Test: regrtest skipped (NANVIX_RELEASE=yes)")
         return
 
@@ -956,12 +886,12 @@ def run_regrtest(
     resolved_nanvixd_extra: list[str] = (
         nanvixd_extra
         if nanvixd_extra is not None
-        else config.PLATFORM_NANVIXD_ARGS.get(platform, [])
+        else config.PLATFORM_NANVIXD_ARGS.get(args.platform, [])
     )
-    standalone = process_mode == "standalone"
+    standalone = args.process_mode == "standalone"
 
     sysroot = staging / "sysroot"
-    run_tests_script = repo_root / ".nanvix" / "run-tests.py"
+    run_tests_script = paths.nanvix_root() / "run-tests.py"
 
     env = os.environ.copy()
     env["NANVIX_TEST_BATCH_SIZE"] = str(batch_size)
@@ -970,7 +900,7 @@ def run_regrtest(
     if standalone:
         # Standalone: ramfs + initrd-based invocation.
         if ramfs_img is None:
-            ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
+            ramfs_img = paths.nanvix_root() / "cpython-rootfs.img"
         bin_dir = sysroot / "bin"
         extra_str = f"-bin-dir {bin_dir} -ramfs {ramfs_img}"
         if resolved_nanvixd_extra:
@@ -992,7 +922,7 @@ def run_regrtest(
 
     cmd = [sys.executable, str(run_tests_script)] + test_list
 
-    print(f"Test: regrtest ({len(test_list)} modules, {process_mode})...")
+    print(f"Test: regrtest ({len(test_list)} modules, {args.process_mode})...")
     result = subprocess.run(cmd, cwd=sysroot, env=env)
     if result.returncode != 0:
         raise RuntimeError(f"regrtest failed with exit code {result.returncode}")
@@ -1003,9 +933,9 @@ def run_regrtest(
 # ---------------------------------------------------------------------------
 
 
-def cleanup(repo_root: Path) -> None:
+def cleanup() -> None:
     """Clean up test artifacts."""
-    staging = repo_root / ".nanvix" / "_test_staging"
+    staging = paths.nanvix_root() / "_test_staging"
     if staging.is_dir():
         shutil.rmtree(staging)
     for name in [
@@ -1013,18 +943,18 @@ def cleanup(repo_root: Path) -> None:
         "cpython_regrtest.log",
         "cpython_regrtest_batch.log",
     ]:
-        p = repo_root / ".nanvix" / name
+        p = paths.nanvix_root() / name
         if p.is_file():
             p.unlink()
 
 
-def deep_cleanup(repo_root: Path) -> None:
+def deep_cleanup() -> None:
     """Deep clean: remove cached ramfs template."""
-    cleanup(repo_root)
-    ramfs_cache = repo_root / ".nanvix" / "_ramfs_cache"
+    cleanup()
+    ramfs_cache = paths.nanvix_root() / "_ramfs_cache"
     if ramfs_cache.is_dir():
         shutil.rmtree(ramfs_cache)
-    ramfs_img = repo_root / ".nanvix" / "cpython-rootfs.img"
+    ramfs_img = paths.nanvix_root() / "cpython-rootfs.img"
     if ramfs_img.is_file():
         ramfs_img.unlink()
 
@@ -1035,82 +965,55 @@ def deep_cleanup(repo_root: Path) -> None:
 
 
 def run_all(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
+    args: build_mod.MakeArgs,
     *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
     test_list: list[str] | None = None,
     batch_size: int = config.DEFAULT_TEST_BATCH_SIZE,
     nanvixd_extra: list[str] | None = None,
-    run_fn: Any = None,
-    docker: bool = False,
 ) -> None:
     """Run the complete test pipeline: stage → hello → regrtest → cleanup."""
-    nanvix_home = Path(sysroot)
-    standalone = process_mode == "standalone"
+    standalone = args.process_mode == "standalone"
 
     # Stage.
     staging = stage(
-        sysroot,
-        toolchain,
-        repo_root,
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=release,
-        run_fn=run_fn,
-        docker=docker,
+        args,
     )
-    lxml_mod.stage_lxml_runtime(repo_root, staging / "sysroot")
+    lxml_mod.stage_lxml_runtime(staging / "sysroot")
 
     # Ramfs — only needed for standalone mode.  Multi-process and
     # single-process use host-filesystem access (no ramfs).
     ramfs_img = None
     if standalone:
-        ramfs_img = stage_ramfs(staging, nanvix_home, repo_root)
+        ramfs_img = stage_ramfs(staging, args)
 
     # Hello test.
     run_hello(
         staging,
-        process_mode=process_mode,
-        platform=platform,
+        args,
         nanvixd_extra=nanvixd_extra,
         ramfs_img=ramfs_img,
-        nanvix_home=nanvix_home,
     )
 
     # HTTP server smoke test.
     run_smoke_httpserver(
         staging,
-        repo_root,
-        process_mode=process_mode,
-        platform=platform,
+        args,
         nanvixd_extra=nanvixd_extra,
         ramfs_img=ramfs_img,
-        nanvix_home=nanvix_home,
     )
 
     # Regression tests.
     run_regrtest(
         staging,
-        repo_root,
-        process_mode=process_mode,
-        platform=platform,
+        args,
         test_list=test_list,
         batch_size=batch_size,
         nanvixd_extra=nanvixd_extra,
         ramfs_img=ramfs_img,
-        release=release,
     )
 
     # Cleanup.
-    cleanup(repo_root)
+    cleanup()
 
     print("\t\t*** CPython tests PASSED ***")
 
@@ -1121,17 +1024,9 @@ def run_all(
 
 
 def run_benchmark(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
+    args: build_mod.MakeArgs,
     *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
     nanvixd_extra: list[str] | None = None,
-    run_fn: Any = None,
-    docker: bool = False,
 ) -> None:
     """Run a hello-world benchmark.
 
@@ -1143,57 +1038,23 @@ def run_benchmark(
 
     No regression tests are executed.
     """
-    nanvix_home = Path(sysroot)
-    standalone = process_mode == "standalone"
-
     try:
         _run_benchmark_impl(
-            sysroot,
-            toolchain,
-            repo_root,
-            nanvix_home=nanvix_home,
-            standalone=standalone,
-            platform=platform,
-            process_mode=process_mode,
-            memory_size=memory_size,
-            install_prefix=install_prefix,
+            args,
             nanvixd_extra=nanvixd_extra,
-            run_fn=run_fn,
-            docker=docker,
         )
     finally:
-        cleanup(repo_root)
+        cleanup()
 
 
 def _run_benchmark_impl(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
+    args: build_mod.MakeArgs,
     *,
-    nanvix_home: Path,
-    standalone: bool,
-    platform: str,
-    process_mode: str,
-    memory_size: str,
-    install_prefix: str,
     nanvixd_extra: list[str] | None = None,
-    run_fn: Any = None,
-    docker: bool = False,
 ) -> None:
     """Inner implementation of :func:`run_benchmark`."""
     # Stage (reuses cached build).
-    staging = stage(
-        sysroot,
-        toolchain,
-        repo_root,
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=False,
-        run_fn=run_fn,
-        docker=docker,
-    )
+    staging = stage(args)
 
     # Write a minimal benchmark script.
     bench_script = "bench_hello.py"
@@ -1201,9 +1062,9 @@ def _run_benchmark_impl(
 
     # Build ramfs with release trimming (keep_tests=False).
     ramfs_img = None
-    if standalone:
-        ramfs_img = repo_root / ".nanvix" / "cpython-benchmark.img"
-        bench_cache = repo_root / ".nanvix" / "_benchmark_cache"
+    if args.process_mode == "standalone":
+        ramfs_img = paths.nanvix_root() / "cpython-benchmark.img"
+        bench_cache = paths.nanvix_root() / "_benchmark_cache"
 
         # Always rebuild to reflect the current sysroot.
         if bench_cache.exists():
@@ -1218,7 +1079,7 @@ def _run_benchmark_impl(
         # Release-style trim: no test/ dir, no dev artifacts.
         ramfs_mod.trim_and_build(
             bench_cache,
-            nanvix_home,
+            args.sysroot,
             ramfs_img,
             keep_tests=False,
         )
@@ -1227,16 +1088,14 @@ def _run_benchmark_impl(
         shutil.rmtree(bench_cache, ignore_errors=True)
 
     # Run benchmark.
-    print(f"Benchmark: Hello world ({process_mode})...")
+    print(f"Benchmark: Hello world ({args.process_mode})...")
 
     returncode, output, elapsed_ms = _run_nanvixd_script(
         staging,
         bench_script,
-        process_mode=process_mode,
-        platform=platform,
+        args,
         nanvixd_extra=nanvixd_extra,
         ramfs_img=ramfs_img,
-        nanvix_home=nanvix_home,
         label="Benchmark",
     )
     print(f"  Execution time: {elapsed_ms} ms")

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -10,187 +10,132 @@ build/install/clean targets from common.mk. Constructs and executes
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+import dataclasses
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
+
+from nanvix_zutil import paths
 
 import _docker as docker_mod
 import config
 import lxml as lxml_mod
 
 
-def make_args(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    *targets: str,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
-) -> list[str]:
-    """Build the make argument list for Makefile.nanvix.
-
-    Args:
-        sysroot: Path to the Nanvix sysroot.
-        toolchain: Path to the Nanvix cross-compilation toolchain.
-
-    Returns:
-        Complete argument list starting with ``make``.
+@dataclass
+class MakeArgs:
     """
-    sysroot_p = Path(sysroot)
-    toolchain_p = Path(toolchain)
-
-    args = [
-        "make",
-        "-f",
-        "Makefile.nanvix",
-        f"CONFIG_NANVIX=y",
-        f"NANVIX_HOME={sysroot_p}",
-        f"NANVIX_TOOLCHAIN={toolchain_p}",
-        f"PLATFORM={platform}",
-        f"PROCESS_MODE={process_mode}",
-        f"MEMORY_SIZE={memory_size}",
-        f"INSTALL_PREFIX={install_prefix}",
-        f"NANVIX_RELEASE={'yes' if release else 'no'}",
-    ]
-    args.extend(targets)
-    return args
-
-
-def run_make(
-    args: list[str],
-    *,
-    cwd: Path | None = None,
-    run_fn: Any = None,
-) -> None:
-    """Execute a make command.
-
-    Args:
-        args: Full make argument list (from :func:`make_args`).
-        cwd: Working directory.
-        run_fn: Callable to execute the command. Defaults to
-            ``subprocess.run`` with check=True.
+    Common arguments passed to Makefile.nanvix.
     """
-    if run_fn:
-        run_fn(*args, cwd=cwd)
-    else:
-        subprocess.run(args, cwd=cwd, check=True)
+
+    toolchain_path: Path
+    release: bool
+    targets: list[str]
+    platform: str = config.DEFAULT_PLATFORM
+    process_mode: str = config.DEFAULT_PROCESS_MODE
+    memory_size: str = config.DEFAULT_MEMORY_SIZE
+    install_prefix: str = config.DEFAULT_INSTALL_PREFIX
+    sysroot: Path = field(default_factory=lambda: paths.nanvix_root() / "sysroot")
+    run_fn: Any = None
+    docker: bool = False
+
+    def to_list(self) -> list[str]:
+        """Convert to a list suitable to pass to a process runner."""
+        nanvix_toolchain = (
+            Path(config.DOCKER_TOOLCHAIN_PATH) if self.docker else self.toolchain_path
+        )
+        nanvix_home = Path(config.DOCKER_SYSROOT_PATH) if self.docker else self.sysroot
+        return [
+            "make",
+            "-f",
+            "Makefile.nanvix",
+            f"CONFIG_NANVIX=y",
+            f"NANVIX_HOME={nanvix_home}",
+            f"NANVIX_TOOLCHAIN={nanvix_toolchain}",
+            f"PLATFORM={self.platform}",
+            f"PROCESS_MODE={self.process_mode}",
+            f"MEMORY_SIZE={self.memory_size}",
+            f"INSTALL_PREFIX={self.install_prefix}",
+            f"NANVIX_RELEASE={'yes' if self.release else 'no'}",
+            *self.targets,
+        ]
+
+    def to_string(self) -> str:
+        import shlex
+
+        return shlex.join(self.to_list())
+
+    def run(self, *, cwd: Path | None = None):
+        """Execute a make command.
+        Args:
+            cwd: Working directory.
+        """
+        if self.run_fn:
+            self.run_fn(*self.to_list(), cwd=cwd)
+        else:
+            subprocess.run(self.to_list(), cwd=cwd, check=True)
+
+    def asset_prefix(self) -> str:
+        return f"cpython-{self.platform}-{self.process_mode}-{self.memory_size}"
 
 
 def build(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
-    *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
-    run_fn: Any = None,
-    docker: bool = False,
+    args: MakeArgs,
 ) -> None:
     """Cross-compile python.elf for Nanvix."""
+    _args = dataclasses.replace(args, targets=["build"])
     if config.IS_WINDOWS:
         # Build and install in one Docker invocation so the install tree
         # is cached for later use by ``./z test`` (no Docker during tests).
-        install_cache = repo_root / ".nanvix" / "_install_cache"
-        docker_mod.docker_build(
-            repo_root,
-            Path(sysroot),
-            platform=platform,
-            process_mode=process_mode,
-            memory_size=memory_size,
-            install_prefix=install_prefix,
-            release=release,
-            install_destdir=install_cache,
-        )
+        install_cache = paths.nanvix_root() / "_install_cache"
+        docker_mod.docker_build(paths.repo_root(), args, install_destdir=install_cache)
         return
-    effective_sysroot = config.DOCKER_SYSROOT_PATH if docker else sysroot
-    effective_toolchain = config.DOCKER_TOOLCHAIN_PATH if docker else toolchain
-    lxml_mod.generate_setup_local(repo_root, Path(effective_sysroot))
-    args = make_args(
-        effective_sysroot,
-        effective_toolchain,
-        "build",
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=release,
+    sysroot_for_setup = (
+        Path(config.DOCKER_SYSROOT_PATH) if _args.docker else args.sysroot
     )
-    run_make(args, cwd=repo_root, run_fn=run_fn)
+    lxml_mod.generate_setup_local(paths.repo_root(), sysroot_for_setup)
+    _args.run(cwd=paths.repo_root())
 
 
 def install(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
     destdir: Path,
+    args: MakeArgs,
     *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = False,
-    run_fn: Any = None,
     extra_make_flags: list[str] | None = None,
-    docker: bool = False,
 ) -> None:
     """Install CPython into a staging directory."""
     if config.IS_WINDOWS:
-        docker_mod.docker_install(
-            repo_root,
-            Path(sysroot),
-            destdir,
-            platform=platform,
-            process_mode=process_mode,
-            memory_size=memory_size,
-            install_prefix=install_prefix,
-            release=release,
-        )
+        docker_mod.docker_install(paths.repo_root(), destdir, args)
         return
-    effective_sysroot = config.DOCKER_SYSROOT_PATH if docker else sysroot
-    effective_toolchain = config.DOCKER_TOOLCHAIN_PATH if docker else toolchain
     # When running inside Docker, repo_root maps to /mnt/workspace.
     # Use a relative DESTDIR so it resolves correctly inside the container.
     try:
-        rel_destdir = destdir.resolve().relative_to(repo_root.resolve())
+        rel_destdir = destdir.resolve().relative_to(paths.repo_root())
     except ValueError:
         rel_destdir = destdir
-    args = make_args(
-        effective_sysroot,
-        effective_toolchain,
-        *(extra_make_flags or []),
-        "install",
-        f"DESTDIR={rel_destdir}",
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=release,
-    )
-    run_make(args, cwd=repo_root, run_fn=run_fn)
+    targets = [*(extra_make_flags or []), "install", f"DESTDIR={rel_destdir}"]
+    _args = dataclasses.replace(args, targets=targets)
+    _args.run(cwd=paths.repo_root())
 
 
-def clean(repo_root: Path) -> None:
+def clean() -> None:
     """Remove build artifacts."""
     if config.IS_WINDOWS:
         for name in (".nanvix-configured", "python.elf", "python.exe"):
-            p = repo_root / name
+            p = paths.repo_root() / name
             if p.is_file():
                 p.unlink()
                 print(f"Removed {name}")
         for name in ("_test_staging", "staging", "_install_cache", "_ramfs_cache"):
-            p = repo_root / ".nanvix" / name
+            p = paths.nanvix_root() / name
             if p.is_dir():
                 shutil.rmtree(p)
                 print(f"Removed .nanvix/{name}/")
     else:
         subprocess.run(
             ["make", "-f", "Makefile.nanvix", "clean"],
-            cwd=repo_root,
+            cwd=paths.repo_root(),
             check=False,
         )

--- a/.nanvix/lxml.py
+++ b/.nanvix/lxml.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from nanvix_zutil import paths
+
 import config
 
 _SETUP_LOCAL_TEMPLATE = """\
@@ -38,13 +40,13 @@ def clear_setup_local(repo_root: Path) -> None:
         print(f"[lxml] Removed {setup_local}")
 
 
-def stage_lxml_runtime(repo_root: Path, sysroot: Path) -> None:
+def stage_lxml_runtime(sysroot: Path) -> None:
     """Copy lxml Python files from buildroot into the test/package sysroot.
 
     Looks for lxml in ``.nanvix/buildroot/python-packages/lxml/``.
     Skips gracefully when the python-packages directory is not available.
     """
-    lxml_src = repo_root / ".nanvix" / "buildroot" / "python-packages" / "lxml"
+    lxml_src = paths.nanvix_root() / "buildroot" / "python-packages" / "lxml"
     if not lxml_src.is_dir():
         print(
             f"[lxml] Staged lxml package not found at {lxml_src}; "

--- a/.nanvix/package.py
+++ b/.nanvix/package.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import shutil
 import tarfile
-from pathlib import Path
-from typing import Any
 import build as build_mod
 import config
 import lxml as lxml_mod
@@ -20,43 +18,18 @@ import ramfs as ramfs_mod
 from nanvix_zutil import paths
 
 
-def _artifact_base(
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-) -> str:
-    """Return the base name for release tarballs."""
-    return f"cpython-{platform}-{process_mode}-{memory_size}"
-
-
 def package(
-    sysroot: str | Path,
-    toolchain: str | Path,
-    repo_root: Path,
-    *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-    install_prefix: str = config.DEFAULT_INSTALL_PREFIX,
-    release: bool = True,
-    run_fn: Any = None,
-    nanvix_home: str | Path | None = None,
-    docker: bool = False,
+    args: build_mod.MakeArgs,
 ) -> None:
     """Package CPython release tarballs.
 
     Creates two tarballs in ``nanvix_zutil.paths.dist_dir()``:
     - ``cpython-<platform>-<mode>-<memory>.tar.gz`` — runtime sysroot + binary + ramfs
     - ``cpython-<platform>-<mode>-<memory>-buildroot.tar.gz`` — build dependencies
-
-    Args:
-        nanvix_home: Host-side path to the Nanvix sysroot for local
-            file operations (mkramfs, etc.).  Defaults to *sysroot*.
     """
-    nanvix_home = Path(nanvix_home) if nanvix_home else Path(sysroot)
-    release_staging = repo_root / ".nanvix" / "release"
+    release_staging = paths.nanvix_root() / "release"
     dist_dir = paths.dist_dir()
-    artifact = _artifact_base(platform, process_mode, memory_size)
+    artifact = args.asset_prefix()
 
     print("Packaging CPython release...")
 
@@ -65,40 +38,17 @@ def package(
         shutil.rmtree(release_staging)
 
     # Build.
-    build_mod.build(
-        sysroot,
-        toolchain,
-        repo_root,
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=True,
-        run_fn=run_fn,
-        docker=docker,
-    )
+    build_mod.build(args)
 
     # Install into staging.
-    build_mod.install(
-        sysroot,
-        toolchain,
-        repo_root,
-        release_staging,
-        platform=platform,
-        process_mode=process_mode,
-        memory_size=memory_size,
-        install_prefix=install_prefix,
-        release=True,
-        run_fn=run_fn,
-        docker=docker,
-    )
+    build_mod.install(release_staging, args)
 
     sysroot_installed = release_staging / "sysroot"
     if not sysroot_installed.is_dir():
         raise FileNotFoundError(f"Install did not produce {sysroot_installed}")
 
     # Stage lxml Python package into the installed sysroot.
-    lxml_mod.stage_lxml_runtime(repo_root, sysroot_installed)
+    lxml_mod.stage_lxml_runtime(sysroot_installed)
 
     # --- Buildroot: build dependencies ---
     buildroot_pkg = release_staging / "buildroot-pkg"
@@ -165,7 +115,7 @@ def package(
 
     # --- Include python.elf binary ---
     bin_dir = release_staging / "bin"
-    python_elf = repo_root / f"python{config.EXE}"
+    python_elf = paths.repo_root() / f"python{config.EXE}"
     if python_elf.is_file():
         bin_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(python_elf, bin_dir / "python.elf")
@@ -176,7 +126,7 @@ def package(
 
     # --- Build ramfs image ---
     ramfs_img = release_staging / "cpython-ramfs.img"
-    ramfs_mod.build_image(ramfs_staging, nanvix_home, ramfs_img)
+    ramfs_mod.build_image(ramfs_staging, args.sysroot, ramfs_img)
 
     # --- Create release tarballs ---
     dist_dir.mkdir(parents=True, exist_ok=True)
@@ -205,19 +155,13 @@ def package(
         print(f"  {f.name} ({size // 1024}K)")
 
 
-def verify(
-    repo_root: Path,
-    *,
-    platform: str = config.DEFAULT_PLATFORM,
-    process_mode: str = config.DEFAULT_PROCESS_MODE,
-    memory_size: str = config.DEFAULT_MEMORY_SIZE,
-) -> None:
+def verify(args: build_mod.MakeArgs) -> None:
     """Verify release tarballs.
 
     Checks that tarballs exist, are not corrupt, and contain the
     expected contents.
     """
-    artifact = _artifact_base(platform, process_mode, memory_size)
+    artifact = args.asset_prefix()
     dist_dir = paths.dist_dir()
 
     print("Verifying release tarballs...")

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -26,6 +26,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from nanvix_zutil import paths
+
 import _test as test_mod
 import build as build_mod
 import config
@@ -46,7 +48,7 @@ from nanvix_zutil.buildroot import (
     extract_nanvix_version_base,
 )
 from nanvix_zutil.github import resolve_release_with_fallback
-from nanvix_zutil.paths import nanvix_root, repo_root
+from nanvix_zutil.paths import nanvix_root
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -135,7 +137,7 @@ class CPythonBuild(ZScript):
 
     # ---- Common helpers --------------------------------------------------
 
-    def _get_host_paths(self) -> tuple[str, str]:
+    def _get_host_paths(self) -> tuple[Path, Path]:
         """Return (sysroot, toolchain) raw host paths from config."""
         sysroot = self.config.get(CFG_SYSROOT, "")
         if not sysroot:
@@ -144,53 +146,23 @@ class CPythonBuild(ZScript):
                 code=EXIT_MISSING_DEP,
                 hint="Run `./z setup` first to download the sysroot.",
             )
-        toolchain = str(TOOLCHAIN_CONTAINER_PATH)
-        return sysroot, toolchain
+        toolchain = Path(TOOLCHAIN_CONTAINER_PATH)
+        return Path(sysroot), toolchain
 
-    def _build_kwargs(self, release: bool = False) -> dict[str, object]:
-        """Return common keyword arguments for build/test/package modules."""
-        return {
-            "platform": self.config.machine,
-            "process_mode": self.config.deployment_mode,
-            "memory_size": self.config.memory_size,
-            "install_prefix": _DEFAULT_INSTALL_PREFIX,
-            "release": release,
-        }
-
-    # ---- Make invocation (for build/install only) ------------------------
-
-    def _run_make(self, make_args: list[str]) -> None:
-        """Execute a make command directly (Linux/macOS only).
-
-        On Windows, callers should use ``build_mod.build()`` or
-        ``build_mod.install()`` which route through ``docker_mod``
-        automatically.
-        """
-        if sys.platform == "win32":
-            raise RuntimeError(
-                "_run_make() is not supported on Windows. "
-                "Use build_mod.build() / build_mod.install() instead."
-            )
-        run(*make_args, cwd=repo_root())
-
-    def _make_args(self, *targets: str) -> list[str]:
+    def _make_args(self, *targets: str, release: bool = False) -> build_mod.MakeArgs:
         """Build the make argument list for configure/build/install."""
         sysroot, toolchain = self._get_host_paths()
-        release = os.environ.get(_MAKE_VAR_RELEASE, "no")
-
-        return build_mod.make_args(
-            str(
-                self.docker.translate_path(Path(sysroot))
-                if self.docker
-                else Path(sysroot)
-            ),
-            toolchain,
-            *targets,
+        return build_mod.MakeArgs(
+            toolchain_path=toolchain,
+            sysroot=sysroot,
+            targets=list(targets),
             platform=self.config.machine,
             process_mode=self.config.deployment_mode,
             memory_size=self.config.memory_size,
             install_prefix=_DEFAULT_INSTALL_PREFIX,
-            release=(release == "yes"),
+            release=release,
+            docker=self.docker is not None,
+            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[assignment]
         )
 
     def setup(self) -> bool:
@@ -205,7 +177,6 @@ class CPythonBuild(ZScript):
         used_fallback = super().setup()
 
         self._install_missing_deps()
-
         self.config.save()
 
         buildroot = nanvix_root() / "buildroot"
@@ -236,18 +207,9 @@ class CPythonBuild(ZScript):
     def build(self) -> None:
         """Cross-compile python.elf and libpython.a for Nanvix."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_host_paths()
         release = os.environ.get(_MAKE_VAR_RELEASE, "no") == "yes"
-        build_mod.build(
-            sysroot,
-            toolchain,
-            repo_root(),
-            **self._build_kwargs(
-                release=release
-            ),  # pyright: ignore[reportArgumentType]
-            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
-        )
+        args = self._make_args(release=release)
+        build_mod.build(args)
 
         # For standalone deployment mode, produce an initrd image
         # containing the system daemons and the application binary.
@@ -257,68 +219,37 @@ class CPythonBuild(ZScript):
     def test(self) -> None:
         """Run the CPython test suite (hello + regrtest)."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_host_paths()
-        kwargs = self._build_kwargs()
-
+        args = self._make_args(release=False)
         nanvixd_extra = ["-allow-host-networking"]
 
         test_mod.run_all(
-            sysroot,
-            toolchain,
-            repo_root(),
-            **kwargs,  # pyright: ignore[reportArgumentType]
+            args,
             nanvixd_extra=nanvixd_extra,
-            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
         )
 
     def benchmark(self) -> None:
         """Run hello-world benchmark with a release-style ramfs."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_host_paths()
-        kwargs = self._build_kwargs()
-
         nanvixd_extra = ["-allow-host-networking"]
-
-        # run_benchmark does not use 'release' — always stages a
-        # non-release build and applies release trimming itself.
-        bench_kwargs = {k: v for k, v in kwargs.items() if k != "release"}
+        args = self._make_args(release=False)
         test_mod.run_benchmark(
-            sysroot,
-            toolchain,
-            repo_root(),
-            **bench_kwargs,  # pyright: ignore[reportArgumentType]
+            args,
             nanvixd_extra=nanvixd_extra,
-            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
         )
 
     def release(self) -> None:
         """Package the CPython release tarballs and verify them."""
         self._overlay_local_nanvix()
-        sysroot, toolchain = self._get_host_paths()
-        kwargs = self._build_kwargs(release=True)
+        args = self._make_args(release=True)
 
-        package_mod.package(
-            sysroot,
-            toolchain,
-            repo_root(),
-            **kwargs,  # pyright: ignore[reportArgumentType]
-            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[arg-type]
-            docker=self.docker is not None,
-        )
-        package_mod.verify(
-            repo_root(),
-            platform=kwargs["platform"],  # pyright: ignore[reportArgumentType]
-            process_mode=kwargs["process_mode"],  # pyright: ignore[reportArgumentType]
-            memory_size=kwargs["memory_size"],  # pyright: ignore[reportArgumentType]
-        )
+        package_mod.package(args)
+        package_mod.verify(args)
 
     def clean(self) -> None:
         """Remove build artifacts."""
-        build_mod.clean(repo_root())
+        build_mod.clean()
         # Remove initrd image generated for standalone mode.
-        initrd = repo_root() / "python.img"
+        initrd = paths.repo_root() / "python.img"
         if initrd.exists():
             initrd.unlink()
 


### PR DESCRIPTION
- Replace free-function make_args()/run_make() in build.py with a MakeArgs dataclass owning to_list()/to_string()/run()/asset_prefix().
- Drive docker-vs-host path selection from args.docker rather than having callers swap sysroot/toolchain paths before invocation.
- Thread MakeArgs through _docker.py, _test.py, package.py, lxml.py, and z.py; drop _inner_make_cmd, _artifact_base, _build_kwargs, _run_make, and the list-returning _make_args.
- lxml.stage_lxml_runtime() loses its repo_root param; uses paths.
- z.py: single _make_args(*targets, release=False) -> MakeArgs; use nanvix_zutil.paths consistently.

No behavioural change: full lifecycle (setup, lint, build, test, release) passes locally.