### PR TITLE
Windows Docker build: keep container paths POSIX in MakeArgs

### DIFF
--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -43,10 +43,14 @@ class MakeArgs:
 
     def to_list(self) -> list[str]:
         """Convert to a list suitable to pass to a process runner."""
+        # When targeting Docker, these are POSIX paths *inside* the Linux
+        # container and must stay as forward-slash strings.  Wrapping them in
+        # Path() on a Windows host would rewrite them with backslashes
+        # (e.g. "\opt\nanvix"), breaking the in-container make invocation.
         nanvix_toolchain = (
-            Path(config.DOCKER_TOOLCHAIN_PATH) if self.docker else self.toolchain_path
+            config.DOCKER_TOOLCHAIN_PATH if self.docker else self.toolchain_path
         )
-        nanvix_home = Path(config.DOCKER_SYSROOT_PATH) if self.docker else self.sysroot
+        nanvix_home = config.DOCKER_SYSROOT_PATH if self.docker else self.sysroot
         return [
             "make",
             "-f",


### PR DESCRIPTION
## Problem

`./z build` was broken on Windows after merge #723 (MakeArgs dataclass consolidation). The build failed with:

```
Makefile.nanvix:54: *** Nanvix toolchain not found at \opt\nanvix and Docker is not available.  Stop.
```

## Root cause

In `MakeArgs.to_list()`, the in-container POSIX paths `DOCKER_TOOLCHAIN_PATH` (`/opt/nanvix`) and `DOCKER_SYSROOT_PATH` (`/mnt/sysroot`) were wrapped in `Path()`. These are paths *inside* the Linux Docker container. On a Windows host, `Path('/opt/nanvix')` produces a `WindowsPath` that renders with backslashes (`\opt\nanvix`), so `make` received `NANVIX_TOOLCHAIN=\opt\nanvix` and could not find the toolchain.

## Fix

Pass the raw POSIX string constants in Docker mode instead of wrapping them in `Path()`, matching the pre-merge behavior. Container paths now stay forward-slash regardless of host OS.

## Testing

- `./z build` on Windows (`--with-docker ghcr.io/nanvix/toolchain-python:latest`) now completes with \success: Build complete\, producing fresh \python.elf\, \libpython3.12.a\, and \python.img\.