### PR TITLE
Fix Windows Docker volume mount path translation (#734)

### DIFF
--- a/.nanvix/_docker.py
+++ b/.nanvix/_docker.py
@@ -34,6 +34,26 @@ def _volume_name(workspace: Path) -> str:
     return f"cpython-nanvix-build-{_workspace_id(workspace)}"
 
 
+def _docker_mount_source(path: Path) -> str:
+    """Render *path* as a Docker bind-mount source.
+
+    Docker's ``-v src:dst[:mode]`` syntax splits fields on ``:``.  On
+    Windows, ``Path`` renders drive-letter paths like ``C:\\Users\\foo``,
+    whose colon is misread as a field separator -- producing errors such
+    as ``invalid mode: /mnt/host-workspace``.  Translate drive-letter
+    paths to the ``//c/Users/foo`` form that Docker accepts and which
+    contains no colon.  POSIX paths are returned unchanged.
+    """
+    resolved = path.resolve()
+    drive = resolved.drive
+    # Drive-letter prefix, e.g. "C:" (UNC drives are longer and skipped).
+    if len(drive) == 2 and drive[1] == ":":
+        letter = drive[0].lower()
+        rest = str(resolved)[len(drive) :].replace("\\", "/").lstrip("/")
+        return f"//{letter}/{rest}"
+    return str(resolved)
+
+
 def _docker_run_base(
     workspace: Path,
     args: build_mod.MakeArgs,
@@ -52,9 +72,9 @@ def _docker_run_base(
         "-v",
         f"{volume}:{config.DOCKER_WORKSPACE_PATH}",
         "-v",
-        f"{workspace}:/mnt/host-workspace",
+        f"{_docker_mount_source(workspace)}:/mnt/host-workspace",
         "-v",
-        f"{args.sysroot.resolve()}:{config.DOCKER_SYSROOT_PATH}:ro",
+        f"{_docker_mount_source(args.sysroot)}:{config.DOCKER_SYSROOT_PATH}:ro",
         "-w",
         config.DOCKER_WORKSPACE_PATH,
         "-e",


### PR DESCRIPTION
## Problem

Fixes #734.

On Windows hosts, the Docker host-mode build (`./z build`) failed with:

```
docker: Error response from daemon: invalid mode: /mnt/host-workspace
```

`_docker_run_base()` emitted bind-mount sources as raw drive-letter paths, e.g.:

```
-v C:\Users\...\cpython:/mnt/host-workspace
-v C:\Users\...\cpython\.nanvix\sysroot:/mnt/sysroot:ro
```

Docker's `-v src:dst[:mode]` syntax splits on `:`, so the drive-letter colon in `C:` is misread as a field separator. Docker then interprets `/mnt/host-workspace` as the *mode*, fails validation, and aborts the build.

## Fix

Add `_docker_mount_source()`, which rewrites drive-letter paths to the colon-free `//c/Users/...` form that Docker accepts, and route both host-side bind mounts (host-workspace and sysroot) through it. POSIX paths are returned unchanged, so Linux/macOS behavior is identical.

## Verification

Reproduced the exact reported error locally with a non-normalizing docker client:

```
docker: Error response from daemon: invalid mode: /mnt/host-workspace   (exit 125)
```

After the fix, `_docker_run_base()` generates:

```
-v cpython-nanvix-build-8dc0fce1:/mnt/workspace
-v //c/Users/ppenna/Projects/cpython:/mnt/host-workspace
-v //c/Users/ppenna/Projects/cpython/.nanvix/sysroot:/mnt/sysroot:ro
```

Running that translated mount through `docker.exe` mounts the real repo contents and exits 0.

- `python -m py_compile .nanvix/_docker.py` passes
- `black --check .nanvix/_docker.py` clean
