### PR TITLE
[nanvix] E: Build bz2/lzma/zlib/sqlite3 as DT_NEEDED .so chains

### DIFF
--- a/.nanvix/runtime_sos.py
+++ b/.nanvix/runtime_sos.py
@@ -31,10 +31,18 @@ from typing import Iterable
 #   _ssl.cpython-312.so              -> libssl.so + libcrypto.so
 #     libssl.so                      -> libcrypto.so
 #   _hashlib.cpython-312.so          -> libcrypto.so
+#   _bz2.cpython-312.so              -> libbz2.so
+#   _lzma.cpython-312.so             -> liblzma.so
+#   zlib.cpython-312.so              -> libz.so
+#   _sqlite3.cpython-312.so          -> libsqlite3.so
 REQUIRED_RUNTIME_SOS: tuple[str, ...] = (
     "libffi.so",
     "libcrypto.so",
     "libssl.so",
+    "libbz2.so",
+    "liblzma.so",
+    "libz.so",
+    "libsqlite3.so",
 )
 
 

--- a/.nanvix/setup_local.py
+++ b/.nanvix/setup_local.py
@@ -277,25 +277,21 @@ SETUP_LOCAL_ENTRIES: tuple[SetupEntry, ...] = (
     SetupEntry(name="termios", linkage=Linkage.SHARED, tokens=("termios.c",)),
     # ---------------- Modules with external Nanvix-ported deps ---------
     #
-    # libffi, libssl, libcrypto each ship as a .so under $(SYSROOT)/lib/
-    # and the consuming extension .so (_ctypes, _ssl, _hashlib)
-    # references it via DT_NEEDED. The loader resolves them at dlopen
-    # time and binds UND symbols against python.elf .dynsym.
-    #
-    # _bz2 / _lzma / zlib / _sqlite3 are intentionally NOT moved here:
-    # the Nanvix port repos for libbz2 / liblzma / libz / libsqlite3 do
-    # not yet ship .so builds, so those four extensions stay statically
-    # built into python.elf (cpython upstream default) until the
-    # follow-up PR that lands alongside the Wave 6 port-repo .so PRs.
+    # libffi / libssl / libcrypto / libbz2 / liblzma / libz / libsqlite3
+    # each ship as a .so under $(SYSROOT)/lib/ and the consuming
+    # extension .so emits DT_NEEDED for it; the Nanvix dynamic loader
+    # walks the chain at dlopen time and binds UND symbols against
+    # python.elf .dynsym. This matches the upstream cpython behavior
+    # when configure is invoked with system-library detection enabled
+    # (the default on every Linux distro).
     SetupEntry(
         name="_ssl",
         linkage=Linkage.SHARED,
         tokens=("_ssl.c",),
         section_header=(
-            "Stdlib modules with external Nanvix-ported deps that are "
-            "already shipped as .so by their respective port repos. "
-            "Each .so emits DT_NEEDED for the corresponding sysroot "
-            "library; the loader walks the chain at dlopen time."
+            "Stdlib modules with external Nanvix-ported deps. Each .so "
+            "emits DT_NEEDED for the corresponding sysroot library; the "
+            "loader walks the chain at dlopen time."
         ),
     ),
     SetupEntry(name="_hashlib", linkage=Linkage.SHARED, tokens=("_hashopenssl.c",)),
@@ -308,6 +304,24 @@ SETUP_LOCAL_ENTRIES: tuple[SetupEntry, ...] = (
             "_ctypes/callproc.c",
             "_ctypes/stgdict.c",
             "_ctypes/cfield.c",
+        ),
+    ),
+    SetupEntry(name="_bz2", linkage=Linkage.SHARED, tokens=("_bz2module.c",)),
+    SetupEntry(name="_lzma", linkage=Linkage.SHARED, tokens=("_lzmamodule.c",)),
+    SetupEntry(name="zlib", linkage=Linkage.SHARED, tokens=("zlibmodule.c",)),
+    SetupEntry(
+        name="_sqlite3",
+        linkage=Linkage.SHARED,
+        tokens=(
+            "_sqlite/blob.c",
+            "_sqlite/connection.c",
+            "_sqlite/cursor.c",
+            "_sqlite/microprotocols.c",
+            "_sqlite/module.c",
+            "_sqlite/prepare_protocol.c",
+            "_sqlite/row.c",
+            "_sqlite/statement.c",
+            "_sqlite/util.c",
         ),
     ),
 )

--- a/.nanvix/test.py
+++ b/.nanvix/test.py
@@ -114,6 +114,11 @@ _SO_MODULE_SANITY_CHECKS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = 
             ("_ssl", "hasattr(m, 'RAND_bytes')"),
             ("_hashlib", "hasattr(m, 'openssl_sha256') or hasattr(m, 'new')"),
             ("_ctypes", "hasattr(m, 'dlopen')"),
+            # libbz2 / liblzma / libz / libsqlite3: same DT_NEEDED model.
+            ("_bz2", "m.BZ2Compressor().compress(b'hello') is not None"),
+            ("_lzma", "hasattr(m, 'LZMACompressor')"),
+            ("zlib", "m.crc32(b'hello') == 0x3610a686"),
+            ("_sqlite3", "hasattr(m, 'connect')"),
         ),
     ),
 )

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -79,15 +79,15 @@ _CFG_LOCAL_NANVIX = "local_nanvix_path"
 
 # Map dependency names to the library files they install into buildroot/lib.
 _DEP_EXPECTED_LIBS: dict[str, list[str]] = {
-    "bzip2": ["libbz2.a"],
+    "bzip2": ["libbz2.a", "libbz2.so"],
     "libffi": ["libffi.a", "libffi.so"],
-    "zlib": ["libz.a"],
-    "sqlite": ["libsqlite3.a"],
+    "zlib": ["libz.a", "libz.so"],
+    "sqlite": ["libsqlite3.a", "libsqlite3.so"],
     "openssl": ["libssl.a", "libcrypto.a", "libssl.so", "libcrypto.so"],
     "libxml2": ["libxml2.a"],
     "libxslt": ["libxslt.a", "libexslt.a"],
     "lxml": ["liblxml_etree.a", "liblxml_elementpath.a"],
-    "xz": ["liblzma.a"],
+    "xz": ["liblzma.a", "liblzma.so"],
 }
 
 

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -185,17 +185,18 @@ endif
 # which libnvx_crt0 is the sole provider. Listing it first today keeps
 # python.elf using a consistent `_start` source across both states.
 #
-# `LIBS` segment 2 (`--start-group ... --end-group`): the external
-# Nanvix-ported libraries (`-lsqlite3 -lz -lbz2 -llzma`) whose .a files
-# stay statically linked into python.elf. The corresponding extensions
-# (_sqlite3, zlib, _bz2, _lzma) remain *static* in Setup.local for now
-# because the Nanvix port repos for libbz2 / libz / liblzma /
-# libsqlite3 do not yet ship .so builds. The follow-up cpython PR that
-# lands alongside the Wave 6 port-repo .so PRs migrates these four
-# extensions to *shared* with DT_NEEDED references to lib*.so. -lssl
-# / -lcrypto / -lffi are NOT in this list -- they ship as separate .so
-# files under sysroot/lib/ and are referenced via DT_NEEDED by their
-# consumer .so modules (_ssl, _hashlib, _ctypes).
+# `LIBS` segment 2 (empty after the Wave 7 unbundling): with libffi /
+# libssl / libcrypto / libsqlite3 / libz / libbz2 / liblzma all
+# shipped as .so under sysroot/lib/, python.elf no longer bundles any
+# external Nanvix-ported libraries. The per-module .so wrappers
+# (_ssl, _hashlib, _ctypes, _sqlite3, zlib, _bz2, _lzma) reference
+# the corresponding system .so via DT_NEEDED; the Nanvix dynamic
+# loader walks the chain at dlopen time and binds UND symbols against
+# python.elf .dynsym. The per-module *_LIBS environment variables
+# (LIBSQLITE3_LIBS, ZLIB_LIBS, BZIP2_LIBS, LIBLZMA_LIBS, LIBFFI_LIBS)
+# in -L/-l form make ld emit the DT_NEEDED entry rather than
+# embedding the .a -- exactly the upstream cpython behavior for
+# system-library builds (Linux distro default).
 CONFIGURE_ENV = \
 	CC="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-gcc" \
 	CXX="$(TOOLCHAIN_PREFIX)/bin/i686-nanvix-g++" \
@@ -205,7 +206,7 @@ CONFIGURE_ENV = \
 	CFLAGS="-O3 -fomit-frame-pointer -fno-unwind-tables -fno-asynchronous-unwind-tables -I$(SYSROOT_PATH)/include" \
 	CFLAGS_NODIST="-fno-semantic-interposition" \
 	LDFLAGS="-L$(SYSROOT_PATH)/lib -T$(SYSROOT_PATH)/lib/user.ld -Wl,--allow-multiple-definition -no-pie -Wl,--export-dynamic -Wl,--no-dynamic-linker" \
-	LIBS="-Wl,--whole-archive $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBSTDCXX) $(LIBGCC) -Wl,--no-whole-archive -Wl,--start-group -lsqlite3 -lz -lbz2 -llzma -Wl,--end-group" \
+	LIBS="-Wl,--whole-archive $(LIBNVX_CRT0) $(LIBPOSIX) $(LIBC) $(LIBM) $(LIBSTDCXX) $(LIBGCC) -Wl,--no-whole-archive" \
 	LIBSQLITE3_LIBS="-L$(SYSROOT_PATH)/lib -lsqlite3" \
 	LIBSQLITE3_CFLAGS="-I$(SYSROOT_PATH)/include" \
 	ZLIB_LIBS="-L$(SYSROOT_PATH)/lib -lz" \


### PR DESCRIPTION
## Summary

Completes the external-library unbundling started in nanvix/cpython#738 by moving the remaining four stdlib extensions (`_bz2`, `_lzma`, `zlib`, `_sqlite3`) from being statically linked into `python.elf` to runtime-loaded `.so` files emitting `DT_NEEDED` for `libbz2.so` / `liblzma.so` / `libz.so` / `libsqlite3.so`.

After this PR, `python.elf` bundles no external Nanvix-ported libraries at all — every `.so` wrapper (`_ssl`, `_hashlib`, `_ctypes`, `_sqlite3`, `zlib`, `_bz2`, `_lzma`) consumes its underlying library through DT_NEEDED. This matches upstream cpython's default behavior on every Linux distro (system-library detection enabled).

## Why

The previous PR (nanvix/cpython#738) took the libffi / openssl / lxml consumers to DT_NEEDED `.so` chains but left these four extensions statically linked into `python.elf` because the Nanvix port repos for `bzip2` / `zlib` / `xz` / `sqlite` did not yet ship `.so` builds. The four port-repo PRs listed under **Dependencies** below add those `.so` builds, which finally lets this PR finish the migration.

## What changed

4 stdlib modules migrated from `*static*` (linked into `python.elf`) to `*shared*` (loaded via dlopen). The corresponding `LIBSQLITE3_LIBS` / `ZLIB_LIBS` / `BZIP2_LIBS` / `LIBLZMA_LIBS` env vars already use `-L/-l` form in nanvix/cpython#738 (no change needed there); cpython's normal `MODULE_*_LDFLAGS` machinery wires them into each `.so`'s link line as DT_NEEDED.

```
DT_NEEDED .so chains added by this PR:
  _bz2.cpython-312.so       -> libbz2.so
  _lzma.cpython-312.so      -> liblzma.so
  zlib.cpython-312.so       -> libz.so
  _sqlite3.cpython-312.so   -> libsqlite3.so
```

The Nanvix dynamic loader walks each DT_NEEDED chain at `dlopen()` time, and UND symbols in any of those `.so` files bind to `python.elf .dynsym`.

## Mechanics

| File | Change |
|---|---|
| `.nanvix/setup_local.py` | Adds 4 `*shared*` entries (`_bz2`, `_lzma`, `zlib`, `_sqlite3`). |
| `Makefile.nanvix` | Drops `-lsqlite3 -lz -lbz2 -llzma` from `python.elf` `LIBS`; the `-Wl,--start-group ... -Wl,--end-group` block is gone. Per-module `*_LIBS` env vars unchanged (already in `-L/-l` form from nanvix/cpython#738). |
| `.nanvix/runtime_sos.py` | `REQUIRED_RUNTIME_SOS` gains `libbz2.so` / `liblzma.so` / `libz.so` / `libsqlite3.so` so `.nanvix/test.py` and `.nanvix/package.py` stage them into `sysroot/lib/` at run time. |
| `.nanvix/z.py` | `_DEP_EXPECTED_LIBS` for `bzip2`, `zlib`, `sqlite`, `xz` extended with the `.so` siblings so `./z setup` validates that the new shared-library port builds installed correctly into `buildroot/lib`. |
| `.nanvix/test.py` | Extends `CPYTHON_TEST_EXTERNAL_DEPS` smoke test with the 4 new modules. |

## Dependencies

**Base branch:** nanvix/cpython#738.

**Runtime dependencies — the four port-repo PRs that produce the `.so` files this PR consumes:**

- [nanvix/bzip2#279](https://github.com/nanvix/bzip2/pull/279) — `libbz2.so` build target.
- [nanvix/zlib#255](https://github.com/nanvix/zlib/pull/255) — `libz.so` build target.
- [nanvix/xz#97](https://github.com/nanvix/xz/pull/97) — `liblzma.so` build target.
- [nanvix/sqlite#268](https://github.com/nanvix/sqlite/pull/268) — `libsqlite3.so` build target.

These four PRs must land and their port-lib releases must be pinned in cpython's `nanvix.toml` before this PR is mergeable upstream.

**Also inherits the runtime deps already required by nanvix/cpython#738:**

- [nanvix/nanvix#2473](https://github.com/nanvix/nanvix/pull/2473) — `dlfcn` init-array + DT_RUNPATH support (already merged upstream).
- The upstream diamond DT_NEEDED loader fix and the libposix `pthread_once` fix described in nanvix/cpython#738 (in-flight in `nanvix/nanvix`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


