### PR TITLE
[nanvix] Makefile.nanvix: drop dead LIBSSL/LIBCRYPTO/LIBZ/LIBSQLITE3 vars

### DIFF
--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -87,10 +87,6 @@ ifdef CONFIG_NANVIX
     LIBC := $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libc.a
     LIBM := $(DOCKER_TOOLCHAIN_PATH)/i686-nanvix/lib/libm.a
     LIBPOSIX := $(DOCKER_SYSROOT_PATH)/lib/libposix.a
-    LIBZ := $(DOCKER_SYSROOT_PATH)/lib/libz.a
-    LIBSQLITE3 := $(DOCKER_SYSROOT_PATH)/lib/libsqlite3.a
-    LIBSSL := $(DOCKER_SYSROOT_PATH)/lib/libssl.a
-    LIBCRYPTO := $(DOCKER_SYSROOT_PATH)/lib/libcrypto.a
     # libnvx_crt0 ships the executable startup symbols (`_do_start`, `_start`,
     # `c_trampoline`).  It must be present in the Nanvix sysroot ahead of this
     # cpython build; the existence check below fails loudly when it is not.
@@ -102,10 +98,6 @@ ifdef CONFIG_NANVIX
     LIBC := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libc.a
     LIBM := $(NANVIX_TOOLCHAIN)/i686-nanvix/lib/libm.a
     LIBPOSIX := $(abspath $(NANVIX_HOME))/lib/libposix.a
-    LIBZ := $(abspath $(NANVIX_HOME))/lib/libz.a
-    LIBSQLITE3 := $(abspath $(NANVIX_HOME))/lib/libsqlite3.a
-    LIBSSL := $(abspath $(NANVIX_HOME))/lib/libssl.a
-    LIBCRYPTO := $(abspath $(NANVIX_HOME))/lib/libcrypto.a
     LIBNVX_CRT0 := $(abspath $(NANVIX_HOME))/lib/libnvx_crt0.a
     BUILD_PYTHON := $(NANVIX_TOOLCHAIN)/bin/python3
   endif


### PR DESCRIPTION
Removes the unused `LIBSSL` / `LIBCRYPTO` / `LIBZ` / `LIBSQLITE3` make variables from `Makefile.nanvix`. These per-library `.a` path variables are no longer referenced anywhere: the build links `libssl` / `libcrypto` / `libz` / `libsqlite3` via `-l<name>` against the `.so` siblings in `$(SYSROOT)/lib/`. Dropping the dead definitions removes a footgun -- referencing one of them in a future `LIBS` rewrite would silently reintroduce static linking of a library that is meant to be loaded as a shared object.

Validated with `./z lint`.

## Dependencies

Must merge after [nanvix/cpython#739](https://github.com/nanvix/cpython/pull/739), the base it branches from: the four variables only become unused once `_ssl` / `_hashlib` / `zlib` / `_sqlite3` are moved to DT_NEEDED `.so` (completed by #739), so removing them earlier would break the link. Independent of the three sibling cleanups that share the same base -- #746 (drop dead `config.py` helpers), #747 (split `setup_local` sections), and #748 (enable `inet_pton`, which also edits `Makefile.nanvix` but a disjoint region) -- so the four can merge in any order.
