### PR TITLE
[nanvix] .nanvix/setup_local: split POSIX-wrapper modules into their own section

### DIFF
--- a/.nanvix/setup_local.py
+++ b/.nanvix/setup_local.py
@@ -140,16 +140,13 @@ SETUP_LOCAL_ENTRIES: tuple[SetupEntry, ...] = (
     # import their C APIs while a shared object initializes, which Nanvix cannot
     # nest safely yet.
     SetupEntry(
-        name="_asyncio",
+        name="_decimal",
         linkage=Linkage.SHARED,
-        tokens=("_asynciomodule.c",),
+        tokens=("_decimal/_decimal.c",),
         section_header=(
             "Modules with bundled CPython dependencies. Each extension keeps "
             "its vendored archive, matching the upstream build."
         ),
-    ),
-    SetupEntry(
-        name="_decimal", linkage=Linkage.SHARED, tokens=("_decimal/_decimal.c",)
     ),
     SetupEntry(name="_elementtree", linkage=Linkage.SHARED, tokens=("_elementtree.c",)),
     SetupEntry(
@@ -203,6 +200,12 @@ SETUP_LOCAL_ENTRIES: tuple[SetupEntry, ...] = (
             "_blake2/blake2b_impl.c",
             "_blake2/blake2s_impl.c",
         ),
+    ),
+    SetupEntry(
+        name="_asyncio",
+        linkage=Linkage.SHARED,
+        tokens=("_asynciomodule.c",),
+        section_header="POSIX wrappers and concurrency primitives.",
     ),
     SetupEntry(name="select", linkage=Linkage.SHARED, tokens=("selectmodule.c",)),
     SetupEntry(name="_socket", linkage=Linkage.SHARED, tokens=("socketmodule.c",)),


### PR DESCRIPTION
Moves `_asyncio`, `_datetime`, `select`, `_socket`, `_posixsubprocess`, `fcntl`, and `termios` out of the "Modules with bundled-in-cpython C deps" section in `.nanvix/setup_local.py` and into a dedicated "POSIX syscall wrappers + concurrency primitives" section. The old grouping was misleading: none of these bundle a vendored `.a`; they are thin POSIX/syscall wrappers (plus `_asyncio` / `_datetime`) whose libc / libm symbols resolve against `python.elf`'s `.dynsym` at `dlopen` time via `--export-dynamic`. The new section mirrors upstream `Modules/Setup.stdlib.in`'s "Modules with some UNIX dependencies" grouping.

Purely cosmetic: no change to the generated `Setup.local` except entry order within the `*shared*` block (which makesetup does not depend on; each module name still appears at most once).

Validated with `./z lint`.

## Dependencies

Must merge after [nanvix/cpython#739](https://github.com/nanvix/cpython/pull/739), the base it branches from: it reorders the `setup_local.py` entries that #739 populates, so it has to sit on top of #739's version of the file. Independent of the three sibling cleanups that share the same base -- #745 (drop dead Makefile variables), #746 (drop dead `config.py` helpers), and #748 (enable `inet_pton`) -- which touch different files, so the four can merge in any order.
