### PR TITLE
Restrict docker to build step

### DIFF
--- a/.nanvix/_docker.py
+++ b/.nanvix/_docker.py
@@ -226,66 +226,6 @@ def docker_build(
     )
 
 
-def docker_install(
-    workspace: Path,
-    destdir: Path,
-    args: build_mod.MakeArgs,
-) -> None:
-    """Run make install inside Docker (Windows host mode)."""
-    targets = [
-        "install",
-        f"DESTDIR={config.DOCKER_WORKSPACE_PATH}/_install_staging",
-    ]
-    _args = dataclasses.replace(args, docker=True, targets=targets)
-    base = _docker_run_base(workspace, _args)
-    sync = sync_sources(workspace)
-
-    # Compute relative path so nested destdirs (e.g. .nanvix/_test_staging)
-    # are preserved correctly on the host.
-    try:
-        rel_dest = destdir.relative_to(workspace).as_posix()
-    except ValueError:
-        rel_dest = destdir.name
-
-    # Copy install staging back to host, stripping the binary first.
-    strip_bin = f"{config.DOCKER_TOOLCHAIN_PATH}/bin/{config.TOOLCHAIN_TRIPLET}-strip"
-    install_bin = (
-        f"{config.DOCKER_WORKSPACE_PATH}/_install_staging"
-        f"{_args.install_prefix}/bin/{config.python_binary()}"
-    )
-    strip_cmd = (
-        f'[ -x "{strip_bin}" ] && [ -f "{install_bin}" ] && '
-        f'"{strip_bin}" --strip-all "{install_bin}" || true'
-    )
-    # The named Docker volume persists across builds; wipe the install
-    # staging dir so stale files (e.g. from a prior INSTALL_PREFIX)
-    # don't leak into the tarball.
-    shell_cmd = (
-        f"{sync} && cd {config.DOCKER_WORKSPACE_PATH} && "
-        f"rm -rf {config.DOCKER_WORKSPACE_PATH}/_install_staging && "
-        f"{_args.to_string()}; rc=$?; "
-        f"{strip_cmd}; "
-        f"if [ -d {config.DOCKER_WORKSPACE_PATH}/_install_staging ]; then "
-        f"mkdir -p /mnt/host-workspace/{rel_dest} && "
-        f"cp -a {config.DOCKER_WORKSPACE_PATH}/_install_staging/* /mnt/host-workspace/{rel_dest}/; fi; "
-        f"exit $rc"
-    )
-
-    subprocess.run(
-        [*base, "sh", "-c", shell_cmd],
-        check=True,
-    )
-
-
-def clean_volume(workspace: Path) -> None:
-    """Remove the persistent Docker build volume."""
-    volume = _volume_name(workspace)
-    subprocess.run(
-        ["docker", "volume", "rm", volume],
-        capture_output=True,
-    )
-
-
 def _generate_setup_local_cmd() -> str:
     """Shell command to generate Modules/Setup.local inside the container."""
     sysroot = config.DOCKER_SYSROOT_PATH

--- a/.nanvix/build.py
+++ b/.nanvix/build.py
@@ -121,12 +121,13 @@ def install(
     *,
     extra_make_flags: list[str] | None = None,
 ) -> None:
-    """Install CPython into a staging directory."""
-    if config.IS_WINDOWS:
-        docker_mod.docker_install(paths.repo_root(), destdir, args)
-        return
-    # When running inside Docker, repo_root maps to /mnt/workspace.
-    # Use a relative DESTDIR so it resolves correctly inside the container.
+    """Install CPython into a staging directory (native host only).
+
+    Windows/Docker installs happen inside :func:`_docker.docker_build`
+    via ``install_destdir=``; this helper is never reached there.
+    """
+    # Use a relative DESTDIR so it resolves the same way whether the
+    # caller runs make directly or under a wrapper.
     try:
         rel_destdir = destdir.resolve().relative_to(paths.repo_root())
     except ValueError:

--- a/.nanvix/z.py
+++ b/.nanvix/z.py
@@ -161,9 +161,20 @@ class CPythonBuild(ZScript):
         toolchain = Path(TOOLCHAIN_CONTAINER_PATH)
         return Path(sysroot), toolchain
 
-    def _make_args(self, *targets: str, release: bool = False) -> build_mod.MakeArgs:
-        """Build the make argument list for configure/build/install."""
+    def _make_args(
+        self,
+        *targets: str,
+        release: bool = False,
+        with_docker: bool = False,
+    ) -> build_mod.MakeArgs:
+        """Build the make argument list for configure/build/install.
+
+        Docker is build-only (see zutils#224 / #666). Callers other than
+        ``build()`` MUST leave ``with_docker=False``; ``self.docker`` is
+        ignored for those steps.
+        """
         sysroot, toolchain = self._get_host_paths()
+        use_docker = with_docker and self.docker is not None
         return build_mod.MakeArgs(
             toolchain_path=toolchain,
             sysroot=sysroot,
@@ -173,8 +184,12 @@ class CPythonBuild(ZScript):
             memory_size=self.config.memory_size,
             install_prefix=_DEFAULT_INSTALL_PREFIX,
             release=release,
-            docker=self.docker is not None,
-            run_fn=lambda *args, **kw: run(*args, docker=self.docker, **kw),  # type: ignore[assignment]
+            docker=use_docker,
+            run_fn=(
+                (lambda *args, **kw: run(*args, docker=self.docker, **kw))  # type: ignore[assignment]
+                if use_docker
+                else None
+            ),
         )
 
     def setup(self) -> bool:
@@ -222,7 +237,7 @@ class CPythonBuild(ZScript):
 
         # Two separate builds: first release -> out/release/, then test -> out/test/.
         build_mod.clean(preserve_nanvix_root=False, preserve_cache=True)
-        args = self._make_args(release=True)
+        args = self._make_args(release=True, with_docker=True)
         build_mod.build(args)
         lxml_mod.stage_lxml_runtime(package_mod.sysroot_pkg())
         package_mod.stage()
@@ -234,7 +249,7 @@ class CPythonBuild(ZScript):
 
         # Build for test
         build_mod.clean(preserve_nanvix_root=True, preserve_cache=True)
-        args = self._make_args(release=False)
+        args = self._make_args(release=False, with_docker=True)
         build_mod.build(args)
         if self.config.deployment_mode == "standalone":
             test_mod.stage_ramfs(args)

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -240,13 +240,10 @@ else
 	fi
 endif
 
-# Install target
+# Install target (native only; Windows/Docker installs are staged inside
+# docker_build via _docker.py).
 install: build
-ifdef CONFIG_NANVIX_DOCKER
-	$(DOCKER_RUN) $(MAKE) install DESTDIR="$(patsubst $(CURDIR)%,$(DOCKER_WORKSPACE_PATH)%,$(abspath $(DESTDIR)))"
-else
 	$(MAKE) install DESTDIR="$(DESTDIR)"
-endif
 
 
 # Clean target


### PR DESCRIPTION
 Fixes #666. Only ./z build (and ./z build --with-docker) may spawn
 docker. Currently, setup/test/release/lint/benchmark do so by construction.

 - build.install(): drop dead Windows/docker branch. Windows installs ride inside docker_build's install_destdir path.
 - _docker: remove now-unused docker_install and clean_volume.
 - z._make_args: opt-in with_docker flag; only build() sets it.
 - Makefile.nanvix: install target native-only.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
