### PR TITLE
[ci] E: Update nanvix workflow refs to v2.5.0

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   ci:
     if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.4.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.5.0
     with:
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'
@@ -41,7 +41,7 @@ jobs:
 
   ci-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.4.0
+    uses: nanvix/workflows/.github/workflows/nanvix-ci.yml@v2.5.0
     with:
       docker-image: "ghcr.io/nanvix/toolchain-python:latest"
       platforms: '["microvm"]'


### PR DESCRIPTION
Automated bump of `nanvix/workflows` references to [`v2.5.0`](https://github.com/nanvix/workflows/releases/tag/v2.5.0).

Generated by the [Update Workflow Refs](https://github.com/nanvix/workflows/actions/workflows/nanvix-update-workflows.yml) workflow.